### PR TITLE
feat: refactor skills architecture + add edit/delete to skill cards

### DIFF
--- a/server/projects.js
+++ b/server/projects.js
@@ -1526,6 +1526,21 @@ async function ensureProjectSkillLinks(projectPath) {
           console.error('[projects] Failed to write skills-index.md:', err.message);
         }
       }
+
+      // Symlink JSON config files from VibeLab root into each project skills folder
+      for (const jsonFile of ['skill-tag-mapping.json', 'stage-skill-map.json']) {
+        const srcJson = path.join(VIBELAB_SKILLS_DIR, jsonFile);
+        const destJson = path.join(skillsSubdir, jsonFile);
+        try {
+          await fs.access(srcJson);
+          try { await fs.unlink(destJson); } catch (_) {}
+          await fs.symlink(srcJson, destJson, 'file');
+        } catch (err) {
+          if (err.code !== 'ENOENT') {
+            console.error(`[projects] Failed to symlink ${jsonFile} in ${dir}/skills:`, err.message);
+          }
+        }
+      }
     }
   } catch (err) {
     console.error('[projects] ensureProjectSkillLinks failed:', err.message);
@@ -2176,5 +2191,6 @@ export {
   clearProjectDirectoryCache,
   getCodexSessions,
   getCodexSessionMessages,
-  deleteCodexSession
+  deleteCodexSession,
+  ensureProjectSkillLinks
 };

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -3,7 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
-import { extractProjectDirectory } from '../projects.js';
+import { extractProjectDirectory, ensureProjectSkillLinks } from '../projects.js';
 import { FORBIDDEN_PATHS } from './projects.js';
 
 const GLOBAL_SKILLS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'skills');
@@ -298,6 +298,26 @@ router.get('/file', async (req, res) => {
   }
 });
 
