### PR TITLE
Add file chat action to preview header

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -11,7 +11,7 @@ import { StreamLanguage } from '@codemirror/language';
 import { EditorView, showPanel, ViewPlugin } from '@codemirror/view';
 import { unifiedMergeView, getChunks } from '@codemirror/merge';
 import { showMinimap } from '@replit/codemirror-minimap';
-import { X, Save, Download, Maximize2, Minimize2, Settings as SettingsIcon, FileText } from 'lucide-react';
+import { X, Save, Download, Maximize2, Minimize2, Settings as SettingsIcon, FileText, MessageSquarePlus } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -149,8 +149,8 @@ const UNSUPPORTED_EXTENSIONS = new Set([
   'bin', 'exe', 'dll', 'npy', 'npz', 'pkl', 'pt', 'pth', 'ckpt', 'onnx',
 ]);
 
-function CodeEditor({ file, onClose, projectPath, isSidebar = false, isExpanded = false, onToggleExpand = null, onPopOut = null }) {
-  const { t } = useTranslation('codeEditor');
+function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStartWorkspaceQa = null, isSidebar = false, isExpanded = false, onToggleExpand = null, onPopOut = null }) {
+  const { t } = useTranslation(['codeEditor', 'common']);
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -191,6 +191,22 @@ function CodeEditor({ file, onClose, projectPath, isSidebar = false, isExpanded 
   const isUnsupported = useMemo(() => UNSUPPORTED_EXTENSIONS.has(fileExt), [fileExt]);
   const isBinary = isPdf || isImage;
   const [blobUrl, setBlobUrl] = useState(null);
+
+  const canStartWorkspaceQa = Boolean(selectedProject && onStartWorkspaceQa);
+
+  const handleAskAboutFile = () => {
+    if (!selectedProject || !onStartWorkspaceQa) {
+      return;
+    }
+
+    onStartWorkspaceQa(
+      selectedProject,
+      t('common:fileTree.askAboutFilePrompt', {
+        name: file.name,
+        path: file.path,
+      }),
+    );
+  };
 
   // Reset disambiguation state when file changes
   useEffect(() => {
@@ -853,6 +869,16 @@ function CodeEditor({ file, onClose, projectPath, isSidebar = false, isExpanded 
           </div>
 
           <div className="flex items-center gap-0.5 md:gap-1 flex-shrink-0">
+            {canStartWorkspaceQa && (
+              <button
+                onClick={handleAskAboutFile}
+                className="p-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 min-w-[36px] min-h-[36px] md:min-w-0 md:min-h-0 flex items-center justify-center"
+                title={t('actions.askAboutFile')}
+              >
+                <MessageSquarePlus className="w-4 h-4" />
+              </button>
+            )}
+
             {!isBinary && !isUnsupported && isMarkdownFile && (
               <button
                 onClick={() => setMarkdownPreview(!markdownPreview)}

--- a/src/components/main-content/types/types.ts
+++ b/src/components/main-content/types/types.ts
@@ -109,6 +109,8 @@ export interface EditorSidebarProps {
   onCloseEditor: () => void;
   onToggleEditorExpand: () => void;
   projectPath?: string;
+  selectedProject?: Project | null;
+  onStartWorkspaceQa?: (project: Project, prompt: string) => void;
   fillSpace?: boolean;
 }
 

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -274,6 +274,8 @@ function MainContent({
           onCloseEditor={handleCloseEditor}
           onToggleEditorExpand={handleToggleEditorExpand}
           projectPath={selectedProject.path}
+          selectedProject={selectedProject}
+          onStartWorkspaceQa={onStartWorkspaceQa}
           fillSpace={false}
         />
       </div>

--- a/src/components/main-content/view/subcomponents/EditorSidebar.tsx
+++ b/src/components/main-content/view/subcomponents/EditorSidebar.tsx
@@ -14,6 +14,8 @@ export default function EditorSidebar({
   onCloseEditor,
   onToggleEditorExpand,
   projectPath,
+  selectedProject,
+  onStartWorkspaceQa,
   fillSpace,
 }: EditorSidebarProps) {
   const [poppedOut, setPoppedOut] = useState(false);
@@ -31,6 +33,8 @@ export default function EditorSidebar({
           onCloseEditor();
         }}
         projectPath={projectPath}
+        selectedProject={selectedProject}
+        onStartWorkspaceQa={onStartWorkspaceQa}
         isSidebar={false}
       />
     );
@@ -59,6 +63,8 @@ export default function EditorSidebar({
           file={editingFile}
           onClose={onCloseEditor}
           projectPath={projectPath}
+          selectedProject={selectedProject}
+          onStartWorkspaceQa={onStartWorkspaceQa}
           isSidebar
           isExpanded={editorExpanded}
           onToggleExpand={onToggleEditorExpand}

--- a/src/i18n/locales/en/codeEditor.json
+++ b/src/i18n/locales/en/codeEditor.json
@@ -14,6 +14,7 @@
     "showingChanges": "Showing changes"
   },
   "actions": {
+    "askAboutFile": "Ask about this file",
     "download": "Download file",
     "save": "Save",
     "saving": "Saving...",

--- a/src/i18n/locales/ko/codeEditor.json
+++ b/src/i18n/locales/ko/codeEditor.json
@@ -14,6 +14,7 @@
     "showingChanges": "변경사항 표시"
   },
   "actions": {
+    "askAboutFile": "이 파일에 대해 묻기",
     "download": "파일 다운로드",
     "save": "저장",
     "saving": "저장 중...",

--- a/src/i18n/locales/zh-CN/codeEditor.json
+++ b/src/i18n/locales/zh-CN/codeEditor.json
@@ -14,6 +14,7 @@
     "showingChanges": "显示更改"
   },
   "actions": {
+    "askAboutFile": "针对这个文件发起问答",
     "download": "下载文件",
     "save": "保存",
     "saving": "保存中...",


### PR DESCRIPTION
## Summary
- add a chat action to the file preview header so users can start a workspace Q&A session from preview
- wire the selected project and workspace Q&A starter through the editor sidebar into the code editor
- add localized tooltip text for the new preview header action

## Testing
- npm run typecheck