### PR TITLE
feat(skills): add Gemini Deep Research skill

### DIFF
--- a/skills/gemini-deep-research/SKILL.md
+++ b/skills/gemini-deep-research/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: gemini-deep-research
+description: |
+  Perform complex, long-running research tasks using Gemini Deep Research Agent.
+  Use when: asked to research topics requiring multi-source synthesis, competitive analysis,
+  market research, literature review, or comprehensive technical investigations that benefit
+  from systematic web search and analysis. Invokes Google's deep-research agent to autonomously
+  search the web, gather evidence, and produce a structured markdown report.
+license: MIT
+metadata:
+  author: clawdbot
+  version: "1.0.0"
+  requires:
+    env:
+      - GEMINI_API_KEY
+---
+
+# Gemini Deep Research
+
+Use Google Gemini's Deep Research Agent to perform complex, long-running context gathering and synthesis tasks. The agent autonomously breaks down your query, searches the web, and synthesizes findings into a comprehensive report.
+
+## Prerequisites
+
+- `GEMINI_API_KEY` environment variable (obtain from [Google AI Studio](https://aistudio.google.com/apikey))
+- Python 3.8+ with `requests` library
+- **Note**: Requires a direct Gemini API key — OAuth tokens are not supported.
+
+## When to Use
+
+- Comprehensive literature or market research
+- Competitive landscape analysis
+- Technical deep dives requiring multi-source synthesis
+- Any research task that benefits from systematic web search
+- When you need a structured report with evidence from multiple sources
+
+## How It Works
+
+The Deep Research agent:
+1. Breaks down complex queries into sub-questions
+2. Searches the web systematically for each sub-question
+3. Synthesizes findings into a comprehensive markdown report
+4. Provides streaming progress updates during execution
+
+## Usage
+
+### Basic Research
+
+```bash
+scripts/deep_research.py --query "Research the current state of quantum error correction" --stream
+```
+
+### Custom Output Format
+
+```bash
+scripts/deep_research.py --query "Competitive landscape of EV batteries" \
+  --format "1. Executive Summary\n2. Key Players (data table)\n3. Technology Comparison\n4. Supply Chain Risks"
+```
+
+### With File Search (optional)
+
+```bash
+scripts/deep_research.py --query "Compare our fiscal year report against current public web news" \
+  --file-search-store "fileSearchStores/my-store-name"
+```
+
+### Specify Output Directory
+
+```bash
+scripts/deep_research.py --query "Your research topic" --output-dir ./reports --stream
+```
+
+## Output
+
+Results are saved as timestamped files in the output directory:
+- `deep-research-YYYY-MM-DD-HH-MM-SS.md` — Final report in markdown
+- `deep-research-YYYY-MM-DD-HH-MM-SS.json` — Full interaction metadata
+
+The report is also printed to stdout for immediate use.
+
+## API Details
+
+- **Endpoint**: `https://generativelanguage.googleapis.com/v1beta/interactions`
+- **Agent model**: `deep-research-pro-preview-12-2025`
+- **Auth**: `x-goog-api-key` header
+
+## Limitations
+
+- Long-running tasks (minutes to tens of minutes depending on complexity)
+- May incur API costs depending on your Google AI quota
+- Results depend on web content available at query time

--- a/skills/gemini-deep-research/scripts/deep_research.py
+++ b/skills/gemini-deep-research/scripts/deep_research.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Gemini Deep Research API client
+Performs complex, long-running research tasks via Gemini's Deep Research Agent
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+import requests
+
+API_BASE = "https://generativelanguage.googleapis.com/v1beta"
+AGENT_MODEL = "deep-research-pro-preview-12-2025"
+
+
+def create_interaction(api_key, query, output_format=None, file_search_store=None):
+    """Start a new deep research interaction"""
+    headers = {
+        "Content-Type": "application/json",
+        "x-goog-api-key": api_key
+    }
+    
+    payload = {
+        "input": query,
+        "agent": AGENT_MODEL,
+        "background": True
+    }
+    
+    if output_format:
+        payload["input"] = f"{query}\n\nFormat the output as follows:\n{output_format}"
+    
+    if file_search_store:
+        payload["tools"] = [{
+            "type": "file_search",
+            "file_search_store_names": [file_search_store]
+        }]
+    
+    response = requests.post(
+        f"{API_BASE}/interactions",
+        headers=headers,
+        json=payload
+    )
+    
+    if response.status_code != 200:
+        print(f"Error creating interaction: {response.status_code}", file=sys.stderr)
+        print(response.text, file=sys.stderr)
+        sys.exit(1)
+    
+    return response.json()
+
+
+def poll_interaction(api_key, interaction_id, stream=False):
+    """Poll for interaction updates"""
+    headers = {
+        "x-goog-api-key": api_key
+    }
+    
+    while True:
+        response = requests.get(
+            f"{API_BASE}/interactions/{interaction_id}",
+            headers=headers
+        )
+        
+        if response.status_code != 200:
+            print(f"Error polling interaction: {response.status_code}", file=sys.stderr)
+            print(response.text, file=sys.stderr)
+            sys.exit(1)
+        
+        data = response.json()
+        status = data.get("status", "UNKNOWN")
+        
+        if stream:
+            # Show progress updates
+            if "statusMessage" in data:
+                print(f"[{status}] {data['statusMessage']}", file=sys.stderr)
+        
+        if status == "completed":
+            return data
+        elif status == "failed":
+            print(f"Research failed: {data.get('error', 'Unknown error')}", file=sys.stderr)
+            sys.exit(1)
+        
+        time.sleep(10)  # Poll every 10 seconds
+
+
+def extract_report(interaction_data):
+    """Extract the final report from interaction data"""
+    if "output" in interaction_data:
+        output = interaction_data["output"]
+        if isinstance(output, dict) and "text" in output:
+            return output["text"]
+        elif isinstance(output, str):
+            return output
+    
+    # Fallback: look in messages
+    messages = interaction_data.get("messages", [])
+    for msg in reversed(messages):
+        if msg.get("role") == "model" and "parts" in msg:
+            for part in msg["parts"]:
+                if "text" in part:
+                    return part["text"]
+    
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Gemini Deep Research API Client")
+    parser.add_argument("--query", required=True, help="Research query")
+    parser.add_argument("--format", help="Custom output format instructions")
+    parser.add_argument("--file-search-store", help="File search store name (optional)")
+    parser.add_argument("--stream", action="store_true", help="Show streaming progress updates")
+    parser.add_argument("--output-dir", default=".", help="Output directory for results")
+    parser.add_argument("--api-key", help="Gemini API key (overrides GEMINI_API_KEY env var)")
+    
+    args = parser.parse_args()
+    
+    # Get API key
+    api_key = args.api_key or os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        print("Error: No API key provided.", file=sys.stderr)
+        print("Please either:", file=sys.stderr)
+        print("  1. Provide --api-key argument", file=sys.stderr)
+        print("  2. Set GEMINI_API_KEY environment variable", file=sys.stderr)
+        sys.exit(1)
+    
+    # Start research
+    print(f"Starting deep research: {args.query}", file=sys.stderr)
+    interaction = create_interaction(
+        api_key,
+        args.query,
+        output_format=args.format,
+        file_search_store=args.file_search_store
+    )
+    
+    interaction_id = interaction.get("id")
+    if not interaction_id:
+        print(f"Error: No interaction ID in response: {interaction}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Interaction started: {interaction_id}", file=sys.stderr)
+    
+    # Poll for completion
+    print("Polling for results (this may take several minutes)...", file=sys.stderr)
+    result = poll_interaction(api_key, interaction_id, stream=args.stream)
+    
+    # Extract report
+    report = extract_report(result)
+    
+    if not report:
+        print("Warning: Could not extract report text from response", file=sys.stderr)
+        report = json.dumps(result, indent=2)
+    
+    # Save results
+    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    
+    md_path = output_dir / f"deep-research-{timestamp}.md"
+    json_path = output_dir / f"deep-research-{timestamp}.json"
+    
+    md_path.write_text(report)
+    json_path.write_text(json.dumps(result, indent=2))
+    
+    print(f"\nResearch complete!", file=sys.stderr)
+    print(f"Report saved: {md_path}", file=sys.stderr)
+    print(f"Full data saved: {json_path}", file=sys.stderr)
+    
+    # Print report to stdout
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-tag-mapping.json
+++ b/skills/skill-tag-mapping.json
@@ -21,6 +21,7 @@
     "biorxiv-database": { "zh": "阶段: 资源准备", "en": "Stage: Resource Prep", "ko": "단계: 리소스 준비" },
     "scientific-writing": { "zh": "阶段: 论文撰写", "en": "Stage: Paper Writing", "ko": "단계: 논문 작성" },
     "academic-researcher": { "zh": "阶段: 调研", "en": "Stage: Survey", "ko": "단계: 조사" },
+    "gemini-deep-research": { "zh": "阶段: 调研", "en": "Stage: Survey", "ko": "단계: 조사" },
     "research-grants": { "zh": "阶段: 论文撰写", "en": "Stage: Paper Writing", "ko": "단계: 논문 작성" },
 
     "accelerate": { "zh": "类别: 训练与调优", "en": "Category: Training & Tuning", "ko": "카테고리: 훈련 및 튜닝" },

--- a/skills/skills-catalog-v2.json
+++ b/skills/skills-catalog-v2.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-03-09T03:31:53.086Z",
+  "generatedAt": "2026-03-11T04:50:01.412Z",
   "schema": "skills-taxonomy-v2",
-  "totalSkills": 107,
+  "totalSkills": 108,
   "skills": [
     {
       "name": "academic-researcher",
@@ -42,10 +42,10 @@
       },
       "owner": "awesome-llm-apps",
       "relatedSkills": [
+        "gemini-deep-research",
         "inno-code-survey",
         "inno-deep-research",
-        "biorxiv-database",
-        "chroma"
+        "biorxiv-database"
       ]
     },
     {
@@ -314,8 +314,8 @@
       "relatedSkills": [
         "dataset-discovery",
         "academic-researcher",
-        "inno-code-survey",
-        "inno-deep-research"
+        "gemini-deep-research",
+        "inno-code-survey"
       ]
     },
     {
@@ -1337,6 +1337,51 @@
       ]
     },
     {
+      "name": "gemini-deep-research",
+      "primaryIntent": "research",
+      "intents": [
+        "research"
+      ],
+      "capabilities": [
+        "search-retrieval",
+        "agent-workflow"
+      ],
+      "domains": [
+        "general"
+      ],
+      "keywords": [
+        "gemini-deep-research",
+        "survey",
+        "search-retrieval",
+        "agent-workflow",
+        "gemini",
+        "deep",
+        "research",
+        "perform",
+        "complex",
+        "long",
+        "running",
+        "tasks"
+      ],
+      "source": "imported",
+      "status": "verified",
+      "summary": "Perform complex, long-running research tasks using Gemini Deep Research Agent. Use when: asked to research topics requiring multi-source synthesis, competitive analysis, market research, literature review, or comprehensive technical invest...",
+      "legacy": {
+        "dirPath": "gemini-deep-research",
+        "skillFile": "skills/gemini-deep-research/SKILL.md",
+        "topLevelGroup": "Standalone",
+        "collection": "Survey",
+        "domain": "General"
+      },
+      "owner": "clawdbot",
+      "relatedSkills": [
+        "inno-deep-research",
+        "inno-code-survey",
+        "inno-pipeline-planner",
+        "inno-research-orchestrator"
+      ]
+    },
+    {
       "name": "llama-cpp",
       "primaryIntent": "deployment",
       "intents": [
@@ -1693,9 +1738,9 @@
       },
       "relatedSkills": [
         "inno-deep-research",
+        "gemini-deep-research",
         "academic-researcher",
-        "biorxiv-database",
-        "inno-pipeline-planner"
+        "biorxiv-database"
       ]
     },
     {
@@ -1736,10 +1781,10 @@
       },
       "owner": "awesome-llm-apps",
       "relatedSkills": [
+        "gemini-deep-research",
         "inno-code-survey",
         "academic-researcher",
-        "biorxiv-database",
-        "inno-research-orchestrator"
+        "biorxiv-database"
       ]
     },
     {
@@ -2131,9 +2176,9 @@
       },
       "relatedSkills": [
         "inno-research-orchestrator",
+        "gemini-deep-research",
         "inno-code-survey",
-        "inno-deep-research",
-        "inno-experiment-dev"
+        "inno-deep-research"
       ]
     },
     {
@@ -2311,9 +2356,9 @@
       },
       "relatedSkills": [
         "inno-pipeline-planner",
+        "gemini-deep-research",
         "inno-deep-research",
-        "inno-code-survey",
-        "inno-experiment-dev"
+        "inno-code-survey"
       ]
     },
     {

--- a/skills/skills-taxonomy-v2.overrides.json
+++ b/skills/skills-taxonomy-v2.overrides.json
@@ -17,6 +17,12 @@
     "capabilities": ["search-retrieval", "data-processing"],
     "domains": ["bioinformatics"]
   },
