### PR TITLE
feat: stage-aware soul templates with pipeline.startStage

### DIFF
--- a/server/routes/taskmaster.js
+++ b/server/routes/taskmaster.js
@@ -635,7 +635,12 @@ function instantiatePipelineTasksFromBrief(briefData = {}, numTasks = DEFAULT_MA
     const generated = [];
     const maxTasks = Number.isFinite(Number(numTasks)) && Number(numTasks) > 0 ? Number(numTasks) : DEFAULT_MAX_TASKS;
 
-    for (const stage of STAGE_ORDER) {
+    // Respect pipeline.startStage — only generate tasks for stages >= startStage
+    const startStage = briefData?.pipeline?.startStage || 'ideation';
+    const startIdx = STAGE_ORDER.indexOf(startStage);
+    const activeStages = startIdx > 0 ? STAGE_ORDER.slice(startIdx) : STAGE_ORDER;
+
+    for (const stage of activeStages) {
         const stageConfig = pipelineStages?.[stage];
         if (!stageConfig || typeof stageConfig !== 'object') continue;
 

--- a/server/templates/AGENTS.md
+++ b/server/templates/AGENTS.md
@@ -14,18 +14,26 @@ Your responsibilities:
 ## When You Start a Conversation
 
 1. Read `instance.json` in the project root to understand the project's current state (if it exists).
-2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, and pipeline stage definitions.
+2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, pipeline stage definitions, and `pipeline.startStage` (which stage the user wants to begin from).
 3. Read `.pipeline/tasks/tasks.json` to see which tasks exist and their current status (pending, in-progress, done, review, deferred, cancelled).
 4. Check which pipeline directories already have content (`Ideation/`, `Experiment/`, `Publication/`, `Research/`). Note: `Research/` holds deep-research reports and is not a pipeline stage.
-5. Briefly orient the user: tell them what stage the project is at, which task is next, and what the next logical step is.
+5. Determine the **effective starting stage**: check `pipeline.startStage` in the research brief (defaults to `"ideation"` if absent). If directories for later stages already have content but earlier ones are empty, the user likely intends to start from a later stage.
+6. Briefly orient the user: tell them the project's starting stage, which stages are active, which task is next, and what the next logical step is.
 
-**If no `research_brief.json` exists**, proactively offer to set up the research pipeline. Read `.agents/skills/inno-pipeline-planner/SKILL.md` and follow its procedure to collect the user's research intent through conversation and generate both `research_brief.json` and `tasks.json`.
+### When to run `inno-pipeline-planner`
+
+Read `.agents/skills/inno-pipeline-planner/SKILL.md` and follow its procedure in any of these situations:
+
+- **No `research_brief.json` exists** — proactively offer to set up the research pipeline through conversation.
+- **No `tasks.json` exists** (but brief does) — generate tasks from the existing brief.
+- **User wants to change the starting stage** — e.g., "I already have results, I just need to write the paper." Re-run the planner to update `pipeline.startStage` and regenerate tasks for the active stages only.
+- **User explicitly asks** to redefine or regenerate the pipeline.
 
 ## Project Workflow
 
 The user drives the pipeline through the VibeLab web UI. Chat is the default landing page:
 
-1. **Chat (you)** — The user describes their research idea or goal. You run the `inno-pipeline-planner` skill to interactively collect requirements and generate `.pipeline/docs/research_brief.json` and `.pipeline/tasks/tasks.json`.
+1. **Chat (you)** — The user describes their research idea, goal, or current progress. You run the `inno-pipeline-planner` skill to interactively collect requirements, determine the appropriate starting stage, and generate `.pipeline/docs/research_brief.json` and `.pipeline/tasks/tasks.json`. If the user indicates they already have artifacts for earlier stages (e.g., "I have an idea and datasets ready, I need to run experiments"), set `pipeline.startStage` accordingly and generate tasks only for the active stages.
 2. **Research Lab** — The user reviews the generated tasks, progress metrics, and research artifacts in the Research Lab tab.
 3. **Chat (you)** — The user clicks "Go to Chat" on a task in the Research Lab to send it to you. You execute the task using the appropriate skills and write results back to the project.
 
@@ -33,16 +41,22 @@ When the user sends you a task from the Pipeline Task List, treat it as your cur
 
 ## Pipeline Stages
 
-The pipeline has three stages, each with its own quality gates:
+The pipeline has three stages. Users do not have to start from Ideation — they can enter the pipeline at any stage depending on what they already have.
 
 **Ideation** — Define research directions, generate and evaluate ideas, establish problem framing and success criteria.
 Output directories: `Ideation/ideas/`, `Ideation/references/`
+*Skip if*: User already has a concrete research idea, problem framing, and success criteria.
 
 **Experiment** — Design and run experiments, implement code, analyze results.
 Output directories: `Experiment/code_references/`, `Experiment/datasets/`, `Experiment/core_code/`, `Experiment/analysis/`
+*Skip if*: User already has experimental results and analysis.
+*Pre-existing input accepted*: Research idea/hypothesis, method description, dataset references.
 
 **Publication** — Write the paper, prepare figures/tables, finalize submission artifacts.
 Output directories: `Publication/paper/`, `Publication/homepage/`, `Publication/slide/`
+*Pre-existing input accepted*: Experimental results, analysis, figures, code artifacts.
+
+The `pipeline.startStage` field in `research_brief.json` controls which stage the pipeline begins from. Tasks are only generated for the starting stage and all subsequent stages.
 
 ## How to Use Skills
 
@@ -63,7 +77,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 ## Key Files
 
 - `instance.json` — Project path mapping. It stores absolute directory paths for each pipeline area (`Ideation.*`, `Experiment.*`, `Publication.*`) and related project metadata. Use these paths as the canonical locations for file I/O.
-- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, and recommended skills, and should be updated as the work evolves.
+- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, recommended skills, and `pipeline.startStage` (which stage to begin from). Should be updated as the work evolves.
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 

--- a/server/templates/CLAUDE.md
+++ b/server/templates/CLAUDE.md
@@ -14,16 +14,26 @@ Your responsibilities:
 ## When You Start a Conversation
 
 1. Read `instance.json` in the project root to understand the project's current state.
-2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, and pipeline stage definitions.
+2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, pipeline stage definitions, and `pipeline.startStage` (which stage the user wants to begin from).
 3. Read `.pipeline/tasks/tasks.json` to see which tasks exist and their current status (pending, in-progress, done, review, deferred, cancelled).
 4. Check which pipeline directories already have content (`Ideation/`, `Experiment/`, `Publication/`, `Research/`). Note: `Research/` holds deep-research reports and is not a pipeline stage.
-5. Briefly orient the user: tell them what stage the project is at, which task is next, and what the next logical step is.
+5. Determine the **effective starting stage**: check `pipeline.startStage` in the research brief (defaults to `"ideation"` if absent). If directories for later stages already have content but earlier ones are empty, the user likely intends to start from a later stage.
+6. Briefly orient the user: tell them the project's starting stage, which stages are active, which task is next, and what the next logical step is.
+
+### When to run `inno-pipeline-planner`
+
+Read `.claude/skills/inno-pipeline-planner/SKILL.md` and follow its procedure in any of these situations:
+
+- **No `research_brief.json` exists** — proactively offer to set up the research pipeline through conversation.
+- **No `tasks.json` exists** (but brief does) — generate tasks from the existing brief.
+- **User wants to change the starting stage** — e.g., "I already have results, I just need to write the paper." Re-run the planner to update `pipeline.startStage` and regenerate tasks for the active stages only.
+- **User explicitly asks** to redefine or regenerate the pipeline.
 
 ## Project Workflow
 
 The user drives the pipeline through the VibeLab web UI:
 
-1. **Pipeline Board** — The user selects a research template, fills in metadata (title, authors, venue, domain), and clicks "Apply Template + Generate Tasks". This creates `.pipeline/docs/research_brief.json` and generates `.pipeline/tasks/tasks.json`.
+1. **Pipeline Board or Chat** — The user either selects a research template via the Pipeline Board, or describes their research idea/goal in Chat. If using Chat, you run the `inno-pipeline-planner` skill to interactively collect requirements, determine the appropriate starting stage, and generate `.pipeline/docs/research_brief.json` and `.pipeline/tasks/tasks.json`. If the user indicates they already have artifacts for earlier stages (e.g., "I have results, I need to write the paper"), set `pipeline.startStage` accordingly and generate tasks only for the active stages.
 2. **Pipeline Task List** — The user reviews the generated tasks and clicks "Go to Chat" or "Use in Chat" on a task to send it to you.
 3. **Chat (you)** — You receive the task prompt, execute it using skills, and write results back to the appropriate directories. Update `research_brief.json` with any clarified or produced outputs.
 
@@ -31,16 +41,22 @@ When the user sends you a task from the Pipeline Task List, treat it as your cur
 
 ## Pipeline Stages
 
-The pipeline has three stages, each with its own quality gates:
+The pipeline has three stages. Users do not have to start from Ideation — they can enter the pipeline at any stage depending on what they already have.
 
 **Ideation** — Define research directions, generate and evaluate ideas, establish problem framing and success criteria.
 Output directories: `Ideation/ideas/`, `Ideation/references/`
+*Skip if*: User already has a concrete research idea, problem framing, and success criteria.
 
 **Experiment** — Design and run experiments, implement code, analyze results.
 Output directories: `Experiment/code_references/`, `Experiment/datasets/`, `Experiment/core_code/`, `Experiment/analysis/`
+*Skip if*: User already has experimental results and analysis.
+*Pre-existing input accepted*: Research idea/hypothesis, method description, dataset references.
 
 **Publication** — Write the paper, prepare figures/tables, finalize submission artifacts.
 Output directories: `Publication/paper/`, `Publication/homepage/`, `Publication/slide/`
+*Pre-existing input accepted*: Experimental results, analysis, figures, code artifacts.
+
+The `pipeline.startStage` field in `research_brief.json` controls which stage the pipeline begins from. Tasks are only generated for the starting stage and all subsequent stages.
 
 ## How to Use Skills
 
@@ -55,7 +71,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 ## Key Files
 
 - `instance.json` — Project path mapping. It stores absolute directory paths for each pipeline area (`Ideation.*`, `Experiment.*`, `Publication.*`) and related project metadata. Use these paths as the canonical locations for file I/O.
-- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, and recommended skills, and should be updated as the work evolves.
+- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, recommended skills, and `pipeline.startStage` (which stage to begin from). Should be updated as the work evolves.
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 

--- a/server/templates/cursor-project.md
+++ b/server/templates/cursor-project.md
@@ -19,16 +19,26 @@ Your responsibilities:
 ## When You Start a Conversation
 
 1. Read `instance.json` in the project root to understand the project's current state.
-2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, and pipeline stage definitions.
+2. Read `.pipeline/docs/research_brief.json` to understand the research brief — topic, goals, pipeline stage definitions, and `pipeline.startStage` (which stage the user wants to begin from).
 3. Read `.pipeline/tasks/tasks.json` to see which tasks exist and their current status (pending, in-progress, done, review, deferred, cancelled).
 4. Check which pipeline directories already have content (`Ideation/`, `Experiment/`, `Publication/`, `Research/`). Note: `Research/` holds deep-research reports and is not a pipeline stage.
-5. Briefly orient the user: tell them what stage the project is at, which task is next, and what the next logical step is.
+5. Determine the **effective starting stage**: check `pipeline.startStage` in the research brief (defaults to `"ideation"` if absent). If directories for later stages already have content but earlier ones are empty, the user likely intends to start from a later stage.
+6. Briefly orient the user: tell them the project's starting stage, which stages are active, which task is next, and what the next logical step is.
+
+### When to run `inno-pipeline-planner`
+
+Read `.cursor/skills/inno-pipeline-planner/SKILL.md` and follow its procedure in any of these situations:
+
+- **No `research_brief.json` exists** — proactively offer to set up the research pipeline through conversation.
+- **No `tasks.json` exists** (but brief does) — generate tasks from the existing brief.
+- **User wants to change the starting stage** — e.g., "I already have results, I just need to write the paper." Re-run the planner to update `pipeline.startStage` and regenerate tasks for the active stages only.
+- **User explicitly asks** to redefine or regenerate the pipeline.
 
 ## Project Workflow
 
 The user drives the pipeline through the VibeLab web UI:
 
-1. **Pipeline Board** — The user selects a research template, fills in metadata (title, authors, venue, domain), and clicks "Apply Template + Generate Tasks". This creates `.pipeline/docs/research_brief.json` and generates `.pipeline/tasks/tasks.json`.
+1. **Pipeline Board or Chat** — The user either selects a research template via the Pipeline Board, or describes their research idea/goal in Chat. If using Chat, you run the `inno-pipeline-planner` skill to interactively collect requirements, determine the appropriate starting stage, and generate `.pipeline/docs/research_brief.json` and `.pipeline/tasks/tasks.json`. If the user indicates they already have artifacts for earlier stages (e.g., "I have results, I need to write the paper"), set `pipeline.startStage` accordingly and generate tasks only for the active stages.
 2. **Pipeline Task List** — The user reviews the generated tasks and clicks "Go to Chat" or "Use in Chat" on a task to send it to you.
 3. **Chat (you)** — You receive the task prompt, execute it using skills, and write results back to the appropriate directories. Update `research_brief.json` with any clarified or produced outputs.
 
@@ -36,16 +46,22 @@ When the user sends you a task from the Pipeline Task List, treat it as your cur
 
 ## Pipeline Stages
 
-The pipeline has three stages, each with its own quality gates:
+The pipeline has three stages. Users do not have to start from Ideation — they can enter the pipeline at any stage depending on what they already have.
 
 **Ideation** — Define research directions, generate and evaluate ideas, establish problem framing and success criteria.
 Output directories: `Ideation/ideas/`, `Ideation/references/`
+*Skip if*: User already has a concrete research idea, problem framing, and success criteria.
 
 **Experiment** — Design and run experiments, implement code, analyze results.
 Output directories: `Experiment/code_references/`, `Experiment/datasets/`, `Experiment/core_code/`, `Experiment/analysis/`
+*Skip if*: User already has experimental results and analysis.
+*Pre-existing input accepted*: Research idea/hypothesis, method description, dataset references.
 
 **Publication** — Write the paper, prepare figures/tables, finalize submission artifacts.
 Output directories: `Publication/paper/`, `Publication/homepage/`, `Publication/slide/`
+*Pre-existing input accepted*: Experimental results, analysis, figures, code artifacts.
+
+The `pipeline.startStage` field in `research_brief.json` controls which stage the pipeline begins from. Tasks are only generated for the starting stage and all subsequent stages.
 
 ## How to Use Skills
 
@@ -60,7 +76,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 ## Key Files
 
 - `instance.json` — Project path mapping. It stores absolute directory paths for each pipeline area (`Ideation.*`, `Experiment.*`, `Publication.*`) and related project metadata. Use these paths as the canonical locations for file I/O.
-- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, and recommended skills, and should be updated as the work evolves.
+- `.pipeline/docs/research_brief.json` — Research process control document and single source of truth. It defines stage goals, required elements, quality gates, task blueprints, recommended skills, and `pipeline.startStage` (which stage to begin from). Should be updated as the work evolves.
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 

--- a/skills/inno-pipeline-planner/SKILL.md
+++ b/skills/inno-pipeline-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inno-pipeline-planner
-description: Guides the user through an interactive conversation to define their research project, then generates research_brief.json and tasks.json. Use when starting a new project, when no research_brief.json exists, or when the user wants to redefine their research pipeline.
+description: Guides the user through an interactive conversation to define their research project, then generates research_brief.json and tasks.json. Use when starting a new project, when no research_brief.json exists, when the user wants to start from a specific pipeline stage, or when the user wants to redefine their research pipeline.
 ---
 
 # Inno Pipeline Planner
@@ -32,10 +32,12 @@ Check:
 - `.pipeline/docs/research_brief.json`
 - `.pipeline/tasks/tasks.json`
 - `instance.json` (legacy source)
+- Content in `Ideation/`, `Experiment/`, `Publication/` directories (to detect pre-existing artifacts)
 
-If brief exists, summarize title, goal, and completion status, then ask:
+If brief exists, summarize title, goal, current `startStage`, and completion status, then ask:
 - Refine existing brief/tasks
 - Regenerate from scratch
+- Change the starting stage
 
 ## 2) Collect project context via conversation
 
@@ -44,6 +46,13 @@ Capture at least:
 - Goal or hypothesis
 - Success criteria or evaluation signal
 
+**Determine the starting stage** early in the conversation:
+- Ask what the user already has: "Do you already have a research idea, experimental results, or are you starting from scratch?"
+- If the user has a concrete idea with problem framing and success criteria -> `startStage = "experiment"`
+- If the user has experimental results and analysis -> `startStage = "publication"`
+- If the user is starting from scratch or only has a vague direction -> `startStage = "ideation"` (default)
+- Detect automatically from conversation context (e.g., "I already ran all experiments" implies publication).
+
 Typical question buckets:
 - Project identity: topic, prior paper/method/dataset, target venue (optional)
 - Scope and method: core question, approach, expected outcome
@@ -51,6 +60,7 @@ Typical question buckets:
 
 Adapt to context:
 - Skip already-provided details.
+- **Skip questions for stages before `startStage`**: If starting from experiment, do not ask ideation questions in detail — just capture a brief summary of the existing idea for the brief's ideation section.
 - If exploratory, keep experiment/publication sections lightweight.
 - If user provides concrete plan, prepare for `pipeline.mode = "plan"`; otherwise use `"idea"`.
 
@@ -65,6 +75,9 @@ Use the exact JSON contracts and generation rules in:
 - `references/pipeline-contract.md` and linked reference files
 
 Rules:
+- Set `pipeline.startStage` to the determined starting stage (default: `"ideation"`).
+- **Generate tasks only for stages >= `startStage`** in the stage order (ideation < experiment < publication).
+- For skipped stages: still populate their `sections.*` fields in the brief with whatever context the user provided, but do not create task blueprints or tasks for them.
 - Tailor blueprint titles/descriptions to the user topic (never generic filler).
 - Keep quality gates domain-appropriate.
 - Resolve recommended skills from local available skills (`.agents/skills/` or `skills/`), optionally using `stage-skill-map.json` if present.
@@ -72,8 +85,8 @@ Rules:
 ## 4) Summarize and confirm next action
 
 After writing files, present:
-- Brief summary (title, goal, filled vs missing sections)
-- Task overview (count by stage + first 2-3 task titles per stage)
+- Brief summary (title, goal, starting stage, filled vs missing sections)
+- Task overview (count by stage + first 2-3 task titles per stage) — only for active stages
 - Recommended first task and why
 
 ## 5) Handle iteration requests
@@ -81,4 +94,5 @@ After writing files, present:
 If user asks for updates:
 - Update brief content directly when only text/content changes.
 - Regenerate `tasks.json` when pipeline structure/blueprints/stages change.
+- **If user asks to change the starting stage**: update `pipeline.startStage` in the brief, then regenerate `tasks.json` to include only the active stages.
 - If asked to add one task only, append a single task with next numeric `id` instead of full regeneration.

--- a/skills/inno-pipeline-planner/references/brief-schema.md
+++ b/skills/inno-pipeline-planner/references/brief-schema.md
@@ -35,6 +35,7 @@ Canonical contract for `.pipeline/docs/research_brief.json`.
   "pipeline": {
     "version": "1.1",
     "mode": "idea",
+    "startStage": "ideation",
     "stages": {
       "ideation": {
         "required_elements": [

--- a/skills/inno-pipeline-planner/references/generation-rules.md
+++ b/skills/inno-pipeline-planner/references/generation-rules.md
@@ -30,20 +30,28 @@ Create when missing:
 - Fill content from user conversation and existing project files only.
 - Leave unknown fields as empty string or empty array.
 - Set `pipeline.mode`:
-- Use `"plan"` when user provides concrete method/architecture/training plan.
-- Use `"idea"` otherwise.
+  - Use `"plan"` when user provides concrete method/architecture/training plan.
+  - Use `"idea"` otherwise.
+- Set `pipeline.startStage`:
+  - Use `"ideation"` (default) when user is starting from scratch.
+  - Use `"experiment"` when user already has a research idea, problem framing, and success criteria.
+  - Use `"publication"` when user already has experimental results and analysis.
 - Make `task_blueprints` and `quality_gate` domain-specific to the topic.
+- For skipped stages (before `startStage`): still populate `sections.*` with whatever context the user provided, but `task_blueprints` in those stages will not produce tasks.
 
 ## Task generation rules
 
-1. Create tasks from each stage's `task_blueprints`.
-2. Create define/refine tasks for each `required_element`:
-- Use `Define <field>` when empty.
-- Use `Refine <field>` when already populated.
-3. Add one quality-gate review task at the end of each stage with `quality_gate`.
-4. Order tasks by execution flow:
-- exploration -> implementation -> analysis -> writing
-5. Add dependencies when obvious (for example, implementation depends on exploration in the same stage).
+Stage order: `ideation` < `experiment` < `publication`.
+
+1. **Only generate tasks for stages >= `pipeline.startStage`**. Skip earlier stages entirely during task generation.
+2. Create tasks from each active stage's `task_blueprints`.
+3. Create define/refine tasks for each `required_element` in active stages:
+   - Use `Define <field>` when empty.
+   - Use `Refine <field>` when already populated.
+4. Add one quality-gate review task at the end of each active stage with `quality_gate`.
+5. Order tasks by execution flow:
+   - exploration -> implementation -> analysis -> writing
+6. Add dependencies when obvious (for example, implementation depends on exploration in the same stage).
 
 ## `nextActionPrompt` template
 


### PR DESCRIPTION
## Summary
- All three soul templates (CLAUDE.md, AGENTS.md, cursor-project.md) now support `pipeline.startStage` so users can enter the pipeline at any stage (ideation/experiment/publication) instead of always starting from ideation
- `inno-pipeline-planner` is now properly referenced in all templates with 4 trigger conditions: no brief, no tasks, stage change, or explicit user request
- `taskmaster.js` respects `startStage` during task generation, skipping earlier stages
- Brief schema and generation rules updated with `startStage` field and stage-filtering logic

## Test plan
- [ ] Create a new workspace project → verify CLAUDE.md/AGENTS.md include stage-aware instructions
- [ ] Open chat with no research_brief.json → agent should proactively offer `inno-pipeline-planner`
- [ ] Tell agent "I already have experimental results, I just need to write the paper" → planner sets `startStage: "publication"`, only publication tasks generated
- [ ] Tell agent "I have an idea, I need to run experiments" → planner sets `startStage: "experiment"`, experiment + publication tasks generated
- [ ] Full idea-to-paper flow still works unchanged (startStage defaults to "ideation")

🤖 Generated with [Claude Code](https://claude.com/claude-code)