### PR TITLE
fix(cli-auth): detect Gemini/Codex CLIs reliably across platforms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ VITE_PORT=5173
 HOST=0.0.0.0
 # CLAUDE_CLI_PATH=claude
 # CURSOR_CLI_PATH=agent
+# GEMINI_CLI_PATH=gemini
+# CODEX_CLI_PATH=codex
 
 # =============================================================================
 # CONTEXT WINDOW

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,8 @@ Dr. Claw is configured through environment variables in a `.env` file at the pro
 | `VITE_PORT` | No | `5173` | Vite dev server port (development only). |
 | `CLAUDE_CLI_PATH` | No | `claude` | Absolute or relative path to the Claude Code binary. Override if `claude` is not on your `PATH`. |
 | `CURSOR_CLI_PATH` | No | Auto-detect (`cursor-agent` then `agent`) | Override Cursor CLI command/binary. Useful when your environment only provides one alias. |
+| `GEMINI_CLI_PATH` | No | `gemini` | Override Gemini CLI command/binary. Useful when your shell resolves Gemini through a custom alias or path. |
+| `CODEX_CLI_PATH` | No | `codex` | Override Codex CLI command/binary. Useful when Codex is installed outside your default `PATH`. |
 
 ### Database
 

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -24,6 +24,8 @@ Dr. Claw 通过项目根目录下的 `.env` 文件中的环境变量进行配置
 | `VITE_PORT` | 否 | `5173` | Vite 开发服务器端口（仅开发模式）。 |
 | `CLAUDE_CLI_PATH` | 否 | `claude` | Claude Code 二进制文件的绝对或相对路径。如果 `claude` 不在你的 `PATH` 中，可在此处覆盖。 |
 | `CURSOR_CLI_PATH` | 否 | 自动探测（先 `cursor-agent` 后 `agent`） | 覆盖 Cursor CLI 命令/二进制名。适用于你的环境只提供某一个别名的情况。 |
+| `GEMINI_CLI_PATH` | 否 | `gemini` | 覆盖 Gemini CLI 命令/二进制名。适用于通过自定义别名或路径安装 Gemini 的环境。 |
+| `CODEX_CLI_PATH` | 否 | `codex` | 覆盖 Codex CLI 命令/二进制名。适用于 Codex 不在默认 `PATH` 中的环境。 |
 
 ### 数据库
 

--- a/server/routes/cli-auth.js
+++ b/server/routes/cli-auth.js
@@ -5,95 +5,9 @@ import path from 'path';
 import os from 'os';
 import fetch from 'node-fetch';
 import { resolveCursorCliCommand } from '../utils/cursorCommand.js';
+import { resolveAvailableCliCommand } from '../utils/cliResolution.js';
 
 const router = express.Router();
