### PR TITLE
fix(chat): handle markdown link file paths in chat messages

### DIFF
--- a/src/components/chat/view/subcomponents/Markdown.tsx
+++ b/src/components/chat/view/subcomponents/Markdown.tsx
@@ -202,17 +202,21 @@ export function Markdown({ children, className, onFileOpen }: MarkdownProps) {
       ...markdownComponents,
       // Make markdown links open as files if href looks like a file path
       a: ({ href, children: linkChildren }: { href?: string; children?: React.ReactNode }) => {
-        if (href && !/^(?:https?:|mailto:|tel:|#)/.test(href) && isFilePath(href)) {
-          const { filePath } = parseFilePath(href);
-          return (
-            <button
-              onClick={() => onFileOpen(filePath)}
-              className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline cursor-pointer transition-colors"
-              title={`Open ${filePath}`}
-            >
-              {linkChildren}
-            </button>
-          );
+        if (href && !/^(?:https?:|mailto:|tel:|#)/.test(href)) {
+          // Strip fragment (e.g. #L1) before checking if it's a file path
+          const hrefWithoutFragment = href.replace(/#.*$/, '');
+          if (isFilePath(hrefWithoutFragment)) {
+            const { filePath } = parseFilePath(hrefWithoutFragment);
+            return (
+              <button
+                onClick={() => onFileOpen(filePath)}
+                className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline cursor-pointer transition-colors"
+                title={`Open ${filePath}`}
+              >
+                {linkChildren}
+              </button>
+            );
+          }
         }
         return (
           <a href={href} className="text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
   - When AI (e.g. Codex) outputs file references as markdown links (e.g. `[App.tsx:1](App.tsx#L1)`), clicking them previously navigated the browser to a non-existent URL instead of opening the file in the editor panel
   - Added `a` component override in `Markdown.tsx` to detect file path hrefs and route them through `onFileOpen`
   - Strips URL fragments (e.g. `#L1`) before file path detection, since AI models often append line anchors to file paths

## Test plan
   - [ ] Ask Codex to convert a `.tex` file to markdown — it will reference output files like `background.zh.md` as markdown links in its response
   - [ ] Verify clicking these links opens the file in the editor side panel, not navigating to a new browser page
   - [ ] Verify regular `https://` links still open in a new tab as before
   - [ ] Verify inline code file paths (e.g. `App.tsx` in backticks) still work as before