### PR TITLE
fix: index CLI-created Claude sessions into Web UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,7 @@ import pty from 'node-pty';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 
-import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache } from './projects.js';
+import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, reconcileClaudeSessionIndex } from './projects.js';
 import { getProjectTokenUsageSummary } from './project-token-usage.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, resolveToolApproval } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getCursorSessionStartTime, getActiveCursorSessions } from './cursor-cli.js';
@@ -98,6 +98,7 @@ const connectedClients = new Set();
 let isGetProjectsRunning = false; // Flag to prevent reentrant calls
 let hasPendingProjectsUpdate = false;
 let lastWatcherEvent = null;
+let pendingClaudeSessionEvents = [];
 let lastProjectsUpdateSignature = '';
 
 function shouldProcessProjectsWatcherEvent(eventType, filePath, provider) {
@@ -163,6 +164,15 @@ async function setupProjectsWatcher() {
 
         lastWatcherEvent = { eventType, filePath, provider, rootPath };
 
+        // Accumulate Claude .jsonl events during debounce window
+        if (provider === 'claude' && (eventType === 'add' || eventType === 'change') && filePath.endsWith('.jsonl')) {
+            const sessionId = path.basename(filePath, '.jsonl');
+            if (!sessionId.startsWith('agent-')) {
+                const projectName = path.basename(path.dirname(filePath));
+                pendingClaudeSessionEvents.push({ projectName, sessionId });
+            }
+        }
+
         if (projectsWatcherDebounceTimer) {
             clearTimeout(projectsWatcherDebounceTimer);
         }
@@ -180,6 +190,12 @@ async function setupProjectsWatcher() {
 
                 // Clear project directory cache when files change
                 clearProjectDirectoryCache();
+
+                // Index CLI-created sessions accumulated during debounce window
+                const eventsToProcess = pendingClaudeSessionEvents.splice(0);
+                for (const { projectName, sessionId } of eventsToProcess) {
+                    await reconcileClaudeSessionIndex(projectName, sessionId);
+                }
 
                 // Get updated projects list
                 const updatedProjects = await getProjects();
@@ -2980,6 +2996,19 @@ async function startServer() {
             // Ensure the workspaces root directory exists
             const startupWorkspaceRoot = await getWorkspacesRoot();
             await fsPromises.mkdir(startupWorkspaceRoot, { recursive: true });
+
+            // Reconcile CLI-created sessions on startup
+            try {
+                const allProjects = await getProjects();
+                for (const project of allProjects) {
+                    if (project.name) {
+                        await reconcileClaudeSessionIndex(project.name);
+                    }
+                }
+                console.log(`${c.ok('[OK]')}   Reconciled session index for ${allProjects.length} projects`);
+            } catch (err) {
+                console.error('[WARN] Failed to reconcile sessions on startup:', err.message);
+            }
 
             // Start watching the projects folder for changes
             await setupProjectsWatcher();


### PR DESCRIPTION
## Summary

- Sessions created via the `claude` CLI were not visible in the Web UI because they were written directly to disk (`.jsonl` files) without being indexed into the `session_metadata` database table
- On startup, reconcile all registered projects to index any existing CLI sessions
- In the file watcher, accumulate `.jsonl` change events during the debounce window and call `reconcileClaudeSessionIndex()` for each before broadcasting the project update

Fixes the CLI session portion of #86.

## Root Cause

Web UI sessions are indexed immediately via `recordIndexedSession()` in `claude-sdk.js` when the first message arrives. CLI sessions bypass the dr-claw server entirely -- the `claude` binary writes `.jsonl` directly to `~/.claude/projects/`. The file watcher detects these changes but only calls `getProjects()`, which reads from the DB index and never parses `.jsonl` files. So CLI sessions remain invisible.

## Test plan

- [ ] Register a project via Web UI (existing workspace)
- [ ] Open a CLI session in that project directory (`cd /path/to/project && claude`)
- [ ] Chat briefly, then exit the CLI session
- [ ] Verify the CLI session appears in the Web UI without manual refresh
- [ ] Restart the dr-claw server and verify CLI sessions still appear
- [ ] Verify existing Web UI sessions are not affected (display name, starred status preserved)
- [ ] Create two CLI sessions rapidly (within 1 second) and verify both appear

Generated with [Claude Code](https://claude.com/claude-code)