### PR TITLE
fix: pass --trust flag to cursor-agent to resolve cursor-agent trust error

### DIFF
--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -45,6 +45,9 @@ async function spawnCursor(command, options = {}, ws) {
       args.push('--output-format', 'stream-json');
     }
     
+    // Always trust the workspace directory since the user explicitly chose it
+    args.push('--trust');
+
     // Add skip permissions flag if enabled
     if (skipPermissions || settings.skipPermissions) {
       args.push('-f');


### PR DESCRIPTION
This PR resolves the `cursor-agent trust error` by explicitly passing the `--trust` flag when spawning the `cursor-agent` process. 

Requiring users to explicitly trust the agent introduced unnecessary friction and increased the likelihood of configuration errors.

By defaulting to trusted mode:
- We eliminate an extra setup step
- Prevent trust-related initialization failures
- Improve overall usability and onboarding experience