### PR TITLE
Fix chat placeholder showing Claude when using Gemini CLI

### DIFF
--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -462,6 +462,8 @@ function ChatInterface({
                 ? t('messageTypes.cursor')
                 : provider === 'codex'
                 ? t('messageTypes.codex')
+                : provider === 'gemini'
+                ? t('messageTypes.gemini')
                 : t('messageTypes.claude'),
           })}
           isTextareaExpanded={isTextareaExpanded}

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -10,7 +10,8 @@
     "tool": "Tool",
     "claude": "Claude",
     "cursor": "Cursor",
-    "codex": "Codex"
+    "codex": "Codex",
+    "gemini": "Gemini"
   },
   "tools": {
     "settings": "Tool Settings",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -10,7 +10,8 @@
     "tool": "도구",
     "claude": "Claude",
     "cursor": "Cursor",
-    "codex": "Codex"
+    "codex": "Codex",
+    "gemini": "Gemini"
   },
   "tools": {
     "settings": "도구 설정",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -10,7 +10,8 @@
     "tool": "工具",
     "claude": "Claude",
     "cursor": "Cursor",
-    "codex": "Codex"
+    "codex": "Codex",
+    "gemini": "Gemini"
   },
   "tools": {
     "settings": "工具设置",


### PR DESCRIPTION
## Summary
- Fix the chat input placeholder to show "ask Gemini anything..." instead of "ask Claude anything..." when Gemini CLI is selected as the provider
- Add `gemini` key to `messageTypes` in all three i18n locale files (en, ko, zh-CN)

## Test plan
- [x] Select Gemini CLI as provider → verify placeholder shows "ask Gemini anything..."
- [x] Select Claude as provider → verify placeholder still shows "ask Claude anything..."
- [x] Select Codex as provider → verify placeholder still shows "ask Codex anything..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)