+// PUT /file — write a single file in the global skills/ directory
+router.put('/file', async (req, res) => {
+  try {
+    const { filePath, content } = req.body || {};
+    if (!filePath || typeof content !== 'string') {
+      return res.status(400).json({ error: 'filePath and content are required' });
+    }
+    const skillsDir = path.resolve(GLOBAL_SKILLS_DIR);
+    const resolved = path.resolve(skillsDir, filePath);
+    if (!resolved.startsWith(skillsDir + path.sep) && resolved !== skillsDir) {
+      return res.status(403).json({ error: 'Path must be under skills root' });
+    }
+    await fs.writeFile(resolved, content, 'utf8');
+    res.json({ success: true });
+  } catch (error) {
+    console.error('[ERROR] Skill file write error:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 // GET /scan-local — scan a local directory for skill subdirectories
 router.get('/scan-local', async (req, res) => {
   try {
@@ -453,6 +473,121 @@ router.post('/import-from-local', async (req, res) => {
     res.json({ imported, skipped, errors });
   } catch (error) {
     console.error('[skills] import-from-local error:', error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// POST /:projectName/import-user-skills — import from ~/.claude/skills/ into GLOBAL_SKILLS_DIR then re-sync symlinks
+router.post('/:projectName/import-user-skills', async (req, res) => {
+  try {
+    const projectName = req.params.projectName;
+    const projectRoot = await extractProjectDirectory(projectName);
+    if (!projectRoot) {
+      return res.status(404).json({ error: 'Project not found.' });
+    }
+
+    // Resolve ~/.claude/skills/
+    const userSkillsDir = path.join(os.homedir(), '.claude', 'skills');
+    let stat;
+    try {
+      stat = await fs.stat(userSkillsDir);
+    } catch {
+      return res.status(404).json({ error: 'User skills directory not found (~/.claude/skills/).' });
+    }
+    if (!stat.isDirectory()) {
+      return res.status(400).json({ error: '~/.claude/skills/ is not a directory.' });
+    }
+
+    // Scan for subdirs containing SKILL.md
+    const entries = await fs.readdir(userSkillsDir, { withFileTypes: true });
+    await fs.mkdir(GLOBAL_SKILLS_DIR, { recursive: true });
+
+    const imported = [];
+    const skipped = [];
+    const errors = [];
+
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+
+      const srcDir = path.join(userSkillsDir, entry.name);
+
+      // Verify SKILL.md exists
+      try {
+        await fs.access(path.join(srcDir, 'SKILL.md'));
+      } catch {
+        continue; // Skip dirs without SKILL.md
+      }
+
+      const destDir = path.join(GLOBAL_SKILLS_DIR, entry.name);
+
+      try {
+        // Check if already exists in global skills
+        try {
+          await fs.access(destDir);
+          skipped.push(entry.name);
+          continue;
+        } catch {
+          // Does not exist — proceed
+        }
+
+        await fs.cp(srcDir, destDir, { recursive: true });
+
+        // Parse frontmatter from SKILL.md for tag extraction
+        let frontmatter = {};
+        try {
+          const skillMdContent = await fs.readFile(path.join(srcDir, 'SKILL.md'), 'utf8');
+          const parsed = await parseFrontmatter(skillMdContent);
+          frontmatter = parsed.data || {};
+        } catch { /* ignore parse errors */ }
+
+        // Update skill-tag-mapping.json with tag overrides from frontmatter
+        const tagMappingPath = path.join(GLOBAL_SKILLS_DIR, 'skill-tag-mapping.json');
+        let tagMapping = { version: 1, stageOverrides: {}, domainOverrides: {}, platformNativeSkills: [], domainCsAiExceptions: [] };
+        try {
+          tagMapping = JSON.parse(await fs.readFile(tagMappingPath, 'utf8'));
+        } catch { /* use defaults */ }
+        if (frontmatter.stage) {
+          tagMapping.stageOverrides = tagMapping.stageOverrides || {};
+          tagMapping.stageOverrides[entry.name] = typeof frontmatter.stage === 'string'
+            ? { en: `Stage: ${frontmatter.stage}`, zh: `阶段: ${frontmatter.stage}` }
+            : frontmatter.stage;
+        }
+        if (frontmatter.domain) {
+          tagMapping.domainOverrides = tagMapping.domainOverrides || {};
+          tagMapping.domainOverrides[entry.name] = typeof frontmatter.domain === 'string'
+            ? { en: `Domain: ${frontmatter.domain}`, zh: `领域: ${frontmatter.domain}` }
+            : frontmatter.domain;
+        }
+        await fs.writeFile(tagMappingPath, JSON.stringify(tagMapping, null, 2), 'utf8');
+
+        // Update stage-skill-map.json with origin
+        const stageSkillMapPath = path.join(GLOBAL_SKILLS_DIR, 'stage-skill-map.json');
+        let stageSkillMap = { skillOrigins: {} };
+        try {
+          stageSkillMap = JSON.parse(await fs.readFile(stageSkillMapPath, 'utf8'));
+        } catch { /* use defaults */ }
+        stageSkillMap.skillOrigins = stageSkillMap.skillOrigins || {};
+        stageSkillMap.skillOrigins[entry.name] = 'user-import';
+        await fs.writeFile(stageSkillMapPath, JSON.stringify(stageSkillMap, null, 2), 'utf8');
+
+        imported.push(entry.name);
+      } catch (err) {
+        errors.push(`${entry.name}: ${err.message}`);
+      }
+    }
+
+    // Re-sync symlinks for the requesting project
+    if (imported.length > 0) {
+      try {
+        await ensureProjectSkillLinks(projectRoot);
+      } catch (err) {
+        console.warn('[skills] ensureProjectSkillLinks after import failed (non-fatal):', err.message);
+      }
+    }
+
+    res.json({ imported, skipped, errors });
+  } catch (error) {
+    console.error('[skills] import-user-skills error:', error);
     res.status(500).json({ error: error.message });
   }
 });
@@ -651,6 +786,52 @@ router.post('/:projectName/upload-skill', async (req, res) => {
   }
 });
 
+// DELETE /global-skill — delete a skill from the global GLOBAL_SKILLS_DIR by relative dirPath
+router.delete('/global-skill', async (req, res) => {
+  try {
+    const { dirPath } = req.body || {};
+    if (!dirPath || typeof dirPath !== 'string') {
+      return res.status(400).json({ error: 'dirPath is required' });
+    }
+    const skillsDir = path.resolve(GLOBAL_SKILLS_DIR);
+    const resolved = path.resolve(skillsDir, dirPath);
+    if (!resolved.startsWith(skillsDir + path.sep) && resolved !== skillsDir) {
+      return res.status(403).json({ error: 'Path must be under skills root' });
+    }
+    try {
+      const stat = await fs.stat(resolved);
+      if (!stat.isDirectory()) {
+        return res.status(400).json({ error: 'Path is not a directory' });
+      }
+    } catch {
+      return res.status(404).json({ error: 'Skill directory not found' });
+    }
+    await fs.rm(resolved, { recursive: true, force: true });
+
+    // Clean config files using the skill folder name
+    const skillName = path.basename(resolved);
+    const tagMappingPath = path.join(GLOBAL_SKILLS_DIR, 'skill-tag-mapping.json');
+    try {
+      const tagMapping = JSON.parse(await fs.readFile(tagMappingPath, 'utf8'));
+      if (tagMapping.stageOverrides) delete tagMapping.stageOverrides[skillName];
+      if (tagMapping.domainOverrides) delete tagMapping.domainOverrides[skillName];
+      await fs.writeFile(tagMappingPath, JSON.stringify(tagMapping, null, 2), 'utf8');
+    } catch { /* file missing or unparseable */ }
+
+    const stageSkillMapPath = path.join(GLOBAL_SKILLS_DIR, 'stage-skill-map.json');
+    try {
+      const stageSkillMap = JSON.parse(await fs.readFile(stageSkillMapPath, 'utf8'));
+      if (stageSkillMap.skillOrigins) delete stageSkillMap.skillOrigins[skillName];
+      await fs.writeFile(stageSkillMapPath, JSON.stringify(stageSkillMap, null, 2), 'utf8');
+    } catch { /* file missing or unparseable */ }
+
+    res.json({ success: true, deleted: dirPath });
+  } catch (error) {
+    console.error('[skills] delete-global-skill error:', error);
+    res.status(500).json({ error: 'Failed to delete skill: ' + error.message });
+  }
+});
+
 // DELETE /:projectName/:skillDirName
 router.delete('/:projectName/:skillDirName', async (req, res) => {
   try {
@@ -683,27 +864,41 @@ router.delete('/:projectName/:skillDirName', async (req, res) => {
     // Delete the skill directory
     await fs.rm(foundDir, { recursive: true, force: true });
 
-    // Clean up skill-tag-mapping.json
-    const tagMappingPath = path.join(projectRoot, 'skills', 'skill-tag-mapping.json');
-    try {
-      const raw = await fs.readFile(tagMappingPath, 'utf8');
-      const tagMapping = JSON.parse(raw);
-      if (tagMapping.stageOverrides) delete tagMapping.stageOverrides[skillDirName];
-      if (tagMapping.domainOverrides) delete tagMapping.domainOverrides[skillDirName];
-      await fs.writeFile(tagMappingPath, JSON.stringify(tagMapping, null, 2), 'utf8');
-    } catch {
-      // Tag mapping file doesn't exist or can't be parsed; skip cleanup
+    // Determine the parent skills dir from the found location for config cleanup
+    const foundSkillsBase = path.dirname(foundDir);
+
+    // Clean up skill-tag-mapping.json in the skills base where the skill was found
+    // Also clean from the legacy skills/ location for backwards compat
+    const tagMappingCandidates = [
+      path.join(foundSkillsBase, 'skill-tag-mapping.json'),
+      path.join(projectRoot, 'skills', 'skill-tag-mapping.json'),
+    ];
+    for (const tagMappingPath of [...new Set(tagMappingCandidates)]) {
+      try {
+        const raw = await fs.readFile(tagMappingPath, 'utf8');
+        const tagMapping = JSON.parse(raw);
+        if (tagMapping.stageOverrides) delete tagMapping.stageOverrides[skillDirName];
+        if (tagMapping.domainOverrides) delete tagMapping.domainOverrides[skillDirName];
+        await fs.writeFile(tagMappingPath, JSON.stringify(tagMapping, null, 2), 'utf8');
+      } catch {
+        // Tag mapping file doesn't exist or can't be parsed; skip cleanup
+      }
     }
 
-    // Clean up stage-skill-map.json
-    const stageSkillMapPath = path.join(projectRoot, 'skills', 'stage-skill-map.json');
-    try {
-      const raw = await fs.readFile(stageSkillMapPath, 'utf8');
-      const stageSkillMap = JSON.parse(raw);
-      if (stageSkillMap.skillOrigins) delete stageSkillMap.skillOrigins[skillDirName];
-      await fs.writeFile(stageSkillMapPath, JSON.stringify(stageSkillMap, null, 2), 'utf8');
-    } catch {
-      // Stage-skill-map file doesn't exist or can't be parsed; skip cleanup
+    // Clean up stage-skill-map.json in the skills base + legacy location
+    const stageMapCandidates = [
+      path.join(foundSkillsBase, 'stage-skill-map.json'),
+      path.join(projectRoot, 'skills', 'stage-skill-map.json'),
+    ];
+    for (const stageSkillMapPath of [...new Set(stageMapCandidates)]) {
+      try {
+        const raw = await fs.readFile(stageSkillMapPath, 'utf8');
+        const stageSkillMap = JSON.parse(raw);
+        if (stageSkillMap.skillOrigins) delete stageSkillMap.skillOrigins[skillDirName];
+        await fs.writeFile(stageSkillMapPath, JSON.stringify(stageSkillMap, null, 2), 'utf8');
+      } catch {
+        // Stage-skill-map file doesn't exist or can't be parsed; skip cleanup
+      }
     }
 
     // Remove from global skills directory

--- a/src/components/SkillsDashboard.tsx
+++ b/src/components/SkillsDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Check, Download, Layers, Loader2, RefreshCw, Search, Sparkles, X } from 'lucide-react';
+import { Check, Download, Edit3, Layers, Loader2, RefreshCw, Save, Search, Sparkles, Trash2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../utils/api';
 type SkillNode = {
@@ -38,6 +38,8 @@ type SkillTagMapping = {
 
 type SkillSummary = {
   name: string;
+  /** Relative path from skills root to the skill directory (e.g. "distributed-training/accelerate") */
+  dirPath: string;
   summary: string;
   fullDescription: string;
   tags: SkillTag[];
@@ -103,6 +105,15 @@ const UI_TEXT: Record<LocaleKey, Record<string, string>> = {
     noSkillsFound: '未在该目录中发现技能。',
     alreadyImported: '已导入',
     pathLabel: '技能目录路径',
+    editSkill: '编辑',
+    deleteSkill: '删除',
+    saveSkill: '保存',
+    cancelEdit: '取消',
+    confirmDeleteSkill: '确定要删除技能 "{{name}}" 吗？此操作不可撤销。',
+    skillDeleted: '技能 "{{name}}" 已删除',
+    skillSaved: '技能 "{{name}}" 已保存',
+    saving: '保存中...',
+    deleting: '删除中...',
   },
   en: {
     loading: 'Loading skills...',
@@ -133,6 +144,15 @@ const UI_TEXT: Record<LocaleKey, Record<string, string>> = {
     noSkillsFound: 'No skills found in this directory.',
     alreadyImported: 'Already imported',
     pathLabel: 'Skills directory path',
+    editSkill: 'Edit',
+    deleteSkill: 'Delete',
+    saveSkill: 'Save',
+    cancelEdit: 'Cancel',
+    confirmDeleteSkill: 'Delete skill "{{name}}"? This cannot be undone.',
+    skillDeleted: '"{{name}}" deleted',
+    skillSaved: '"{{name}}" saved',
+    saving: 'Saving...',
+    deleting: 'Deleting...',
   },
   ko: {
     loading: 'Loading skills...',
@@ -163,6 +183,15 @@ const UI_TEXT: Record<LocaleKey, Record<string, string>> = {
     noSkillsFound: 'No skills found in this directory.',
     alreadyImported: 'Already imported',
     pathLabel: 'Skills directory path',
+    editSkill: 'Edit',
+    deleteSkill: 'Delete',
+    saveSkill: 'Save',
+    cancelEdit: 'Cancel',
+    confirmDeleteSkill: 'Delete skill "{{name}}"? This cannot be undone.',
+    skillDeleted: '"{{name}}" deleted',
+    skillSaved: '"{{name}}" saved',
+    saving: 'Saving...',
+    deleting: 'Deleting...',
   },
 };
 
@@ -522,7 +551,11 @@ function sortSkillTags(tags: SkillTag[]): SkillTag[] {
   });
 }
 
-export default function SkillsDashboard() {
+interface SkillsDashboardProps {
+  selectedProject?: { name: string; displayName: string } | null;
+}
+
+export default function SkillsDashboard({ selectedProject }: SkillsDashboardProps) {
   const { i18n } = useTranslation();
   const localeKey = useMemo(() => resolveLocaleKey(i18n.language || 'en'), [i18n.language]);
   const text = UI_TEXT[localeKey];
@@ -541,6 +574,11 @@ export default function SkillsDashboard() {
   const [selectedSkills, setSelectedSkills] = useState<Set<string>>(new Set());
   const [importMessage, setImportMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [hasScanned, setHasScanned] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState('');
+  const [editLoading, setEditLoading] = useState(false);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [modalMessage, setModalMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const loadSkills = useCallback(async () => {
     setLoading(true);
@@ -578,10 +616,21 @@ export default function SkillsDashboard() {
       const treeNodes = (await treeResponse.json()) as SkillNode[];
       const skillDirs = collectSkillDirectories(treeNodes);
 
+      // Infer skills root from top-level node paths (strip the node name to get the parent)
+      const skillsRoot = treeNodes.length > 0 && treeNodes[0].path
+        ? treeNodes[0].path.replace(/[/\\][^/\\]+$/, '')
+        : '';
+
       const extractedSkills = await Promise.all(
         skillDirs.map(async (node) => {
           const skillName = node.name;
           const skillMdPath = findDirectFilePathByName(node, 'SKILL.md');
+
+          // Compute relative path from skills root (e.g. "distributed-training/accelerate")
+          let dirPath = skillName;
+          if (skillsRoot && node.path && node.path.startsWith(skillsRoot + '/')) {
+            dirPath = node.path.slice(skillsRoot.length + 1);
+          }
 
           let summary = '';
           let fullDescription = '';
@@ -617,6 +666,7 @@ export default function SkillsDashboard() {
 
           return {
             name: skillName,
+            dirPath,
             summary,
             fullDescription,
             tags: normalizedTags,
@@ -716,6 +766,85 @@ export default function SkillsDashboard() {
     setSelectedSkills(new Set());
     setImportMessage(null);
     setHasScanned(false);
+  }, []);
+
+  const handleStartEdit = useCallback(async () => {
+    if (!focusedSkill) return;
+    setEditLoading(true);
+    setModalMessage(null);
+    try {
+      const skillMdPath = `${focusedSkill.dirPath}/SKILL.md`;
+      const response = await api.readGlobalSkillFile(skillMdPath);
+      if (response.ok) {
+        const payload = await response.json();
+        setEditContent(payload.content || '');
+        setIsEditing(true);
+      } else {
+        const errBody = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+        setModalMessage({ type: 'error', text: errBody.error || `Could not load SKILL.md (${response.status})` });
+      }
+    } catch (err) {
+      setModalMessage({ type: 'error', text: err instanceof Error ? err.message : 'Load failed' });
+    } finally {
+      setEditLoading(false);
+    }
+  }, [focusedSkill]);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!focusedSkill) return;
+    setEditLoading(true);
+    setModalMessage(null);
+    try {
+      const skillMdPath = `${focusedSkill.dirPath}/SKILL.md`;
+      const response = await api.saveGlobalSkillFile(skillMdPath, editContent);
+      if (response.ok) {
+        setModalMessage({ type: 'success', text: text.skillSaved.replace('{{name}}', focusedSkill.name) });
+        setIsEditing(false);
+        loadSkills();
+      } else {
+        const err = await response.json();
+        setModalMessage({ type: 'error', text: err.error || 'Save failed' });
+      }
+    } catch (err) {
+      setModalMessage({ type: 'error', text: err instanceof Error ? err.message : 'Save failed' });
+    } finally {
+      setEditLoading(false);
+    }
+  }, [focusedSkill, editContent, text.skillSaved, loadSkills]);
+
+  const handleCancelEdit = useCallback(() => {
+    setIsEditing(false);
+    setEditContent('');
+    setModalMessage(null);
+  }, []);
+
+  const handleDeleteSkill = useCallback(async () => {
+    if (!focusedSkill) return;
+    if (!confirm(text.confirmDeleteSkill.replace('{{name}}', focusedSkill.name))) return;
+    setDeleteLoading(true);
+    setModalMessage(null);
+    try {
+      const response = await api.deleteGlobalSkill(focusedSkill.dirPath);
+      if (response.ok) {
+        setFocusedSkill(null);
+        setIsEditing(false);
+        loadSkills();
+      } else {
+        const err = await response.json();
+        setModalMessage({ type: 'error', text: err.error || 'Delete failed' });
+      }
+    } catch (err) {
+      setModalMessage({ type: 'error', text: err instanceof Error ? err.message : 'Delete failed' });
+    } finally {
+      setDeleteLoading(false);
+    }
+  }, [focusedSkill, text.confirmDeleteSkill, loadSkills]);
+
+  const handleCloseModal = useCallback(() => {
+    setFocusedSkill(null);
+    setIsEditing(false);
+    setEditContent('');
+    setModalMessage(null);
   }, []);
 
   useEffect(() => {
@@ -913,7 +1042,7 @@ export default function SkillsDashboard() {
       {focusedSkill && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
-          onClick={() => setFocusedSkill(null)}
+          onClick={handleCloseModal}
         >
           <div
             className="w-full max-w-3xl rounded-2xl border border-border bg-card p-5 shadow-2xl"
@@ -924,15 +1053,67 @@ export default function SkillsDashboard() {
                 <h3 className="text-lg font-semibold text-foreground break-all">{focusedSkill.name}</h3>
                 <p className="mt-1 text-xs text-muted-foreground">{text.detailTitle}</p>
               </div>
-              <button
-                type="button"
-                onClick={() => setFocusedSkill(null)}
-                className="rounded-md border border-border p-1.5 text-muted-foreground hover:bg-muted"
-                aria-label="Close"
-              >
-                <X className="h-4 w-4" />
-              </button>
+              <div className="flex items-center gap-1.5">
+                {!isEditing && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleStartEdit}
+                      disabled={editLoading}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+                      title={text.editSkill}
+                    >
+                      {editLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Edit3 className="h-3.5 w-3.5" />}
+                      {text.editSkill}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDeleteSkill}
+                      disabled={deleteLoading}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-red-200 px-2.5 py-1.5 text-xs text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/30 transition-colors disabled:opacity-50"
+                      title={text.deleteSkill}
+                    >
+                      {deleteLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                      {text.deleteSkill}
+                    </button>
+                  </>
+                )}
+                {isEditing && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleSaveEdit}
+                      disabled={editLoading}
+                      className="inline-flex items-center gap-1.5 rounded-md bg-sky-600 px-2.5 py-1.5 text-xs text-white hover:bg-sky-700 transition-colors disabled:opacity-50"
+                    >
+                      {editLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+                      {editLoading ? text.saving : text.saveSkill}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleCancelEdit}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-xs text-foreground hover:bg-muted transition-colors"
+                    >
+                      {text.cancelEdit}
+                    </button>
+                  </>
+                )}
+                <button
+                  type="button"
+                  onClick={handleCloseModal}
+                  className="rounded-md border border-border p-1.5 text-muted-foreground hover:bg-muted"
+                  aria-label="Close"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
             </div>
+
+            {modalMessage && (
+              <div className={`mb-3 rounded-md border px-3 py-2 text-sm ${modalMessage.type === 'success' ? 'border-green-300/60 bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300' : 'border-red-300/60 bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300'}`}>
+                {modalMessage.text}
+              </div>
+            )}
 
             <div className="mb-3 flex flex-wrap gap-1.5">
               {sortSkillTags(focusedSkill.tags).map((tag) => (
@@ -942,9 +1123,18 @@ export default function SkillsDashboard() {
               ))}
             </div>
 
-            <div className="max-h-[60vh] overflow-auto rounded-lg border border-border/70 bg-muted/30 p-4">
-              <p className="whitespace-pre-wrap text-sm leading-7 text-foreground">{focusedSkill.fullDescription}</p>
-            </div>
+            {isEditing ? (
+              <textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                className="w-full max-h-[60vh] min-h-[300px] overflow-auto rounded-lg border border-border/70 bg-background p-4 font-mono text-sm leading-6 text-foreground outline-none transition focus:ring-2 focus:ring-sky-300/70 dark:focus:ring-sky-700/70 resize-y"
+                spellCheck={false}
+              />
+            ) : (
+              <div className="max-h-[60vh] overflow-auto rounded-lg border border-border/70 bg-muted/30 p-4">
+                <p className="whitespace-pre-wrap text-sm leading-7 text-foreground">{focusedSkill.fullDescription}</p>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -160,7 +160,7 @@ function MainContent({
 
           {activeTab === 'skills' && (
             <div className="h-full overflow-hidden">
-              <SkillsDashboard />
+              <SkillsDashboard selectedProject={selectedProject} />
             </div>
           )}
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -211,6 +211,11 @@ export const api = {
   getGlobalSkills: () => authenticatedFetch('/api/skills'),
   readGlobalSkillFile: (filePath) =>
     authenticatedFetch(`/api/skills/file?filePath=${encodeURIComponent(filePath)}`),
+  saveGlobalSkillFile: (filePath, content) =>
+    authenticatedFetch('/api/skills/file', {
+      method: 'PUT',
+      body: JSON.stringify({ filePath, content }),
+    }),
   validateSkillZip: (projectName, formData) =>
     authenticatedFetch(`/api/skills/${projectName}/validate-skill-zip`, {
       method: 'POST',
@@ -229,6 +234,15 @@ export const api = {
     authenticatedFetch('/api/skills/import-from-local', {
       method: 'POST',
       body: JSON.stringify({ sourcePath, skillNames }),
+    }),
+  deleteProjectSkill: (projectName, skillDirName) =>
+    authenticatedFetch(`/api/skills/${encodeURIComponent(projectName)}/${encodeURIComponent(skillDirName)}`, {
+      method: 'DELETE',
+    }),
+  deleteGlobalSkill: (dirPath) =>
+    authenticatedFetch('/api/skills/global-skill', {
+      method: 'DELETE',
+      body: JSON.stringify({ dirPath }),
     }),
 
   // Generic GET method for any endpoint

--- a/test/skills-refactor.spec.ts
+++ b/test/skills-refactor.spec.ts
@@ -1,0 +1,252 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import jwt from 'jsonwebtoken';
+
+/**
+ * Verify the Skills refactor:
+ * - Only ONE "Import Local Skills" button exists (sky-blue "Import Your Local Skills" removed)
+ * - "Project Skills" section is gone
+ * - The remaining "Import Local Skills" button opens the scan/import modal
+ * - Removed API endpoints return non-200
+ */
+
+const JWT_SECRET = process.env.JWT_SECRET || 'claude-ui-dev-secret-change-in-production';
+const MAX_USER_ID_SCAN = Number(process.env.PLAYWRIGHT_MAX_USER_ID_SCAN || 10);
+const LOGIN_USERNAME = process.env.PLAYWRIGHT_USERNAME;
+const LOGIN_PASSWORD = process.env.PLAYWRIGHT_PASSWORD;
+
+async function findValidTokenForExistingUser(request: APIRequestContext): Promise<string | null> {
+  for (let userId = 1; userId <= MAX_USER_ID_SCAN; userId += 1) {
+    const candidateToken = jwt.sign(
+      { userId, username: `playwright-e2e-${userId}` },
+      JWT_SECRET,
+    );
+    const response = await request.get('/api/auth/user', {
+      headers: { Authorization: `Bearer ${candidateToken}` },
+    });
+    if (response.ok()) return candidateToken;
+  }
+  return null;
+}
+
+async function getAuthToken(request: APIRequestContext): Promise<string> {
+  const authStatusResponse = await request.get('/api/auth/status');
+  const authStatus = await authStatusResponse.json();
+
+  // Auth might be disabled (isAuthenticated: true without setup) — return empty token
+  if (authStatus.isAuthenticated && !authStatus.needsSetup) {
+    // Try to find a valid token anyway
+    const discovered = await findValidTokenForExistingUser(request);
+    if (discovered) return discovered;
+    // Auth wall might be disabled — return empty token, pages should load fine
+    return '';
+  }
+
+  if (authStatus.needsSetup) {
+    const setupUsername = process.env.PLAYWRIGHT_SETUP_USERNAME || `playwright-${Date.now()}`;
+    const setupPassword = process.env.PLAYWRIGHT_SETUP_PASSWORD || 'playwright-password-123';
+    const registerResponse = await request.post('/api/auth/register', {
+      data: { username: setupUsername, password: setupPassword },
+    });
+    expect(registerResponse.ok()).toBeTruthy();
+    return (await registerResponse.json()).token;
+  }
+
+  if (LOGIN_USERNAME && LOGIN_PASSWORD) {
+    const loginResponse = await request.post('/api/auth/login', {
+      data: { username: LOGIN_USERNAME, password: LOGIN_PASSWORD },
+    });
+    expect(loginResponse.ok()).toBeTruthy();
+    return (await loginResponse.json()).token;
+  }
+
+  const discoveredToken = await findValidTokenForExistingUser(request);
+  if (discoveredToken) return discoveredToken;
+
+  // Fall back to empty token — auth wall may be disabled
+  return '';
+}
+
+async function ensureAuthenticated(page: Page, request: APIRequestContext) {
+  const token = await getAuthToken(request);
+  if (token) {
+    try {
+      await request.post('/api/user/complete-onboarding', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    } catch { /* non-fatal */ }
+    await page.addInitScript((authToken) => {
+      window.localStorage.setItem('auth-token', authToken);
+    }, token);
+  }
+}
+
+/** Select the first project in the sidebar (desktop layout). */
+async function selectFirstProject(page: Page) {
+  // Wait for project list to load — look for any project button in sidebar
+  // Desktop buttons use md:flex class
+  const projectBtn = page.locator('button.md\\:flex').first();
+  await expect(projectBtn).toBeVisible({ timeout: 20000 });
+  await projectBtn.click();
+  await page.waitForTimeout(2000);
+}
+
+/** Click the Skills tab */
+async function clickSkillsTab(page: Page) {
+  // Try the span inside tab button first (lg+ screens)
+  const skillsSpan = page.locator('button span.lg\\:inline:has-text("Skills")').first();
+  const visible = await skillsSpan.isVisible({ timeout: 3000 }).catch(() => false);
+  if (visible) {
+    await skillsSpan.click();
+  } else {
+    // Fallback: click the tab button by aria or tooltip
+    const skillsBtn = page.locator('button[title="Skills"], button:has(svg.lucide-sparkles)').first();
+    await skillsBtn.click();
+  }
+  await page.waitForTimeout(2000);
+}
+
+/** Navigate to Skills Dashboard with a project selected */
+async function goToSkillsDashboard(page: Page) {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(3000);
+  await selectFirstProject(page);
+  await clickSkillsTab(page);
+}
+
+test.describe('Skills Refactor — Single Import Button + No Project Skills', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await ensureAuthenticated(page, page.request);
+  });
+
+  test('1. "Import Your Local Skills" button is removed', async ({ page }) => {
+    await goToSkillsDashboard(page);
+
+    await page.screenshot({ path: 'test-results/skills-01-dashboard.png', fullPage: true });
+
+    // The old sky-blue "Import Your Local Skills" button must be gone
+    const oldButton = page.locator('button:has-text("Import Your Local Skills")');
+    await expect(oldButton).toHaveCount(0);
+
+    console.log('PASS: "Import Your Local Skills" button is removed');
+  });
+
+  test('2. Exactly one "Import Local Skills" button exists', async ({ page }) => {
+    await goToSkillsDashboard(page);
+
+    // There should be exactly one button with this text — use a broad locator
+    // The button has Download icon + translated text ("Import Local Skills" or "导入本地技能")
+    const importButtons = page.getByRole('button', { name: /Import Local Skills|导入本地技能/ });
+    const count = await importButtons.count();
+    expect(count).toBe(1);
+
+    await page.screenshot({ path: 'test-results/skills-02-single-button.png', fullPage: true });
+
+    console.log('PASS: Exactly one "Import Local Skills" button exists');
+  });
+
+  test('3. "Project Skills" section is removed', async ({ page }) => {
+    await goToSkillsDashboard(page);
+
+    // "Project Skills" heading must be gone
+    const projectSkillsHeading = page.locator('h3:has-text("Project Skills")');
+    await expect(projectSkillsHeading).toHaveCount(0);
+
+    // The description text must also be gone
+    const projectSkillsDesc = page.locator('text=Skills imported into this project');
+    await expect(projectSkillsDesc).toHaveCount(0);
+
+    console.log('PASS: "Project Skills" section is removed');
+  });
+
+  test('4. Import modal opens with default path', async ({ page }) => {
+    await goToSkillsDashboard(page);
+
+    // Click the "Import Local Skills" button
+    const importBtn = page.getByRole('button', { name: /Import Local Skills|导入本地技能/ }).first();
+    await expect(importBtn).toBeVisible({ timeout: 10000 });
+    await importBtn.click();
+
+    // Modal should appear
+    const modalTitle = page.locator('text=Import skills from local directory');
+    await expect(modalTitle).toBeVisible({ timeout: 5000 });
+
+    // Path input should default to ~/.claude/skills
+    const pathInput = page.locator('input[placeholder="~/.claude/skills"]');
+    await expect(pathInput).toBeVisible();
+    const pathValue = await pathInput.inputValue();
+    expect(pathValue).toBe('~/.claude/skills');
+
+    // Scan button should be visible
+    const scanBtn = page.getByRole('button', { name: /^Scan$|^扫描$/ });
+    await expect(scanBtn).toBeVisible();
+
+    await page.screenshot({ path: 'test-results/skills-03-import-modal.png', fullPage: true });
+
+    console.log('PASS: Import modal opens with default path ~/.claude/skills');
+  });
+
+  test('5. Scan works and shows results or empty state', async ({ page }) => {
+    await goToSkillsDashboard(page);
+
+    // Open modal
+    const importBtn = page.getByRole('button', { name: /Import Local Skills|导入本地技能/ }).first();
+    await importBtn.click();
+    await expect(page.locator('text=Import skills from local directory')).toBeVisible({ timeout: 5000 });
+
+    // Click Scan
+    const scanBtn = page.getByRole('button', { name: /^Scan$|^扫描$/ });
+    await scanBtn.click();
+
+    // Wait for the scan to complete (scan-local API call)
+    await page.waitForTimeout(3000);
+
+    await page.screenshot({ path: 'test-results/skills-04-scan-result.png', fullPage: true });
+
+    // Either: skills listed (checkboxes), "no skills found", or path error — all valid
+    const checkboxes = page.locator('input[type="checkbox"]');
+    const noSkillsMsg = page.locator('text=/No skills found|未在该目录中发现/');
+    const errorMsg = page.locator('text=/Path does not exist|does not exist/');
+
+    const hasCheckboxes = (await checkboxes.count()) > 0;
+    const hasNoSkills = (await noSkillsMsg.count()) > 0;
+    const hasError = (await errorMsg.count()) > 0;
+
+    expect(hasCheckboxes || hasNoSkills || hasError).toBeTruthy();
+
+    console.log(`PASS: Scan completed — checkboxes: ${await checkboxes.count()}, noSkills: ${hasNoSkills}, error: ${hasError}`);
+  });
+
+  test('6. Removed API endpoints no longer return JSON', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(2000);
+
+    // GET /:projectName/user-skills should no longer return a JSON skills list
+    // (Vite SPA fallback may return 200 with HTML, so we check content-type)
+    const userSkillsResponse = await page.request.get('/api/skills/test-project/user-skills');
+    const contentType = userSkillsResponse.headers()['content-type'] || '';
+    const isJsonSkillsList = contentType.includes('application/json') &&
+      userSkillsResponse.status() === 200;
+
+    if (isJsonSkillsList) {
+      // If it somehow returns JSON 200, the body should NOT have a "skills" array
+      const body = await userSkillsResponse.json().catch(() => ({}));
+      expect(body).not.toHaveProperty('skills');
+    }
+
+    // PUT /:projectName/user-skills/:skillName should not return success JSON
+    const updateResponse = await page.request.put('/api/skills/test-project/user-skills/some-skill');
+    const updateContentType = updateResponse.headers()['content-type'] || '';
+    const isJsonUpdate = updateContentType.includes('application/json') &&
+      updateResponse.status() === 200;
+
+    if (isJsonUpdate) {
+      const body = await updateResponse.json().catch(() => ({}));
+      expect(body).not.toHaveProperty('success');
+    }
+
+    console.log(`PASS: GET user-skills → ${userSkillsResponse.status()} (${contentType}), PUT → ${updateResponse.status()} (${updateContentType})`);
+  });
+});


### PR DESCRIPTION
## Summary
- Restructure three-tier skill architecture so VibeLab root (`skills/`) is the ground reference for all imports
- Merge two import buttons into a single "Import Local Skills" button with scan/select modal
- Remove "Project Skills" section — project skills are now symlinks to VibeLab root
- Add **Edit** and **Delete** buttons to the skill detail modal (supports nested skills like `distributed-training/accelerate`)
- Export `ensureProjectSkillLinks` and add JSON config file symlinks (`skill-tag-mapping.json`, `stage-skill-map.json`)
- Add `PUT /file` endpoint for editing SKILL.md and `DELETE /global-skill` endpoint with dirPath-based resolution

## Test plan
- [x] `npx tsc --noEmit --skipLibCheck` — clean
- [x] All 6 Playwright e2e tests pass (`test/skills-refactor.spec.ts`)
- [x] Manual verification: single Import button, Edit loads SKILL.md content, Save persists, Delete removes skill
- [ ] Verify nested skills (e.g. `distributed-training/accelerate`) edit/delete correctly
- [ ] Verify symlinks created in project `.claude/skills/` after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)