### PR TITLE
fix: WebSocket fails to connect after login due to stale unmountedRef / 修复登录后 WebSocket 无法连接的问题

### DIFF
--- a/src/contexts/WebSocketContext.tsx
+++ b/src/contexts/WebSocketContext.tsx
@@ -42,6 +42,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
   const { token } = useAuth();
 
   useEffect(() => {
+    unmountedRef.current = false;
     connect();
     
     return () => {
@@ -53,7 +54,7 @@ const useWebSocketProviderState = (): WebSocketContextType => {
         wsRef.current.close();
       }
     };
-  }, [token]); // everytime token changes, we reconnect
+  }, [token]);
 
   const connect = useCallback(() => {
     if (unmountedRef.current) return; // Prevent connection if unmounted


### PR DESCRIPTION
## Problem / 问题

After logging in through the Dr. Claw web UI, the **Chat page appears functional but all messages silently fail** — the user types a prompt, the UI enters a "Thinking..." state, but the backend never receives the `claude-command` WebSocket message. The session hangs indefinitely.

通过 Dr. Claw 网页端登录后，**Chat 页面看似正常但所有消息都静默失败** — 用户输入提示词后，界面进入 "Thinking..." 状态，但后端始终未收到 `claude-command` WebSocket 消息，会话永久挂起。

### Browser console evidence / 浏览器控制台证据

```
[DEBUG] Sending claude-command          ← frontend attempts to send / 前端尝试发送
WebSocket not connected                 ← WebSocket was never established / WebSocket 从未建立
```

And earlier during page load / 更早的页面加载阶段：

```
No authentication token found for WebSocket connection   ← initial connect with token=null / 初次连接时 token 为空
```

No subsequent successful connection ever occurs, even after the token becomes available.

即使 token 已可用，后续也不会再有成功的连接。

---

## Root Cause / 根因分析

`WebSocketContext.tsx` uses an `unmountedRef` to prevent WebSocket operations after the `WebSocketProvider` component unmounts. However, React's `useEffect` cleanup runs in **two** scenarios:

`WebSocketContext.tsx` 使用 `unmountedRef` 来防止组件卸载后执行 WebSocket 操作。然而 React 的 `useEffect` cleanup 在**两种**场景下都会执行：

1. **Component truly unmounts** — the intended case / **组件真正卸载** — 预期场景
2. **Effect re-runs because a dependency changed** (e.g. `token` goes from `null` to a valid JWT after login) / **依赖项变化导致 effect 重新执行**（例如 `token` 从 `null` 变为有效 JWT）

The cleanup sets `unmountedRef.current = true` unconditionally, and **nothing ever resets it to `false`**, so the following sequence occurs:

cleanup 无条件地将 `unmountedRef.current` 设为 `true`，且**从未被重置为 `false`**，于是产生以下时序：

```
1. Page loads → token = null
   页面加载 → token = null
   → useEffect runs → connect() → no token → returns early (no WS created)
   → useEffect 执行 → connect() → 无 token → 提前返回（未创建 WS）

2. User logs in → token = "eyJ..."
   用户登录 → token = "eyJ..."
   → useEffect cleanup runs first → unmountedRef.current = true  ← BUG: component is still mounted!
   → useEffect cleanup 先执行 → unmountedRef.current = true  ← BUG：组件仍然存活！
   → new useEffect runs → connect() → checks unmountedRef → true → returns immediately
   → 新的 useEffect 执行 → connect() → 检查 unmountedRef → true → 直接返回
   → WebSocket is NEVER created / WebSocket 永远不会创建

3. User sends a chat message
   用户发送聊天消息
   → sendMessage() → socket is null → "WebSocket not connected" → message silently dropped
   → sendMessage() → socket 为空 → "WebSocket not connected" → 消息被静默丢弃
   → UI shows "Thinking..." forever / UI 永久显示 "Thinking..."
```

---

## Fix / 修复方案

Add `unmountedRef.current = false` at the top of each effect invocation to distinguish "dependency changed" from "true unmount":

在每次 effect 执行的开头重置 `unmountedRef.current = false`，区分"依赖变化"和"真正卸载"：

```diff
  useEffect(() => {
+   unmountedRef.current = false;
    connect();

    return () => {
      unmountedRef.current = true;
      // ... cleanup
    };
  }, [token]);
```

### Why this is safe / 为什么这样做是安全的

- **On dependency change / 依赖变化时**: cleanup sets the flag to `true`, then the new effect immediately resets it to `false` before calling `connect()`. The component is still alive — correct. / cleanup 将标记设为 `true`，紧接着新 effect 将其重置为 `false` 后再调用 `connect()`。组件仍然存活 — 行为正确。
- **On true unmount / 真正卸载时**: cleanup sets the flag to `true`, and **no subsequent effect will ever run** to reset it. Pending reconnect timers still see `true` and bail out — correct. / cleanup 将标记设为 `true`，且**不会再有后续 effect 执行**来重置它。待执行的重连定时器检查时仍为 `true` 并跳过 — 行为正确。

---

## Verification / 验证

Tested end-to-end in the browser / 在浏览器中进行了端到端测试：

| Step / 步骤 | Before fix / 修复前 | After fix / 修复后 |
|---|---|---|
| Login → open Chat / 登录 → 打开 Chat | WS never connects; console: "WebSocket not connected" / WS 从未连接 | WS connects; server logs "Chat WebSocket connected" / WS 成功连接 |
| Send message / 发送消息 | UI stuck on "Thinking..." forever; backend receives nothing / UI 永久卡在 "Thinking..."；后端无收到 | Backend receives `claude-command`; Claude responds / 后端收到 `claude-command`；Claude 正常响应 |
| Claude response / Claude 响应 | Never arrives / 永不到达 | Streams back and renders correctly / 流式返回并正确渲染 |

---

## Test Plan / 测试清单

- [ ] Login via the web UI, open a project Chat, send a message → verify Claude responds / 通过网页登录，打开项目 Chat，发送消息 → 验证 Claude 正常响应
- [ ] Refresh the page while logged in → verify WS reconnects automatically / 登录状态下刷新页面 → 验证 WS 自动重连
- [ ] Logout and login again → verify WS re-establishes with new token / 登出再登录 → 验证 WS 使用新 token 重新连接
- [ ] Navigate between tabs (Chat → Shell → Chat) → verify WS remains connected / 在标签间切换（Chat → Shell → Chat）→ 验证 WS 保持连接

Made with [Cursor](https://cursor.com)