### PR TITLE
feat(dashboard): add project overview dashboard

### DIFF
--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -39,6 +39,7 @@ export default function AppContent() {
   } = useSessionProtection();
 
   const {
+    projects,
     selectedProject,
     selectedSession,
     activeTab,
@@ -53,6 +54,7 @@ export default function AppContent() {
     openSettings,
     fetchProjects,
     sidebarSharedProps,
+    handleProjectSelect,
     pendingAutoIntake,
     handleProjectCreatedWithIntake,
     clearPendingAutoIntake,
@@ -217,6 +219,7 @@ export default function AppContent() {
 
       <div className={`flex-1 flex flex-col min-w-0 ${isMobile ? 'pb-mobile-nav' : ''}`}>
         <MainContent
+          projects={projects}
           selectedProject={selectedProject}
           selectedSession={selectedSession}
           activeTab={activeTab}
@@ -239,6 +242,7 @@ export default function AppContent() {
           externalMessageUpdate={externalMessageUpdate}
           pendingAutoIntake={pendingAutoIntake}
           clearPendingAutoIntake={clearPendingAutoIntake}
+          onProjectSelect={handleProjectSelect}
         />
       </div>
 

--- a/src/components/main-content/types/types.ts
+++ b/src/components/main-content/types/types.ts
@@ -47,6 +47,7 @@ export interface PrdFile {
 }
 
 export interface MainContentProps {
+  projects: Project[];
   selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   activeTab: AppTab;
@@ -69,12 +70,13 @@ export interface MainContentProps {
   externalMessageUpdate: number;
   pendingAutoIntake?: boolean;
   clearPendingAutoIntake?: () => void;
+  onProjectSelect: (project: Project) => void;
 }
 
 export interface MainContentHeaderProps {
   activeTab: AppTab;
   setActiveTab: Dispatch<SetStateAction<AppTab>>;
-  selectedProject: Project;
+  selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   shouldShowTasksTab: boolean;
   isMobile: boolean;

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -8,6 +8,7 @@ import SkillsDashboard from '../../SkillsDashboard';
 import ComputePanel from '../../ComputePanel';
 import ErrorBoundary from '../../ErrorBoundary';
 import SurveyPage from '../../survey/view/SurveyPage';
+import ProjectDashboard from '../../project-dashboard/view/ProjectDashboard';
 
 import MainContentHeader from './subcomponents/MainContentHeader';
 import MainContentStateView from './subcomponents/MainContentStateView';
@@ -28,6 +29,7 @@ type TaskMasterContextValue = {
 };
 
 function MainContent({
+  projects,
   selectedProject,
   selectedSession,
   activeTab,
@@ -50,6 +52,7 @@ function MainContent({
   externalMessageUpdate,
   pendingAutoIntake,
   clearPendingAutoIntake,
+  onProjectSelect,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
   const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter } = preferences;
@@ -85,6 +88,32 @@ function MainContent({
 
   if (isLoading) {
     return <MainContentStateView mode="loading" isMobile={isMobile} onMenuClick={onMenuClick} />;
+  }
+
+  if (activeTab === 'dashboard') {
+    return (
+      <div className="h-full flex flex-col">
+        <MainContentHeader
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          selectedProject={null}
+          selectedSession={null}
+          shouldShowTasksTab={shouldShowTasksTab}
+          isMobile={isMobile}
+          onMenuClick={onMenuClick}
+        />
+
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <ProjectDashboard
+            projects={projects}
+            onProjectAction={(project, tab) => {
+              onProjectSelect(project);
+              setActiveTab(tab);
+            }}
+          />
+        </div>
+      </div>
+    );
   }
 
   if (!selectedProject) {

--- a/src/components/main-content/view/subcomponents/MainContentHeader.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentHeader.tsx
@@ -26,11 +26,13 @@ export default function MainContentHeader({
         </div>
 
         <div className="flex-shrink-0 hidden sm:block">
-          <MainContentTabSwitcher
-            activeTab={activeTab}
-            setActiveTab={setActiveTab}
-            shouldShowTasksTab={shouldShowTasksTab}
-          />
+          {selectedProject && activeTab !== 'dashboard' && (
+            <MainContentTabSwitcher
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+              shouldShowTasksTab={shouldShowTasksTab}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/main-content/view/subcomponents/MainContentTitle.tsx
+++ b/src/components/main-content/view/subcomponents/MainContentTitle.tsx
@@ -4,7 +4,7 @@ import type { AppTab, Project, ProjectSession } from '../../../../types/app';
 
 type MainContentTitleProps = {
   activeTab: AppTab;
-  selectedProject: Project;
+  selectedProject: Project | null;
   selectedSession: ProjectSession | null;
   shouldShowTasksTab: boolean;
 };
@@ -12,6 +12,10 @@ type MainContentTitleProps = {
 function getTabTitle(activeTab: AppTab, shouldShowTasksTab: boolean, t: (key: string) => string) {
   if (activeTab === 'files') {
     return t('mainContent.projectFiles');
+  }
+
+  if (activeTab === 'dashboard') {
+    return t('projectDashboard.title');
   }
 
   if (activeTab === 'git') {
@@ -55,6 +59,7 @@ export default function MainContentTitle({
 
   const showSessionIcon = activeTab === 'chat' && Boolean(selectedSession);
   const showChatNewSession = activeTab === 'chat' && !selectedSession;
+  const isDashboard = activeTab === 'dashboard';
 
   return (
     <div className="min-w-0 flex items-center gap-2 flex-1 overflow-x-auto scrollbar-hide">
@@ -65,26 +70,35 @@ export default function MainContentTitle({
       )}
 
       <div className="min-w-0 flex-1">
-        {activeTab === 'chat' && selectedSession ? (
+        {isDashboard ? (
+          <div className="min-w-0">
+            <h2 className="text-[15px] font-bold text-foreground leading-tight">
+              {t('projectDashboard.title')}
+            </h2>
+            <div className="text-[12px] text-muted-foreground truncate leading-tight mt-0.5">
+              {t('projectDashboard.subtitle')}
+            </div>
+          </div>
+        ) : activeTab === 'chat' && selectedSession && selectedProject ? (
           <div className="min-w-0">
             <h2 className="text-[15px] font-bold text-foreground whitespace-nowrap overflow-x-auto scrollbar-hide leading-tight">
               {getSessionTitle(selectedSession)}
             </h2>
             <div className="text-[12px] text-muted-foreground truncate leading-tight mt-0.5">{selectedProject.displayName}</div>
           </div>
-        ) : showChatNewSession ? (
+        ) : showChatNewSession && selectedProject ? (
           <div className="min-w-0">
             <h2 className="text-[15px] font-bold text-foreground leading-tight">{t('mainContent.newSession')}</h2>
             <div className="text-[12px] text-muted-foreground truncate leading-tight mt-0.5">{selectedProject.displayName}</div>
           </div>
-        ) : (
+        ) : selectedProject ? (
           <div className="min-w-0">
             <h2 className="text-[15px] font-bold text-foreground leading-tight">
               {getTabTitle(activeTab, shouldShowTasksTab, t)}
             </h2>
             <div className="text-[12px] text-muted-foreground truncate leading-tight mt-0.5">{selectedProject.displayName}</div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/src/components/project-dashboard/view/ProjectDashboard.tsx
+++ b/src/components/project-dashboard/view/ProjectDashboard.tsx
@@ -1,0 +1,280 @@
+import {
+  Activity,
+  ArrowRight,
+  FolderOpen,
+  FlaskConical,
+  MessageSquare,
+  Terminal,
+} from 'lucide-react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Badge } from '../../ui/badge';
+import { Button } from '../../ui/button';
+import { formatTimeAgo } from '../../../utils/dateUtils';
+import type { AppTab, Project, ProjectSession } from '../../../types/app';
+
+type ProjectDashboardProps = {
+  projects: Project[];
+  onProjectAction: (project: Project, tab: AppTab) => void;
+};
+
+type TaskmasterMetadata = {
+  taskCount?: number;
+  completed?: number;
+  completionPercentage?: number;
+  lastModified?: string;
+};
+
+function getProjectSessions(project: Project): ProjectSession[] {
+  return [
+    ...(project.sessions ?? []),
+    ...(project.cursorSessions ?? []),
+    ...(project.codexSessions ?? []),
+  ];
+}
+
+function getLastActivity(project: Project) {
+  const sessionDates = getProjectSessions(project)
+    .map((session) => session.updated_at || session.lastActivity || session.created_at || session.createdAt)
+    .filter((value): value is string => Boolean(value))
+    .map((value) => new Date(value))
+    .filter((value) => !Number.isNaN(value.getTime()))
+    .sort((a, b) => b.getTime() - a.getTime());
+
+  if (sessionDates.length > 0) {
+    return sessionDates[0].toISOString();
+  }
+
+  return project.createdAt ?? null;
+}
+
+function getTaskmasterMetadata(project: Project): TaskmasterMetadata | null {
+  const metadata = project.taskmaster?.metadata;
+
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  return metadata as TaskmasterMetadata;
+}
+
+function getProgress(project: Project) {
+  const metadata = getTaskmasterMetadata(project);
+
+  if (typeof metadata?.completionPercentage === 'number') {
+    return Math.max(0, Math.min(100, metadata.completionPercentage));
+  }
+
+  return null;
+}
+
+export default function ProjectDashboard({
+  projects,
+  onProjectAction,
+}: ProjectDashboardProps) {
+  const { t } = useTranslation('common');
+  const now = new Date();
+
+  const totals = useMemo(() => {
+    const projectCount = projects.length;
+    const projectsWithProgress = projects.filter((project) => getProgress(project) !== null);
+    const trackedProjects = projectsWithProgress.length;
+    const averageProgress = trackedProjects > 0
+      ? Math.round(
+          projectsWithProgress.reduce((sum, project) => sum + (getProgress(project) ?? 0), 0) / trackedProjects,
+        )
+      : null;
+    const totalSessions = projects.reduce((sum, project) => sum + getProjectSessions(project).length, 0);
+
+    return {
+      projectCount,
+      trackedProjects,
+      averageProgress,
+      totalSessions,
+    };
+  }, [projects]);
+
+  if (projects.length === 0) {
+    return (
+      <div className="h-full overflow-y-auto">
+        <div className="mx-auto flex h-full w-full max-w-6xl items-center px-4 py-8 sm:px-6 lg:px-8">
+          <div className="w-full rounded-3xl border border-dashed border-border/70 bg-card/40 p-8 text-center sm:p-12">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <FolderOpen className="h-6 w-6" />
+            </div>
+            <h2 className="mt-5 text-2xl font-semibold text-foreground">
+              {t('projectDashboard.emptyTitle')}
+            </h2>
+            <p className="mx-auto mt-3 max-w-2xl text-sm text-muted-foreground sm:text-base">
+              {t('projectDashboard.emptyDescription')}
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+        <section className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-3xl border border-border/60 bg-card/80 p-5 shadow-sm">
+            <div className="text-sm text-muted-foreground">{t('projectDashboard.summary.projects')}</div>
+            <div className="mt-2 text-3xl font-semibold text-foreground">{totals.projectCount}</div>
+          </div>
+          <div className="rounded-3xl border border-border/60 bg-card/80 p-5 shadow-sm">
+            <div className="text-sm text-muted-foreground">{t('projectDashboard.summary.sessions')}</div>
+            <div className="mt-2 text-3xl font-semibold text-foreground">{totals.totalSessions}</div>
+          </div>
+          <div className="rounded-3xl border border-border/60 bg-card/80 p-5 shadow-sm">
+            <div className="text-sm text-muted-foreground">{t('projectDashboard.summary.progress')}</div>
+            <div className="mt-2 text-3xl font-semibold text-foreground">
+              {totals.averageProgress === null ? t('projectDashboard.notTrackedShort') : `${totals.averageProgress}%`}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {t('projectDashboard.summary.trackedProjects', { count: totals.trackedProjects })}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-2">
+          {projects.map((project) => {
+            const sessions = getProjectSessions(project);
+            const metadata = getTaskmasterMetadata(project);
+            const progress = getProgress(project);
+            const lastActivity = getLastActivity(project);
+
+            return (
+              <article
+                key={project.name}
+                className="rounded-3xl border border-border/60 bg-card/90 p-5 shadow-sm transition-colors hover:border-primary/30"
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="truncate text-lg font-semibold text-foreground">
+                          {project.displayName}
+                        </h2>
+                        {progress !== null && (
+                          <Badge variant="secondary" className="rounded-full">
+                            {t('projectDashboard.progressBadge', { progress })}
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 break-all text-xs text-muted-foreground sm:text-sm">
+                        {project.fullPath}
+                      </p>
+                    </div>
+
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="self-start rounded-full"
+                      onClick={() => onProjectAction(project, 'chat')}
+                    >
+                      <FolderOpen className="h-4 w-4" />
+                      {t('projectDashboard.openProject')}
+                    </Button>
+                  </div>
+
+                  <div className="grid gap-3 sm:grid-cols-3">
+                    <div className="rounded-2xl bg-muted/40 p-3">
+                      <div className="text-xs text-muted-foreground">{t('projectDashboard.metrics.sessions')}</div>
+                      <div className="mt-1 text-xl font-semibold text-foreground">{sessions.length}</div>
+                    </div>
+                    <div className="rounded-2xl bg-muted/40 p-3">
+                      <div className="text-xs text-muted-foreground">{t('projectDashboard.metrics.tasks')}</div>
+                      <div className="mt-1 text-xl font-semibold text-foreground">{metadata?.taskCount ?? '0'}</div>
+                    </div>
+                    <div className="rounded-2xl bg-muted/40 p-3">
+                      <div className="text-xs text-muted-foreground">{t('projectDashboard.metrics.completed')}</div>
+                      <div className="mt-1 text-xl font-semibold text-foreground">{metadata?.completed ?? '0'}</div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-border/50 bg-background/60 p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                        <Activity className="h-4 w-4 text-primary" />
+                        {t('projectDashboard.progressTitle')}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {progress === null
+                          ? t('projectDashboard.notTracked')
+                          : t('projectDashboard.progressValue', { progress })}
+                      </div>
+                    </div>
+                    <div className="mt-3 h-2 overflow-hidden rounded-full bg-muted">
+                      <div
+                        className="h-full rounded-full bg-primary transition-[width] duration-300"
+                        style={{ width: `${progress ?? 0}%` }}
+                      />
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground">
+                      <span>
+                        {lastActivity
+                          ? t('projectDashboard.lastActivity', {
+                              time: formatTimeAgo(lastActivity, now, t),
+                            })
+                          : t('projectDashboard.noRecentActivity')}
+                      </span>
+                      {metadata?.lastModified && (
+                        <span>
+                          {t('projectDashboard.pipelineUpdated', {
+                            time: formatTimeAgo(metadata.lastModified, now, t),
+                          })}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="default"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => onProjectAction(project, 'chat')}
+                    >
+                      <MessageSquare className="h-4 w-4" />
+                      {t('projectDashboard.actions.chat')}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => onProjectAction(project, 'files')}
+                    >
+                      <FolderOpen className="h-4 w-4" />
+                      {t('projectDashboard.actions.files')}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => onProjectAction(project, 'researchlab')}
+                    >
+                      <FlaskConical className="h-4 w-4" />
+                      {t('projectDashboard.actions.researchLab')}
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="rounded-full"
+                      onClick={() => onProjectAction(project, 'shell')}
+                    >
+                      <Terminal className="h-4 w-4" />
+                      {t('projectDashboard.actions.shell')}
+                      <ArrowRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sidebar/types/types.ts
+++ b/src/components/sidebar/types/types.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { LoadingProgress, Project, ProjectSession, SessionProvider } from '../../../types/app';
+import type { AppTab, LoadingProgress, Project, ProjectSession, SessionProvider } from '../../../types/app';
 
 export type ProjectSortOrder = 'name' | 'date';
 
@@ -39,6 +39,8 @@ export type SidebarProps = {
   settingsInitialTab: string;
   onCloseSettings: () => void;
   isMobile: boolean;
+  activeTab: AppTab;
+  onOpenDashboard: () => void;
 };
 
 export type SessionViewModel = {

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -37,6 +37,8 @@ function Sidebar({
   settingsInitialTab,
   onCloseSettings,
   isMobile,
+  activeTab,
+  onOpenDashboard,
 }: SidebarProps) {
   const { t } = useTranslation(['sidebar', 'common']);
   const { isPWA } = useDeviceSettings({ trackMobile: false });
@@ -262,6 +264,8 @@ function Sidebar({
               void refreshProjects();
             }}
             isRefreshing={isRefreshing}
+            activeTab={activeTab}
+            onOpenDashboard={onOpenDashboard}
             onCreateProject={() => void handleQuickCreateProject()}
             onCollapseSidebar={handleCollapseSidebar}
             updateAvailable={updateAvailable}

--- a/src/components/sidebar/view/subcomponents/SidebarContent.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarContent.tsx
@@ -1,6 +1,6 @@
+import type { AppTab, Project } from '../../../../types/app';
 import { ScrollArea } from '../../../ui/scroll-area';
 import type { TFunction } from 'i18next';
-import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 import SidebarFooter from './SidebarFooter';
 import SidebarHeader from './SidebarHeader';
@@ -16,6 +16,8 @@ type SidebarContentProps = {
   onClearSearchFilter: () => void;
   onRefresh: () => void;
   isRefreshing: boolean;
+  activeTab: AppTab;
+  onOpenDashboard: () => void;
   onCreateProject: () => void;
   onCollapseSidebar: () => void;
   updateAvailable: boolean;
@@ -37,6 +39,8 @@ export default function SidebarContent({
   onClearSearchFilter,
   onRefresh,
   isRefreshing,
+  activeTab,
+  onOpenDashboard,
   onCreateProject,
   onCollapseSidebar,
   updateAvailable,
@@ -62,6 +66,8 @@ export default function SidebarContent({
         onClearSearchFilter={onClearSearchFilter}
         onRefresh={onRefresh}
         isRefreshing={isRefreshing}
+        activeTab={activeTab}
+        onOpenDashboard={onOpenDashboard}
         onCreateProject={onCreateProject}
         onCollapseSidebar={onCollapseSidebar}
         t={t}

--- a/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
@@ -1,5 +1,6 @@
-import { FolderPlus, Plus, RefreshCw, Search, X, PanelLeftClose } from 'lucide-react';
+import { FolderPlus, LayoutDashboard, PanelLeftClose, Plus, RefreshCw, Search, X } from 'lucide-react';
 import type { TFunction } from 'i18next';
+import type { AppTab } from '../../../../types/app';
 import { Button } from '../../../ui/button';
 import { Input } from '../../../ui/input';
 import { IS_PLATFORM } from '../../../../constants/config';
@@ -14,6 +15,8 @@ type SidebarHeaderProps = {
   onClearSearchFilter: () => void;
   onRefresh: () => void;
   isRefreshing: boolean;
+  activeTab: AppTab;
+  onOpenDashboard: () => void;
   onCreateProject: () => void;
   onCollapseSidebar: () => void;
   t: TFunction;
@@ -29,6 +32,8 @@ export default function SidebarHeader({
   onClearSearchFilter,
   onRefresh,
   isRefreshing,
+  activeTab,
+  onOpenDashboard,
   onCreateProject,
   onCollapseSidebar,
   t,
@@ -98,23 +103,35 @@ export default function SidebarHeader({
 
         {/* Search bar */}
         {projectsCount > 0 && !isLoading && (
-          <div className="relative mt-2.5">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50 pointer-events-none" />
-            <Input
-              type="text"
-              placeholder={t('projects.searchPlaceholder')}
-              value={searchFilter}
-              onChange={(event) => onSearchFilterChange(event.target.value)}
-              className="nav-search-input pl-9 pr-8 h-9 text-xs rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
-            />
-            {searchFilter && (
-              <button
-                onClick={onClearSearchFilter}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-accent rounded-md"
-              >
-                <X className="w-3 h-3 text-muted-foreground" />
-              </button>
-            )}
+          <div className="mt-2.5 space-y-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground/50 pointer-events-none" />
+              <Input
+                type="text"
+                placeholder={t('projects.searchPlaceholder')}
+                value={searchFilter}
+                onChange={(event) => onSearchFilterChange(event.target.value)}
+                className="nav-search-input pl-9 pr-8 h-9 text-xs rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
+              />
+              {searchFilter && (
+                <button
+                  onClick={onClearSearchFilter}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-accent rounded-md"
+                >
+                  <X className="w-3 h-3 text-muted-foreground" />
+                </button>
+              )}
+            </div>
+
+            <Button
+              variant={activeTab === 'dashboard' ? 'secondary' : 'outline'}
+              size="sm"
+              className="h-9 w-full justify-start rounded-xl"
+              onClick={onOpenDashboard}
+            >
+              <LayoutDashboard className="h-4 w-4" />
+              {t('common:tabs.dashboard')}
+            </Button>
           </div>
         )}
       </div>
@@ -159,23 +176,34 @@ export default function SidebarHeader({
 
         {/* Mobile search */}
         {projectsCount > 0 && !isLoading && (
-          <div className="relative mt-2.5">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50 pointer-events-none" />
-            <Input
-              type="text"
-              placeholder={t('projects.searchPlaceholder')}
-              value={searchFilter}
-              onChange={(event) => onSearchFilterChange(event.target.value)}
-              className="nav-search-input pl-10 pr-9 h-10 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
-            />
-            {searchFilter && (
-              <button
-                onClick={onClearSearchFilter}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded-md"
-              >
-                <X className="w-3.5 h-3.5 text-muted-foreground" />
-              </button>
-            )}
+          <div className="mt-2.5 space-y-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/50 pointer-events-none" />
+              <Input
+                type="text"
+                placeholder={t('projects.searchPlaceholder')}
+                value={searchFilter}
+                onChange={(event) => onSearchFilterChange(event.target.value)}
+                className="nav-search-input pl-10 pr-9 h-10 text-sm rounded-xl border-0 placeholder:text-muted-foreground/40 focus-visible:ring-0 focus-visible:ring-offset-0 transition-all duration-200"
+              />
+              {searchFilter && (
+                <button
+                  onClick={onClearSearchFilter}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 hover:bg-accent rounded-md"
+                >
+                  <X className="w-3.5 h-3.5 text-muted-foreground" />
+                </button>
+              )}
+            </div>
+
+            <Button
+              variant={activeTab === 'dashboard' ? 'secondary' : 'outline'}
+              className="h-10 w-full justify-start rounded-xl"
+              onClick={onOpenDashboard}
+            >
+              <LayoutDashboard className="h-4 w-4" />
+              {t('common:tabs.dashboard')}
+            </Button>
           </div>
         )}
       </div>

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -117,7 +117,7 @@ export function useProjectsState({
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [selectedSession, setSelectedSession] = useState<ProjectSession | null>(null);
-  const [activeTab, setActiveTab] = useState<AppTab>('chat');
+  const [activeTab, setActiveTab] = useState<AppTab>('dashboard');
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isLoadingProjects, setIsLoadingProjects] = useState(true);
   const [loadingProgress, setLoadingProgress] = useState<LoadingProgress | null>(null);
@@ -161,13 +161,6 @@ export function useProjectsState({
   useEffect(() => {
     void fetchProjects();
   }, [fetchProjects]);
-
-  // Auto-select the project when there is only one, so the user lands on the new session page
-  useEffect(() => {
-    if (!isLoadingProjects && projects.length === 1 && !selectedProject && !sessionId) {
-      setSelectedProject(projects[0]);
-    }
-  }, [isLoadingProjects, projects, selectedProject, sessionId]);
 
   useEffect(() => {
     if (!latestMessage) {
@@ -356,6 +349,7 @@ export function useProjectsState({
     (project: Project) => {
       setSelectedProject(project);
       setSelectedSession(null);
+      setActiveTab((currentTab) => (currentTab === 'dashboard' ? 'chat' : currentTab));
       navigate('/');
 
       if (isMobile) {
@@ -419,6 +413,17 @@ export function useProjectsState({
   );
 
   const clearPendingAutoIntake = useCallback(() => setPendingAutoIntake(false), []);
+
+  const handleOpenDashboard = useCallback(() => {
+    setSelectedProject(null);
+    setSelectedSession(null);
+    setActiveTab('dashboard');
+    navigate('/');
+
+    if (isMobile) {
+      setSidebarOpen(false);
+    }
+  }, [isMobile, navigate]);
 
   const handleSessionDelete = useCallback(
     (sessionIdToDelete: string) => {
@@ -518,6 +523,8 @@ export function useProjectsState({
       settingsInitialTab,
       onCloseSettings: () => setShowSettings(false),
       isMobile,
+      activeTab,
+      onOpenDashboard: handleOpenDashboard,
     }),
     [
       handleNewSession,
@@ -530,6 +537,8 @@ export function useProjectsState({
       isMobile,
       loadingProgress,
       projects,
+      activeTab,
+      handleOpenDashboard,
       settingsInitialTab,
       selectedProject,
       selectedSession,
@@ -558,6 +567,7 @@ export function useProjectsState({
     sidebarSharedProps,
     handleProjectSelect,
     handleSessionSelect,
+    handleOpenDashboard,
     handleNewSession,
     handleSessionDelete,
     handleProjectDelete,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -18,6 +18,7 @@
     "browse": "Browse"
   },
   "tabs": {
+    "dashboard": "Dashboard",
     "chat": "Chat",
     "survey": "Survey",
     "shell": "Shell",
@@ -154,8 +155,11 @@
   },
   "time": {
     "justNow": "Just now",
+    "oneMinuteAgo": "1 min ago",
     "minutesAgo": "{{count}} mins ago",
+    "oneHourAgo": "1 hour ago",
     "hoursAgo": "{{count}} hours ago",
+    "oneDayAgo": "1 day ago",
     "daysAgo": "{{count}} days ago",
     "yesterday": "Yesterday"
   },
@@ -178,6 +182,38 @@
     "newSession": "New Session",
     "untitledSession": "Untitled Session",
     "projectFiles": "Project Files"
+  },
+  "projectDashboard": {
+    "title": "Project Dashboard",
+    "subtitle": "Track every workspace and jump back into active work quickly.",
+    "emptyTitle": "No projects yet",
+    "emptyDescription": "Create or add a workspace from the sidebar to start tracking project progress here.",
+    "summary": {
+      "projects": "Projects",
+      "sessions": "Sessions",
+      "progress": "Average Progress",
+      "trackedProjects": "{{count}} tracked"
+    },
+    "metrics": {
+      "sessions": "Sessions",
+      "tasks": "Tasks",
+      "completed": "Completed"
+    },
+    "actions": {
+      "chat": "Open Chat",
+      "files": "Browse Files",
+      "researchLab": "Open Lab",
+      "shell": "Open Shell"
+    },
+    "openProject": "Open Project",
+    "progressTitle": "Progress",
+    "progressBadge": "{{progress}}% complete",
+    "progressValue": "{{progress}}% complete",
+    "notTracked": "No tracked progress",
+    "notTrackedShort": "N/A",
+    "lastActivity": "Last activity {{time}}",
+    "pipelineUpdated": "Pipeline updated {{time}}",
+    "noRecentActivity": "No recent activity"
   },
   "fileTree": {
     "loading": "Loading files...",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -18,6 +18,7 @@
     "browse": "찾아보기"
   },
   "tabs": {
+    "dashboard": "대시보드",
     "chat": "채팅",
     "survey": "서베이",
     "shell": "Shell",
@@ -154,8 +155,11 @@
   },
   "time": {
     "justNow": "방금 전",
+    "oneMinuteAgo": "1분 전",
     "minutesAgo": "{{count}}분 전",
+    "oneHourAgo": "1시간 전",
     "hoursAgo": "{{count}}시간 전",
+    "oneDayAgo": "1일 전",
     "daysAgo": "{{count}}일 전",
     "yesterday": "어제"
   },
@@ -178,6 +182,38 @@
     "newSession": "새 세션",
     "untitledSession": "제목 없는 세션",
     "projectFiles": "프로젝트 파일"
+  },
+  "projectDashboard": {
+    "title": "프로젝트 대시보드",
+    "subtitle": "모든 워크스페이스 진행 상황을 보고 바로 작업으로 돌아갑니다.",
+    "emptyTitle": "아직 프로젝트가 없습니다",
+    "emptyDescription": "사이드바에서 워크스페이스를 추가하거나 생성하면 여기에서 모든 프로젝트 진행 상황을 볼 수 있습니다.",
+    "summary": {
+      "projects": "프로젝트",
+      "sessions": "세션",
+      "progress": "평균 진행률",
+      "trackedProjects": "{{count}}개 추적 중"
+    },
+    "metrics": {
+      "sessions": "세션",
+      "tasks": "작업",
+      "completed": "완료"
+    },
+    "actions": {
+      "chat": "채팅 열기",
+      "files": "파일 보기",
+      "researchLab": "랩 열기",
+      "shell": "Shell 열기"
+    },
+    "openProject": "프로젝트 열기",
+    "progressTitle": "진행률",
+    "progressBadge": "{{progress}}% 완료",
+    "progressValue": "{{progress}}% 완료",
+    "notTracked": "추적 중인 진행률 없음",
+    "notTrackedShort": "없음",
+    "lastActivity": "마지막 활동 {{time}}",
+    "pipelineUpdated": "파이프라인 업데이트 {{time}}",
+    "noRecentActivity": "최근 활동 없음"
   },
   "fileTree": {
     "loading": "파일 로딩 중...",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -18,6 +18,7 @@
     "browse": "浏览"
   },
   "tabs": {
+    "dashboard": "仪表盘",
     "chat": "聊天",
     "survey": "调研",
     "shell": "终端",
@@ -154,8 +155,11 @@
   },
   "time": {
     "justNow": "刚刚",
+    "oneMinuteAgo": "1 分钟前",
     "minutesAgo": "{{count}} 分钟前",
+    "oneHourAgo": "1 小时前",
     "hoursAgo": "{{count}} 小时前",
+    "oneDayAgo": "1 天前",
     "daysAgo": "{{count}} 天前",
     "yesterday": "昨天"
   },
@@ -178,6 +182,38 @@
     "newSession": "新会话",
     "untitledSession": "未命名会话",
     "projectFiles": "项目文件"
+  },
+  "projectDashboard": {
+    "title": "项目仪表盘",
+    "subtitle": "集中查看所有工作区进度，并快速回到正在进行的项目。",
+    "emptyTitle": "还没有项目",
+    "emptyDescription": "从侧边栏创建或添加工作区后，这里会显示所有项目及其进度。",
+    "summary": {
+      "projects": "项目数",
+      "sessions": "会话数",
+      "progress": "平均进度",
+      "trackedProjects": "已跟踪 {{count}} 个"
+    },
+    "metrics": {
+      "sessions": "会话",
+      "tasks": "任务",
+      "completed": "已完成"
+    },
+    "actions": {
+      "chat": "打开聊天",
+      "files": "查看文件",
+      "researchLab": "打开实验室",
+      "shell": "打开终端"
+    },
+    "openProject": "打开项目",
+    "progressTitle": "进度",
+    "progressBadge": "已完成 {{progress}}%",
+    "progressValue": "已完成 {{progress}}%",
+    "notTracked": "暂无可跟踪进度",
+    "notTrackedShort": "无",
+    "lastActivity": "最近活动：{{time}}",
+    "pipelineUpdated": "流水线更新于 {{time}}",
+    "noRecentActivity": "暂无最近活动"
   },
   "fileTree": {
     "loading": "正在加载文件...",

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,6 +1,6 @@
 export type SessionProvider = 'claude' | 'cursor' | 'codex';
 
-export type AppTab = 'chat' | 'survey' | 'files' | 'shell' | 'git' | 'researchlab' | 'skills' | 'tasks' | 'preview' | 'compute';
+export type AppTab = 'dashboard' | 'chat' | 'survey' | 'files' | 'shell' | 'git' | 'researchlab' | 'skills' | 'tasks' | 'preview' | 'compute';
 
 export interface ProjectSession {
   id: string;


### PR DESCRIPTION
## Summary

Adds a project dashboard to VibeLab that shows all projects and their progress in one place.

## What Changed

- added a new  app view and made it the default landing screen
- added a new project dashboard page that lists all projects with:
  - session counts
  - TaskMaster progress when available
  - recent activity
  - quick actions for Chat, Files, Research Lab, and Shell
- added a dashboard button in the sidebar directly under the project search input
- updated app state/navigation so entering the dashboard clears project/session selection
- updated tab/title handling for the new dashboard view
- added i18n strings for English, Simplified Chinese, and Korean
- added singular relative-time labels used by the dashboard

## Validation

- 
> vibelab@2026.3.4 typecheck
> tsc --noEmit -p tsconfig.json
- 
> vibelab@2026.3.4 build
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 5120 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                           2.08 kB │ gzip:   0.82 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff             4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2            4.93 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2            5.21 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2            5.47 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff             5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff             6.19 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff             6.50 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2      6.91 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2         6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf              7.59 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff       7.66 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff          7.72 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2           9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2       10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf             10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff           10.59 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2         11.32 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2            11.35 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf             11.51 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2        12.03 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2          12.22 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf             12.23 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff        12.32 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf       12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf          12.37 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff          13.21 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff             13.30 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2      13.57 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff         14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff           14.41 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff       16.03 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2         16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2             16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf            16.65 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2         16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2             16.99 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff          18.67 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff              18.75 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff          19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf         19.44 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf           19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf              19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff              19.68 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf          22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf            24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2               25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2            26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf        27.56 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2             28.08 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff                29.91 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff             30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf           31.20 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf               31.31 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf           32.97 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff              33.52 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf               33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf                 51.34 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf              53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf               63.63 kB
dist/assets/index-DpTtxhU3.css                          204.14 kB │ gzip:  34.41 kB
dist/assets/clone-BdgQS34e.js                             0.10 kB │ gzip:   0.11 kB
dist/assets/channel-CaOhP5sK.js                           0.12 kB │ gzip:   0.13 kB
dist/assets/init-Gi6I4Gst.js                              0.15 kB │ gzip:   0.13 kB
dist/assets/chunk-QZHKN3VN-BJIMUnI-.js                    0.19 kB │ gzip:   0.16 kB
dist/assets/chunk-4BX2VUAB-CLEpQerZ.js                    0.23 kB │ gzip:   0.17 kB
dist/assets/chunk-55IACEB6-CFprAlGj.js                    0.24 kB │ gzip:   0.21 kB
dist/assets/chunk-FMBD7UC4-C9TQM4Au.js                    0.37 kB │ gzip:   0.27 kB
dist/assets/stateDiagram-v2-4FDKWEC3-BTaHSrwN.js          0.50 kB │ gzip:   0.33 kB
dist/assets/chunk-QN33PNHL-ClWYxBUn.js                    0.51 kB │ gzip:   0.36 kB
dist/assets/classDiagram-2ON5EDUG-BOL4SV3k.js             0.54 kB │ gzip:   0.35 kB
dist/assets/classDiagram-v2-WZHVMYZB-BOL4SV3k.js          0.54 kB │ gzip:   0.35 kB
dist/assets/infoDiagram-HS3SLOUP-DkY8F-Xv.js              0.80 kB │ gzip:   0.50 kB
dist/assets/ordinal-Cboi1Yqb.js                           1.19 kB │ gzip:   0.57 kB
dist/assets/chunk-TZMSLE5B-t6eSU7rY.js                    1.44 kB │ gzip:   0.64 kB
dist/assets/_basePickBy-B5vYkwoc.js                       2.59 kB │ gzip:   1.29 kB
dist/assets/arc-DuWpX8H5.js                               3.44 kB │ gzip:   1.49 kB
dist/assets/diagram-S2PKOQOG-Cg3oodMO.js                  4.42 kB │ gzip:   1.93 kB
dist/assets/defaultLocale-DX6XiGOO.js                     4.69 kB │ gzip:   2.18 kB
dist/assets/pieDiagram-ADFJNKIX-CF5IP4Gf.js               5.35 kB │ gzip:   2.37 kB
dist/assets/linear-R2uRhYqJ.js                            5.66 kB │ gzip:   2.31 kB
dist/assets/graph-BCUNBOvw.js                             5.92 kB │ gzip:   1.87 kB
dist/assets/diagram-QEK2KX5R-DPzHB94I.js                  6.02 kB │ gzip:   2.54 kB
dist/assets/stateDiagram-FKZM4ZOC-C_OyA9HY.js            10.50 kB │ gzip:   3.69 kB
dist/assets/dagre-6UL2VRFP-Bno19XvB.js                   11.12 kB │ gzip:   4.16 kB
dist/assets/_baseUniq-BRL0s1kh.js                        11.89 kB │ gzip:   4.65 kB
dist/assets/diagram-PSM6KHXK-43M05pUe.js                 15.98 kB │ gzip:   5.72 kB
dist/assets/kanban-definition-3W4ZIXB7-GOWGvN4O.js       20.31 kB │ gzip:   7.22 kB
dist/assets/mindmap-definition-VGOIOE7T-q8frL59o.js      21.02 kB │ gzip:   7.35 kB
dist/assets/sankeyDiagram-TZEHDZUN-BhgbceNg.js           22.22 kB │ gzip:   8.19 kB
dist/assets/journeyDiagram-XKPGCS4Q-Dfc8uEkl.js          23.65 kB │ gzip:   8.37 kB
dist/assets/timeline-definition-IT6M3QCI-Cg45-jBp.js     23.69 kB │ gzip:   8.28 kB
dist/assets/gitGraphDiagram-V2S2FVAM-BvUon0xK.js         24.25 kB │ gzip:   7.49 kB
dist/assets/erDiagram-Q2GNP2WA-BAh8kOMA.js               25.35 kB │ gzip:   8.89 kB
dist/assets/layout-Bv10aKij.js                           27.39 kB │ gzip:   9.73 kB
dist/assets/requirementDiagram-UZGBJVZJ-DmR1VnI9.js      30.20 kB │ gzip:   9.48 kB
dist/assets/quadrantDiagram-AYHSOK5B-CYWKZvxl.js         33.95 kB │ gzip:  10.01 kB
dist/assets/chunk-DI55MBZ5-TpSETCzU.js                   36.34 kB │ gzip:  11.85 kB
dist/assets/xychartDiagram-PRI3JC2R-DlcmMKLW.js          40.32 kB │ gzip:  11.50 kB
dist/assets/chunk-B4BG7PRW-B7pXgz3t.js                   45.32 kB │ gzip:  14.71 kB
dist/assets/flowDiagram-NV44I4VS-CllgHWDh.js             60.56 kB │ gzip:  19.50 kB
dist/assets/ganttDiagram-JELNMOA3-CkXszEG6.js            68.42 kB │ gzip:  23.20 kB
dist/assets/c4Diagram-YG6GDRKO-B-lf3_49.js               70.25 kB │ gzip:  19.74 kB
dist/assets/blockDiagram-VD42YOAC-DHWJVODa.js            71.89 kB │ gzip:  20.55 kB
dist/assets/cose-bilkent-S5V4N54A-BKoUUTxu.js            81.81 kB │ gzip:  22.53 kB
dist/assets/sequenceDiagram-WL72ISMW-CANoQS5o.js         97.92 kB │ gzip:  26.91 kB
dist/assets/architectureDiagram-VXUJARFQ-DoHLY3e-.js    148.75 kB │ gzip:  42.13 kB
dist/assets/vendor-react-0OC6tFzp.js                    160.66 kB │ gzip:  52.73 kB
dist/assets/vendor-xterm-DfcmCpbH.js                    391.44 kB │ gzip:  97.53 kB
dist/assets/cytoscape.esm-5J0xJHOV.js                   441.64 kB │ gzip: 141.47 kB
dist/assets/treemap-GDKQZRPO-C8GrSEuZ.js                452.66 kB │ gzip: 107.19 kB
dist/assets/mermaid.core-CJNDyjCV.js                    491.67 kB │ gzip: 138.22 kB
dist/assets/vendor-codemirror-DcvHJBZF.js               666.01 kB │ gzip: 232.75 kB
dist/assets/index-BZdbSfbm.js                         2,234.86 kB │ gzip: 686.51 kB
✓ built in 6.35s

## Notes

- the production build still shows the existing Vite chunk-size warning, but the build completes successfully