### PR TITLE
Fix stale session deletion across providers

### DIFF
--- a/server/__tests__/session-delete.test.mjs
+++ b/server/__tests__/session-delete.test.mjs
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalDatabasePath = process.env.DATABASE_PATH;
+
+let tempRoot = null;
+
+async function loadTestModules() {
+  vi.resetModules();
+  const projects = await import('../projects.js');
+  const database = await import('../database/db.js');
+  await database.initializeDatabase();
+  return { projects, database };
+}
+
+describe('session deletion fallbacks', () => {
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'dr-claw-session-delete-'));
+    process.env.HOME = tempRoot;
+    process.env.USERPROFILE = tempRoot;
+    process.env.DATABASE_PATH = path.join(tempRoot, 'db', 'auth.db');
+  });
+
+  afterEach(async () => {
+    vi.resetModules();
+
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+
+    if (originalDatabasePath === undefined) delete process.env.DATABASE_PATH;
+    else process.env.DATABASE_PATH = originalDatabasePath;
+
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it('deletes a Claude session from the index when the project directory is missing', async () => {
+    const { projects, database } = await loadTestModules();
+    const projectName = 'tmp-project';
+    const sessionId = 'claude-session-missing-file';
+
+    database.sessionDb.upsertSessionPlaceholder(sessionId, projectName, 'claude');
+    expect(database.sessionDb.getSessionById(sessionId)?.provider).toBe('claude');
+
+    await expect(projects.deleteSession(projectName, sessionId, 'claude')).resolves.toBe(true);
+    expect(database.sessionDb.getSessionById(sessionId)).toBeNull();
+  });
+
+  it('deletes a Gemini session from the index when the jsonl file is missing', async () => {
+    const { projects, database } = await loadTestModules();
+    const projectName = 'tmp-project';
+    const sessionId = 'gemini-session-missing-file';
+
+    database.sessionDb.upsertSessionPlaceholder(sessionId, projectName, 'gemini');
+    expect(database.sessionDb.getSessionById(sessionId)?.provider).toBe('gemini');
+
+    await expect(projects.deleteSession(projectName, sessionId, 'gemini')).resolves.toBe(true);
+    expect(database.sessionDb.getSessionById(sessionId)).toBeNull();
+  });
+
+  it('deletes a Codex session from the index when the jsonl file is missing', async () => {
+    const { projects, database } = await loadTestModules();
+    const projectName = 'tmp-project';
+    const sessionId = 'codex-session-missing-file';
+
+    database.sessionDb.upsertSessionPlaceholder(sessionId, projectName, 'codex');
+    expect(database.sessionDb.getSessionById(sessionId)?.provider).toBe('codex');
+
+    await expect(projects.deleteCodexSession(sessionId)).resolves.toBe(true);
+    expect(database.sessionDb.getSessionById(sessionId)).toBeNull();
+  });
+});

--- a/server/projects.js
+++ b/server/projects.js
@@ -1874,19 +1874,32 @@ async function renameProject(projectName, newDisplayName, userId = null) {
 // Delete a session from a project
 async function deleteSession(projectName, sessionId, provider = 'claude') {
   const { sessionDb } = await import('./database/db.js');
+  const indexedSession = sessionDb.getSessionById(sessionId);
 
   if (provider === 'gemini') {
     const geminiSessionFile = path.join(os.homedir(), '.gemini', 'sessions', `${sessionId}.jsonl`);
+    let deletedFile = false;
     try {
-      await fs.access(geminiSessionFile);
       await fs.unlink(geminiSessionFile);
-      sessionDb.deleteSession(sessionId);
-      console.log(`[Gemini] Deleted session file: ${geminiSessionFile}`);
-      return true;
+      deletedFile = true;
     } catch (e) {
-      console.error(`[Gemini] Failed to delete session ${sessionId}:`, e.message);
-      throw new Error(`Failed to delete Gemini session: ${e.message}`);
+      if (e?.code !== 'ENOENT') {
+        console.error(`[Gemini] Failed to delete session ${sessionId}:`, e.message);
+        throw new Error(`Failed to delete Gemini session: ${e.message}`);
+      }
     }
+
+    const deletedIndex = indexedSession?.provider === 'gemini' || deletedFile;
+    if (deletedIndex) {
+      sessionDb.deleteSession(sessionId);
+    }
+
+    if (deletedFile || deletedIndex) {
+      console.log(`[Gemini] Deleted session ${sessionId}${deletedFile ? ` file: ${geminiSessionFile}` : ' from index only'}`);
+      return true;
+    }
+
+    throw new Error(`Gemini session ${sessionId} not found in file system or index`);
   }
 
   const projectDir = path.join(os.homedir(), '.claude', 'projects', projectName);
@@ -1929,12 +1942,12 @@ async function deleteSession(projectName, sessionId, provider = 'claude') {
       }
     }
 
-    const indexedSession = sessionDb.getSessionById(sessionId);
-    if (indexedSession) {
+    const deletedIndex = indexedSession?.provider === 'claude' || matchedFiles > 0;
+    if (deletedIndex) {
       sessionDb.deleteSession(sessionId);
     }
 
-    if (matchedFiles > 0 || indexedSession) {
+    if (matchedFiles > 0 || deletedIndex) {
       console.log(
         `[Claude] Deleted session ${sessionId} from ${matchedFiles} file(s), removed ${removedEntries} entr${removedEntries === 1 ? 'y' : 'ies'}`,
       );
@@ -1943,6 +1956,11 @@ async function deleteSession(projectName, sessionId, provider = 'claude') {
 
     throw new Error(`Session ${sessionId} not found in any files or index`);
   } catch (error) {
+    if (error?.code === 'ENOENT' && indexedSession?.provider === 'claude') {
+      sessionDb.deleteSession(sessionId);
+      console.log(`[Claude] Deleted session ${sessionId} from index only; project directory missing: ${projectDir}`);
+      return true;
+    }
     console.error(`Error deleting session ${sessionId} from project ${projectName}:`, error);
     throw error;
   }
@@ -3375,7 +3393,9 @@ async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
 
 async function deleteCodexSession(sessionId) {
   try {
+    const { sessionDb } = await import('./database/db.js');
     const codexSessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+    const indexedSession = sessionDb.getSessionById(sessionId);
 
     const findJsonlFiles = async (dir) => {
       const files = [];
@@ -3394,13 +3414,26 @@ async function deleteCodexSession(sessionId) {
     };
 
     const jsonlFiles = await findJsonlFiles(codexSessionsDir);
+    let deletedFile = false;
 
     for (const filePath of jsonlFiles) {
       const sessionData = await parseCodexSessionFile(filePath);
       if (sessionData && sessionData.id === sessionId) {
         await fs.unlink(filePath);
-        return true;
+        deletedFile = true;
+        break;
       }
+    }
+
+    const deletedIndex =
+      indexedSession?.provider === 'codex' || deletedFile;
+
+    if (deletedIndex) {
+      sessionDb.deleteSession(sessionId);
+    }
+
+    if (deletedFile || deletedIndex) {
+      return true;
     }
 
     throw new Error(`Codex session file not found for session ${sessionId}`);


### PR DESCRIPTION
## Summary
- clean up indexed session metadata when deleting Codex sessions so project lists no longer show stale entries
- add the same missing-file/index-only deletion fallback for Gemini and Claude sessions
- add a regression test covering Claude, Gemini, and Codex deletion when source files are already missing

## Testing
- npx vitest run server/__tests__/session-delete.test.mjs
- npm run typecheck