### PR TITLE
Add browser notification and file report for Auto Research

### DIFF
--- a/server/routes/auto-research.js
+++ b/server/routes/auto-research.js
@@ -188,6 +188,40 @@ function withTimeout(promise, timeoutMs, onTimeout) {
   ]);
 }
 
+async function writeCompletionReport(runId, projectPath, projectName) {
+  const run = autoResearchDb.getRunById(runId);
+  if (!run) return;
+
+  const status = run.status || 'unknown';
+  const lines = [
+    `# Auto Research Report`,
+    '',
+    `**Project:** ${projectName}`,
+    `**Status:** ${status}`,
+    `**Provider:** ${run.provider || 'claude'}`,
+    `**Tasks:** ${run.completed_tasks ?? 0} / ${run.total_tasks ?? 0} completed`,
+    `**Started:** ${run.started_at || 'N/A'}`,
+    `**Finished:** ${run.finished_at || 'N/A'}`,
+  ];
+
+  if (run.session_id) {
+    lines.push(`**Session ID:** ${run.session_id}`);
+  }
+  if (run.error) {
+    lines.push('', '## Error', '', `\`\`\`\n${run.error}\n\`\`\``);
+  }
+
+  lines.push('', '---', `*Generated at ${new Date().toISOString()}*`, '');
+
+  try {
+    const reportPath = path.join(projectPath, 'auto-research-report.md');
+    await fs.writeFile(reportPath, lines.join('\n'), 'utf8');
+    console.log(`[AutoResearch] Report written to ${reportPath}`);
+  } catch (error) {
+    console.error('[AutoResearch] Failed to write report:', error);
+  }
+}
+
 async function deliverCompletionEmail(runId, userId, projectName) {
   const run = autoResearchDb.getRunById(runId);
   const profile = userDb.getProfile(userId);
@@ -322,6 +356,7 @@ async function runAutoResearch(runId, userId, projectName, projectPath) {
     });
   } finally {
     activeRuns.delete(runId);
+    await writeCompletionReport(runId, projectPath, projectName);
     await deliverCompletionEmail(runId, userId, projectName);
   }
 }

--- a/src/components/project-dashboard/view/ProjectDashboard.tsx
+++ b/src/components/project-dashboard/view/ProjectDashboard.tsx
@@ -7,7 +7,7 @@ import {
   Sparkles,
   Terminal,
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { api } from '../../../utils/api';
@@ -208,6 +208,7 @@ export default function ProjectDashboard({
   const [tokenUsageSummary, setTokenUsageSummary] = useState<ProjectTokenUsageSummary | null>(null);
   const [autoResearchStatuses, setAutoResearchStatuses] = useState<Record<string, AutoResearchStatus>>({});
   const [autoResearchLoading, setAutoResearchLoading] = useState<Record<string, boolean>>({});
+  const prevActiveRunsRef = useRef<Record<string, string>>({});
 
   const totals = useMemo(() => {
     const projectCount = projects.length;
@@ -326,6 +327,39 @@ export default function ProjectDashboard({
     };
   }, [projectUsageRefreshKey, projects]);
 
+  // Browser notification when Auto Research finishes
+  const notifyAutoResearchCompletion = useCallback((projectName: string, status: string) => {
+    if (typeof Notification === 'undefined' || Notification.permission !== 'granted') return;
+    const title = status === 'completed'
+      ? `Auto Research completed`
+      : `Auto Research ${status}`;
+    const body = `Project: ${projectName}`;
+    try {
+      new Notification(title, { body, icon: '/favicon.png' });
+    } catch { /* silent */ }
+  }, []);
+
+  useEffect(() => {
+    const terminalStatuses = new Set(['completed', 'failed', 'cancelled']);
+    const currentActiveRuns: Record<string, string> = {};
+
+    for (const [name, status] of Object.entries(autoResearchStatuses)) {
+      const run = status?.activeRun ?? status?.latestRun;
+      if (!run) continue;
+
+      if (!terminalStatuses.has(run.status)) {
+        currentActiveRuns[name] = run.id;
+      } else {
+        const prevRunId = prevActiveRunsRef.current[name];
+        if (prevRunId && prevRunId === run.id) {
+          notifyAutoResearchCompletion(name, run.status);
+        }
+      }
+    }
+
+    prevActiveRunsRef.current = currentActiveRuns;
+  }, [autoResearchStatuses, notifyAutoResearchCompletion]);
+
   const refreshAutoResearchStatus = async (projectName: string) => {
     try {
       const response = await api.autoResearch.status(projectName);
@@ -343,6 +377,9 @@ export default function ProjectDashboard({
   };
 
   const handleAutoResearchStart = async (projectName: string) => {
+    if (typeof Notification !== 'undefined' && Notification.permission === 'default') {
+      void Notification.requestPermission();
+    }
     setAutoResearchLoading((current) => ({ ...current, [projectName]: true }));
     try {
       const response = await api.autoResearch.start(projectName);


### PR DESCRIPTION
## Summary
- Adds `writeCompletionReport()` that writes `auto-research-report.md` to the project directory when a run finishes
- Adds browser Notification API support — pops a notification when Auto Research completes/fails/cancels
- Requests notification permission on first Auto Research start

Intended to be merged into `fix/auto-research-stale-session` (PR #38) before it goes to main.

## Test plan
- [ ] Start an Auto Research run, verify `auto-research-report.md` is written on completion
- [ ] Allow browser notifications, verify popup appears when run finishes
- [ ] Verify notification permission prompt shows on first "Start" click

🤖 Generated with [Claude Code](https://claude.com/claude-code)