+  "gemini-deep-research": {
+    "primaryIntent": "research",
+    "intents": ["research"],
+    "capabilities": ["search-retrieval", "agent-workflow"],
+    "domains": ["general"]
+  },
   "constitutional-ai": {
     "primaryIntent": "evaluation",
     "intents": ["evaluation", "deployment"],

--- a/skills/stage-skill-map.json
+++ b/skills/stage-skill-map.json
@@ -2,6 +2,7 @@
   "survey": {
     "base": [
       "inno-deep-research",
+      "gemini-deep-research",
       "academic-researcher",
       "dataset-discovery",
       "biorxiv-database"
@@ -9,10 +10,12 @@
     "byTaskType": {
       "analysis": [
         "inno-deep-research",
+        "gemini-deep-research",
         "academic-researcher"
       ],
       "exploration": [
         "inno-deep-research",
+        "gemini-deep-research",
         "dataset-discovery",
         "biorxiv-database",
         "academic-researcher"

--- a/src/components/chat/constants/guidedPromptScenarios.ts
+++ b/src/components/chat/constants/guidedPromptScenarios.ts
@@ -12,14 +12,14 @@ export const GUIDED_PROMPT_SCENARIOS: GuidedPromptScenario[] = [
     icon: '📄',
     titleKey: 'guidedStarter.scenarios.paperReproduction.title',
     descriptionKey: 'guidedStarter.scenarios.paperReproduction.description',
-    skills: ['inno-deep-research', 'academic-researcher', 'inno-paper-reviewer'],
+    skills: ['inno-deep-research', 'gemini-deep-research', 'academic-researcher', 'inno-paper-reviewer'],
   },
   {
     id: 'literature-survey',
     icon: '🔎',
     titleKey: 'guidedStarter.scenarios.literatureSurvey.title',
     descriptionKey: 'guidedStarter.scenarios.literatureSurvey.description',
-    skills: ['inno-deep-research', 'dataset-discovery', 'inno-code-survey'],
+    skills: ['inno-deep-research', 'gemini-deep-research', 'dataset-discovery', 'inno-code-survey'],
   },
   {
     id: 'research-idea',

--- a/src/components/chat/view/subcomponents/SkillShortcutsPanel.tsx
+++ b/src/components/chat/view/subcomponents/SkillShortcutsPanel.tsx
@@ -14,7 +14,7 @@ interface SkillCategory {
 }
 
 const CATEGORIES: SkillCategory[] = [
-  { key: 'deepResearch', icon: '🔍', skills: ['inno-deep-research', 'academic-researcher', 'biorxiv-database', 'dataset-discovery', 'inno-code-survey'] },
+  { key: 'deepResearch', icon: '🔍', skills: ['inno-deep-research', 'gemini-deep-research', 'academic-researcher', 'biorxiv-database', 'dataset-discovery', 'inno-code-survey'] },
   { key: 'ideation', icon: '💡', skills: ['inno-idea-generation', 'inno-idea-eval', 'brainstorming-research-ideas', 'creative-thinking-for-research'] },
   { key: 'pipeline', icon: '🗺️', skills: ['inno-pipeline-planner'] },
   { key: 'experiment', icon: '🧪', skills: ['inno-experiment-dev', 'inno-experiment-analysis', 'bioinformatics-init-analysis', 'inno-prepare-resources'] },


### PR DESCRIPTION
## Summary
- Import Gemini Deep Research skill (v1.0.0) from clawdbot, adapted to VibeLab conventions
- Includes `deep_research.py` script that calls Google's deep-research agent API for autonomous multi-source web research and report synthesis
- Registered across all skill config files (catalog, taxonomy, tag mapping, stage-skill map) and chat UI recommendation surfaces (Skill Shortcuts Panel, Guided Prompt Starter)

## Test plan
- [ ] Verify skill appears in Skills Dashboard under "Survey" stage
- [ ] Verify "Deep Research" category in Chat Skill Shortcuts shows `gemini-deep-research`
- [ ] Verify Guided Prompt Starter scenarios (Paper Reproduction, Literature Survey) include `gemini-deep-research`
- [ ] Verify TaskMaster suggests `gemini-deep-research` for survey-stage tasks
- [ ] Test `scripts/deep_research.py --query "test" --stream` with valid `GEMINI_API_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)