### PR TITLE
Fix chat image attachments for Gemini and Codex

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -22,6 +22,7 @@ import { classifyError, classifySDKError } from '../shared/errorClassifier.js';
 import { encodeProjectPath, ensureProjectSkillLinks, reconcileClaudeSessionIndex } from './projects.js';
 import { writeProjectTemplates } from './templates/index.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
+import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 
 import { createRequestId, waitForToolApproval, resolveToolApproval as resolvePermApproval, matchesToolPermission } from './utils/permissions.js';
 
@@ -280,9 +281,7 @@ async function handleImages(command, images, cwd) {
       }
 
       const [, , base64Data] = matches;
-      // Prefer original filename if available, fallback to index-based name
-      const originalName = image.name ? image.name.replace(/[^a-zA-Z0-9._-]/g, '_') : null;
-      const filename = originalName || `file_${index}`;
+      const filename = buildTempAttachmentFilename(index, image?.name, matches[1]);
       const filepath = path.join(tempDir, filename);
 
       // Write base64 data to file

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -8,6 +8,7 @@ import { encodeProjectPath, ensureProjectSkillLinks, reconcileGeminiSessionIndex
 import { writeProjectTemplates } from './templates/index.js';
 import { stripInternalContextPrefix } from './utils/sessionFormatting.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
+import { buildTempAttachmentFilename, toPortableAtPath } from './utils/imageAttachmentFiles.js';
 import { splitLegacyGeminiThoughtContent } from '../shared/geminiThoughtParser.js';
 import { classifyError } from '../shared/errorClassifier.js';
 
@@ -395,9 +396,7 @@ async function handleGeminiAttachments(command, attachments, workingDir) {
       const matches = data.match(/^data:([^;]+);base64,(.+)$/);
       if (!matches) continue;
       const [, mimeType, base64Data] = matches;
-      const ext = mimeType.includes('/') ? mimeType.split('/')[1] : 'bin';
-      const originalName = item?.name ? String(item.name).replace(/[^a-zA-Z0-9._-]/g, '_') : null;
-      const filename = originalName || `attachment_${index}.${ext}`;
+      const filename = buildTempAttachmentFilename(index, item?.name, mimeType);
       const filepath = path.join(tempDir, filename);
       await fs.writeFile(filepath, Buffer.from(base64Data, 'base64'));
       tempFilePaths.push(filepath);
@@ -407,7 +406,10 @@ async function handleGeminiAttachments(command, attachments, workingDir) {
       return { modifiedCommand: command, tempFilePaths, tempDir };
     }
 
-    const note = `\n\n[Attached files]\n${tempFilePaths.map((p, i) => `${i + 1}. ${p}`).join('\n')}`;
+    const referencedPaths = tempFilePaths.map((filePath) => {
+      return toPortableAtPath(filePath, workingDir || process.cwd());
+    });
+    const note = `\n\nAttached files:\n${referencedPaths.join('\n')}`;
     return { modifiedCommand: `${command}${note}`, tempFilePaths, tempDir };
   } catch (error) {
     console.error('[Gemini] Failed to process attachments:', error.message);

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -14,10 +14,13 @@
  */
 
 import { Codex } from '@openai/codex-sdk';
+import { promises as fs } from 'fs';
+import path from 'path';
 import { encodeProjectPath, reconcileCodexSessionIndex } from './projects.js';
 import { sessionDb } from './database/db.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
 import { classifyError, classifySDKError } from '../shared/errorClassifier.js';
+import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 
 // Track active sessions
 const activeCodexSessions = new Map();
@@ -262,6 +265,66 @@ function buildCodexInput(command, attachments) {
   ];
 }
 
+async function prepareCodexInput(command, images, cwd) {
+  const tempImagePaths = [];
+  let tempDir = null;
+
+  if (!Array.isArray(images) || images.length === 0) {
+    return { input: command, tempImagePaths, tempDir };
+  }
+
+  try {
+    const workingDir = cwd || process.cwd();
+    tempDir = path.join(workingDir, '.tmp', 'images', Date.now().toString());
+    await fs.mkdir(tempDir, { recursive: true });
+
+    const input = [{ type: 'text', text: command }];
+
+    for (const [index, image] of images.entries()) {
+      const data = String(image?.data || '');
+      const matches = data.match(/^data:([^;]+);base64,(.+)$/);
+      if (!matches) {
+        continue;
+      }
+
+      const [, mimeType, base64Data] = matches;
+      const filename = buildTempAttachmentFilename(index, image?.name, mimeType);
+      const filepath = path.join(tempDir, filename);
+
+      await fs.writeFile(filepath, Buffer.from(base64Data, 'base64'));
+      tempImagePaths.push(filepath);
+      input.push({ type: 'local_image', path: filepath });
+    }
+
+    return {
+      input: input.length > 1 ? input : command,
+      tempImagePaths,
+      tempDir,
+    };
+  } catch (error) {
+    console.error('[Codex] Failed to prepare image inputs:', error);
+    return { input: command, tempImagePaths, tempDir };
+  }
+}
+
+async function cleanupCodexTempFiles(tempImagePaths, tempDir) {
+  if (!Array.isArray(tempImagePaths) || tempImagePaths.length === 0) {
+    return;
+  }
+
+  for (const filePath of tempImagePaths) {
+    try {
+      await fs.unlink(filePath);
+    } catch {}
+  }
+
+  if (tempDir) {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {}
+  }
+}
+
 /**
  * Execute a Codex query with streaming
  * @param {string} command - The prompt to send
@@ -276,6 +339,7 @@ export async function queryCodex(command, options = {}, ws) {
     model,
     env,
     attachments,
+    images,
     permissionMode = 'default',
     sessionMode,
     stageTagKeys,
@@ -289,6 +353,8 @@ export async function queryCodex(command, options = {}, ws) {
   let thread;
   let currentSessionId = sessionId;
   const abortController = new AbortController();
+  let tempImagePaths = [];
+  let tempDir = null;
 
   try {
     // Synchronous (better-sqlite3) — no await needed.
@@ -350,8 +416,15 @@ export async function queryCodex(command, options = {}, ws) {
       mode: sessionMode || 'research'
     });
 
+    const preparedInput = await prepareCodexInput(command, images, workingDirectory);
+    tempImagePaths = preparedInput.tempImagePaths;
+    tempDir = preparedInput.tempDir;
+
     // Execute with streaming
-    const codexInput = buildCodexInput(command, attachments);
+    // Prefer pre-uploaded attachments (buildCodexInput) over base64 temp images (prepareCodexInput)
+    const codexInput = attachments
+      ? buildCodexInput(command, attachments)
+      : preparedInput.input;
     const streamedTurn = await thread.runStreamed(codexInput, {
       signal: abortController.signal
     });
@@ -508,6 +581,8 @@ export async function queryCodex(command, options = {}, ws) {
     }
 
   } finally {
+    await cleanupCodexTempFiles(tempImagePaths, tempDir);
+
     // Update session status
     if (currentSessionId) {
       const session = activeCodexSessions.get(currentSessionId);

--- a/server/utils/imageAttachmentFiles.js
+++ b/server/utils/imageAttachmentFiles.js
@@ -1,0 +1,35 @@
+import path from 'path';
+
+function normalizeMimeExtension(mimeType) {
+  const raw = String(mimeType || '').trim().toLowerCase();
+  if (!raw.includes('/')) {
+    return 'bin';
+  }
+
+  const subtype = raw.split('/')[1] || 'bin';
+  if (subtype === 'svg+xml') {
+    return 'svg';
+  }
+
+  return subtype.replace(/[^a-z0-9]+/g, '_') || 'bin';
+}
+
+export function buildTempAttachmentFilename(index, originalName, mimeType) {
+  const ext = normalizeMimeExtension(mimeType);
+  const sanitizedOriginal = String(originalName || '')
+    .replace(/[^a-zA-Z0-9._-]/g, '_')
+    .replace(/^\.+/, '')
+    .trim();
+
+  if (sanitizedOriginal) {
+    return `${index + 1}_${sanitizedOriginal}`;
+  }
+
+  return `image_${index}.${ext}`;
+}
+
+export function toPortableAtPath(filePath, workingDir, pathApi = path) {
+  const baseDir = workingDir || process.cwd();
+  const relativePath = pathApi.relative(baseDir, filePath);
+  return `@${relativePath.split(pathApi.sep).join('/')}`;
+}

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -1037,6 +1037,7 @@ export function useChatComposerState({
             model: codexModel,
             permissionMode: permissionMode === 'plan' ? 'default' : permissionMode,
             attachments: codexAttachmentPayload,
+            images: uploadedImages,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
             stageTagKeys: pendingStageTagKeys,

--- a/test/image-attachment-files.test.mjs
+++ b/test/image-attachment-files.test.mjs
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+
+import {
+  buildTempAttachmentFilename,
+  toPortableAtPath,
+} from '../server/utils/imageAttachmentFiles.js';
+
+test('buildTempAttachmentFilename prefixes original names to avoid Windows reserved basenames', () => {
+  assert.equal(buildTempAttachmentFilename(0, 'con.png', 'image/png'), '1_con.png');
+  assert.equal(buildTempAttachmentFilename(1, 'aux.jpg', 'image/jpeg'), '2_aux.jpg');
+});
+
+test('buildTempAttachmentFilename sanitizes names and normalizes svg mime extensions', () => {
+  assert.equal(buildTempAttachmentFilename(0, 'my diagram?.png', 'image/png'), '1_my_diagram_.png');
+  assert.equal(buildTempAttachmentFilename(2, '', 'image/svg+xml'), 'image_2.svg');
+});
+
+test('toPortableAtPath produces Gemini-compatible relative paths on POSIX', () => {
+  const result = toPortableAtPath(
+    '/workspace/.tmp/attachments/123/example.png',
+    '/workspace',
+    path.posix,
+  );
+
+  assert.equal(result, '@.tmp/attachments/123/example.png');
+});
+
+test('toPortableAtPath normalizes Windows separators to forward slashes', () => {
+  const result = toPortableAtPath(
+    'C:\\workspace\\.tmp\\attachments\\123\\example.png',
+    'C:\\workspace',
+    path.win32,
+  );
+
+  assert.equal(result, '@.tmp/attachments/123/example.png');
+});
+
+test('toPortableAtPath keeps absolute Windows paths when drives differ', () => {
+  const result = toPortableAtPath(
+    'D:\\temp\\example.png',
+    'C:\\workspace',
+    path.win32,
+  );
+
+  assert.equal(result, '@D:/temp/example.png');
+});


### PR DESCRIPTION
## Summary
- forward uploaded chat images to Codex and send them to the Codex SDK as structured `local_image` inputs
- switch Gemini chat attachments from plain file-path notes to `@path` references so Gemini CLI reads them as multimodal inputs
- harden temporary attachment filenames and add Windows-focused path/file-name tests for shared image handling

## Testing
- npm run typecheck
- node --test test/image-attachment-files.test.mjs
- node --check server/claude-sdk.js
- node --check server/gemini-cli.js
- node --check server/openai-codex.js