-
-function checkCommandAvailable(command, args = ['--help'], platform = process.platform) {
-  return new Promise((resolve) => {
-    let completed = false;
-
-    let childProcess;
-    try {
-      childProcess = spawn(command, args, {
-        stdio: 'ignore',
-        env: process.env,
-        shell: platform === 'win32'
-      });
-    } catch {
-      resolve(false);
-      return;
-    }
-
-    const finish = (value) => {
-      if (completed) return;
-      completed = true;
-      resolve(value);
-    };
-
-    const timeout = setTimeout(() => {
-      if (!completed) {
-        childProcess.kill();
-      }
-      finish(true);
-    }, 3000);
-
-    childProcess.on('error', (error) => {
-      clearTimeout(timeout);
-      if (error?.code === 'ENOENT') {
-        finish(false);
-        return;
-      }
-      finish(true);
-    });
-
-    childProcess.on('spawn', () => {
-      clearTimeout(timeout);
-      finish(true);
-    });
-
-    childProcess.on('close', (code) => {
-      clearTimeout(timeout);
-      finish(code !== 127);
-    });
-  });
-}
-
-function getCliCommandCandidates(defaultCommand, envVarName, platform = process.platform) {
-  const envCommand = String(process.env[envVarName] || '').trim();
-  const rawCandidates = [envCommand, defaultCommand].filter(Boolean);
-  const candidates = [];
-
-  for (const candidate of rawCandidates) {
-    candidates.push(candidate);
-
-    if (platform === 'win32' && !/\.(cmd|exe|bat)$/i.test(candidate)) {
-      candidates.push(`${candidate}.cmd`, `${candidate}.exe`);
-    }
-  }
-
-  return [...new Set(candidates)];
-}
-
-async function resolveAvailableCliCommand(
-  defaultCommand,
-  envVarName,
-  args = ['--help'],
-  {
-    platform = process.platform,
-    probe = checkCommandAvailable
-  } = {}
-) {
-  const candidates = getCliCommandCandidates(defaultCommand, envVarName, platform);
-
-  for (const candidate of candidates) {
-    // Probe command candidates in order so npm shims like *.cmd work on Windows.
-    if (await probe(candidate, args, platform)) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
 
 function buildCliInstallHint(agent) {
   switch (agent) {
@@ -219,6 +133,7 @@ router.get('/gemini/status', async (req, res) => {
 
 async function checkGeminiCredentials() {
   console.log('[DEBUG] Checking Gemini credentials...');
+  let cliCommand = process.env.GEMINI_CLI_PATH || 'gemini';
   try {
     if (isCliMockedMissing('gemini')) {
       return {
@@ -226,19 +141,25 @@ async function checkGeminiCredentials() {
         email: null,
         error: 'Gemini CLI not installed (mocked)',
         cliAvailable: false,
-        cliCommand: 'gemini',
+        cliCommand,
         installHint: buildCliInstallHint('gemini')
       };
     }
 
-    const cliCommand = await resolveAvailableCliCommand('gemini', 'GEMINI_CLI_PATH');
-    if (!cliCommand) {
+    const resolvedCliCommand = await resolveAvailableCliCommand({
+      envVarName: 'GEMINI_CLI_PATH',
+      defaultCommands: ['gemini'],
+      appendWindowsSuffixes: true
+    });
+    cliCommand = resolvedCliCommand || cliCommand;
+
+    if (!resolvedCliCommand) {
       return {
         authenticated: false,
         email: null,
         error: 'Gemini CLI not installed',
         cliAvailable: false,
-        cliCommand: process.env.GEMINI_CLI_PATH || 'gemini',
+        cliCommand,
         installHint: buildCliInstallHint('gemini')
       };
     }
@@ -260,11 +181,11 @@ async function checkGeminiCredentials() {
     try {
       const content = await fs.readFile(oauthPath, 'utf8');
       const creds = JSON.parse(content);
-      
+
       // Check for presence of refresh_token or access_token
       if (creds.refresh_token || creds.access_token) {
         let email = creds.email || 'OAuth (Config)';
-        
+
         // Try to extract email from id_token if available
         if (!creds.email && creds.id_token) {
           try {
@@ -277,7 +198,7 @@ async function checkGeminiCredentials() {
             console.warn('[DEBUG] Gemini: Failed to decode id_token', jwtError.message);
           }
         }
-        
+
         console.log(`[DEBUG] Gemini: Authenticated via OAuth as ${email}`);
         return {
           authenticated: true,
@@ -334,7 +255,7 @@ async function checkGeminiCredentials() {
         email: null,
         error: 'Gemini not configured',
         cliAvailable: true,
-        cliCommand: process.env.GEMINI_CLI_PATH || 'gemini'
+        cliCommand
       };
     }
     return {
@@ -342,7 +263,7 @@ async function checkGeminiCredentials() {
       email: null,
       error: error.message,
       cliAvailable: true,
-      cliCommand: process.env.GEMINI_CLI_PATH || 'gemini'
+      cliCommand
     };
   }
 }
@@ -567,15 +488,22 @@ function checkCursorStatus() {
 }
 
 async function checkCodexCredentials() {
+  let cliCommand = process.env.CODEX_CLI_PATH || 'codex';
   try {
-    const cliCommand = await resolveAvailableCliCommand('codex', 'CODEX_CLI_PATH');
-    if (!cliCommand) {
+    const resolvedCliCommand = await resolveAvailableCliCommand({
+      envVarName: 'CODEX_CLI_PATH',
+      defaultCommands: ['codex'],
+      appendWindowsSuffixes: true
+    });
+    cliCommand = resolvedCliCommand || cliCommand;
+
+    if (!resolvedCliCommand) {
       return {
         authenticated: false,
         email: null,
         error: 'Codex CLI not installed',
         cliAvailable: false,
-        cliCommand: process.env.CODEX_CLI_PATH || 'codex',
+        cliCommand,
         installHint: buildCliInstallHint('codex')
       };
     }
@@ -638,7 +566,7 @@ async function checkCodexCredentials() {
         email: null,
         error: 'Codex not configured',
         cliAvailable: true,
-        cliCommand: process.env.CODEX_CLI_PATH || 'codex'
+        cliCommand
       };
     }
     return {
@@ -646,7 +574,7 @@ async function checkCodexCredentials() {
       email: null,
       error: error.message,
       cliAvailable: true,
-      cliCommand: process.env.CODEX_CLI_PATH || 'codex'
+      cliCommand
     };
   }
 }
@@ -720,9 +648,3 @@ router.post('/claude/verify-custom-api', async (req, res) => {
 });
 
 export default router;
-
-export {
-  checkCommandAvailable,
-  getCliCommandCandidates,
-  resolveAvailableCliCommand
-};

--- a/server/utils/cliResolution.js
+++ b/server/utils/cliResolution.js
@@ -1,0 +1,164 @@
+import { spawn, spawnSync } from 'child_process';
+
+/**
+ * Build ordered CLI command candidates from env override + defaults.
+ *
+ * @param {Object} options
+ * @param {string} options.envVarName Environment variable name containing an override command.
+ * @param {string[]} options.defaultCommands Fallback command names in preference order.
+ * @param {string} [options.platform=process.platform] Runtime platform, used for Windows suffix handling.
+ * @param {boolean} [options.appendWindowsSuffixes=false] Whether to append .cmd/.exe candidates on Windows.
+ * @returns {string[]} Unique command candidates in probe order.
+ */
+function getCliCommandCandidates({
+    envVarName,
+    defaultCommands,
+    platform = process.platform,
+    appendWindowsSuffixes = false
+}) {
+    const envCommand = String(process.env[envVarName] || '').trim();
+    const rawCandidates = [];
+
+    if (envCommand) {
+        rawCandidates.push(envCommand);
+    }
+
+    for (const command of defaultCommands) {
+        if (command) {
+            rawCandidates.push(command);
+        }
+    }
+
+    const candidates = [];
+    for (const candidate of rawCandidates) {
+        candidates.push(candidate);
+
+        if (appendWindowsSuffixes && platform === 'win32' && !/\.(cmd|exe|bat)$/i.test(candidate)) {
+            candidates.push(`${candidate}.cmd`, `${candidate}.exe`);
+        }
+    }
+
+    return [...new Set(candidates)];
+}
+
+/**
+ * Probe command availability via synchronous spawn.
+ *
+ * @param {string} command Command to check.
+ * @param {string[]} [args=['--help']] Probe arguments.
+ * @param {string} [platform=process.platform] Runtime platform.
+ * @returns {boolean} True when command can be invoked.
+ */
+function isCommandAvailable(command, args = ['--help'], platform = process.platform) {
+    if (!command) return false;
+
+    const result = spawnSync(command, args, {
+        stdio: 'ignore',
+        shell: platform === 'win32'
+    });
+
+    return !result.error;
+}
+
+/**
+ * Probe command availability via async spawn with timeout.
+ *
+ * @param {string} command Command to check.
+ * @param {string[]} [args=['--help']] Probe arguments.
+ * @param {Object} [options]
+ * @param {string} [options.platform=process.platform] Runtime platform.
+ * @param {number} [options.timeoutMs=3000] Max probe duration.
+ * @returns {Promise<boolean>} True when command can be spawned.
+ */
+function checkCommandAvailable(command, args = ['--help'], { platform = process.platform, timeoutMs = 3000 } = {}) {
+    return new Promise((resolve) => {
+        let completed = false;
+
+        let childProcess;
+        try {
+            childProcess = spawn(command, args, {
+                stdio: 'ignore',
+                env: process.env,
+                shell: platform === 'win32'
+            });
+        } catch {
+            resolve(false);
+            return;
+        }
+
+        const finish = (value) => {
+            if (completed) return;
+            completed = true;
+            resolve(value);
+        };
+
+        const timeout = setTimeout(() => {
+            if (!completed) {
+                childProcess.kill();
+            }
+            finish(true);
+        }, timeoutMs);
+
+        childProcess.on('error', (error) => {
+            clearTimeout(timeout);
+            if (error?.code === 'ENOENT') {
+                finish(false);
+                return;
+            }
+            finish(true);
+        });
+
+        childProcess.on('spawn', () => {
+            clearTimeout(timeout);
+            finish(true);
+        });
+
+        childProcess.on('close', (code) => {
+            clearTimeout(timeout);
+            finish(code !== 127);
+        });
+    });
+}
+
+/**
+ * Resolve the first available command from a candidate list.
+ *
+ * @param {Object} options
+ * @param {string} options.envVarName Environment variable with command override.
+ * @param {string[]} options.defaultCommands Fallback command names in preference order.
+ * @param {string[]} [options.args=['--help']] Probe arguments.
+ * @param {string} [options.platform=process.platform] Runtime platform.
+ * @param {boolean} [options.appendWindowsSuffixes=false] Whether to append .cmd/.exe candidates on Windows.
+ * @param {(command: string, args: string[], options: {platform: string}) => Promise<boolean>} [options.probe=checkCommandAvailable] Async probe function.
+ * @returns {Promise<string|null>} First available command, or null.
+ */
+async function resolveAvailableCliCommand({
+    envVarName,
+    defaultCommands,
+    args = ['--help'],
+    platform = process.platform,
+    appendWindowsSuffixes = false,
+    probe = (command, probeArgs, probeOptions) => checkCommandAvailable(command, probeArgs, probeOptions)
+}) {
+    const candidates = getCliCommandCandidates({
+        envVarName,
+        defaultCommands,
+        platform,
+        appendWindowsSuffixes
+    });
+
+    for (const candidate of candidates) {
+        if (await probe(candidate, args, { platform })) {
+            return candidate;
+        }
+    }
+
+    return null;
+}
+
+export {
+    getCliCommandCandidates,
+    isCommandAvailable,
+    checkCommandAvailable,
+    resolveAvailableCliCommand
+};

--- a/server/utils/cursorCommand.js
+++ b/server/utils/cursorCommand.js
@@ -1,28 +1,12 @@
-import { spawnSync } from 'child_process';
+import { isCommandAvailable, getCliCommandCandidates } from './cliResolution.js';
 
 let cachedCursorCommand = null;
 
 function getCursorCommandCandidates() {
-  const envCommand = (process.env.CURSOR_CLI_PATH || '').trim();
-  const candidates = [];
-
-  if (envCommand) {
-    candidates.push(envCommand);
-  }
-
-  candidates.push('cursor-agent', 'agent');
-  return [...new Set(candidates)];
-}
-
-function isCommandAvailable(command) {
-  if (!command) return false;
-
-  const result = spawnSync(command, ['--help'], {
-    stdio: 'ignore',
-    shell: process.platform === 'win32'
+  return getCliCommandCandidates({
+    envVarName: 'CURSOR_CLI_PATH',
+    defaultCommands: ['cursor-agent', 'agent']
   });
-
-  return !result.error;
 }
 
 function resolveCursorCliCommand(options = {}) {
@@ -56,7 +40,7 @@ function normalizeCursorLoginCommand(command = '') {
   if (isGeminiLoginCommand(command)) {
     return command;
   }
-  
+
   if (!isCursorLoginCommand(command)) {
     return command;
   }

--- a/test/cli-resolution.test.mjs
+++ b/test/cli-resolution.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    getCliCommandCandidates,
+    resolveAvailableCliCommand
+} from '../server/utils/cliResolution.js';
+
+test('Windows candidates include npm shim extensions', () => {
+    process.env.GEMINI_CLI_PATH = 'gemini';
+
+    const candidates = getCliCommandCandidates({
+        envVarName: 'GEMINI_CLI_PATH',
+        defaultCommands: ['gemini'],
+        platform: 'win32',
+        appendWindowsSuffixes: true
+    });
+
+    assert.deepEqual(candidates, ['gemini', 'gemini.cmd', 'gemini.exe']);
+
+    delete process.env.GEMINI_CLI_PATH;
+});
+
+test('Non-Windows candidates keep plain command names', () => {
+    process.env.CODEX_CLI_PATH = '';
+
+    const candidates = getCliCommandCandidates({
+        envVarName: 'CODEX_CLI_PATH',
+        defaultCommands: ['codex'],
+        platform: 'linux',
+        appendWindowsSuffixes: true
+    });
+
+    assert.deepEqual(candidates, ['codex']);
+});
+
+test('Command resolver prefers first working candidate on Windows', async () => {
+    process.env.CODEX_CLI_PATH = 'codex';
+    const calls = [];
+
+    const selected = await resolveAvailableCliCommand({
+        envVarName: 'CODEX_CLI_PATH',
+        defaultCommands: ['codex'],
+        platform: 'win32',
+        appendWindowsSuffixes: true,
+        probe: async (candidate) => {
+            calls.push(candidate);
+            return candidate === 'codex.cmd';
+        }
+    });
+
+    assert.equal(selected, 'codex.cmd');
+    assert.deepEqual(calls, ['codex', 'codex.cmd']);
+
+    delete process.env.CODEX_CLI_PATH;
+});
+
+test('Command resolver returns null when no candidates are executable', async () => {
+    delete process.env.GEMINI_CLI_PATH;
+
+    const selected = await resolveAvailableCliCommand({
+        envVarName: 'GEMINI_CLI_PATH',
+        defaultCommands: ['gemini'],
+        platform: 'linux',
+        appendWindowsSuffixes: true,
+        probe: async () => false
+    });
+
+    assert.equal(selected, null);
+});


### PR DESCRIPTION
- make CLI availability probe Windows-aware (`shell: true` on win32)
- add command candidate resolution with env overrides and win32 shim suffixes (`.cmd`, `.exe`)
- use resolved commands for Gemini/Codex status checks (`GEMINI_CLI_PATH`, `CODEX_CLI_PATH`)