### PR TITLE
Add automatic port fallback for server and Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ pids
 *.pid
 *.seed
 *.pid.lock
+.runtime/
 
 # Coverage directory used by tools like istanbul
 coverage/

--- a/server/__tests__/runtimePorts.test.mjs
+++ b/server/__tests__/runtimePorts.test.mjs
@@ -1,0 +1,115 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const probeResults = [];
+
+vi.mock('net', () => ({
+  default: {
+    createServer() {
+      let errorHandler = null;
+
+      return {
+        once(event, handler) {
+          if (event === 'error') {
+            errorHandler = handler;
+          }
+        },
+        off(event, handler) {
+          if (event === 'error' && errorHandler === handler) {
+            errorHandler = null;
+          }
+        },
+        listen(port, host, callback) {
+          const nextResult = probeResults.shift();
+          if (nextResult instanceof Error) {
+            queueMicrotask(() => errorHandler?.(nextResult));
+            return;
+          }
+          queueMicrotask(() => callback());
+        },
+        close(callback) {
+          queueMicrotask(() => callback?.());
+        },
+      };
+    },
+  },
+}));
+
+const {
+  DEFAULT_FRONTEND_PORT,
+  getBackendPortSync,
+  getFrontendPortSync,
+  listenOnAvailablePort,
+  setRuntimePortSync,
+} = await import('../utils/runtimePorts.js');
+
+const cleanupTasks = [];
+
+function createFakeHttpServer() {
+  let errorHandler = null;
+  let listenedPort = null;
+
+  return {
+    once(event, handler) {
+      if (event === 'error') {
+        errorHandler = handler;
+      }
+    },
+    off(event, handler) {
+      if (event === 'error' && errorHandler === handler) {
+        errorHandler = null;
+      }
+    },
+    listen(port, host, callback) {
+      listenedPort = port;
+      queueMicrotask(() => callback());
+    },
+    get listenedPort() {
+      return listenedPort;
+    },
+  };
+}
+
+afterEach(async () => {
+  probeResults.length = 0;
+
+  while (cleanupTasks.length > 0) {
+    const task = cleanupTasks.pop();
+    await task();
+  }
+
+  delete process.env.DR_CLAW_RUNTIME_DIR;
+  delete process.env.DR_CLAW_RUNTIME_FILE;
+});
+
+describe('runtimePorts', () => {
+  it('listens on the next available backend port when the requested port is occupied', async () => {
+    const busyPortError = new Error('busy');
+    busyPortError.code = 'EADDRINUSE';
+    probeResults.push(busyPortError, true);
+
+    const server = createFakeHttpServer();
+    const activePort = await listenOnAvailablePort(server, {
+      startPort: 3001,
+      host: '0.0.0.0',
+      maxAttempts: 5,
+    });
+
+    expect(activePort).toBe(3002);
+    expect(server.listenedPort).toBe(3002);
+  });
+
+  it('reads runtime ports from an override directory and ignores stale process entries', async () => {
+    const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dr-claw-runtime-'));
+    process.env.DR_CLAW_RUNTIME_DIR = runtimeDir;
+    cleanupTasks.push(() => fs.rm(runtimeDir, { recursive: true, force: true }));
+
+    setRuntimePortSync('backend', 4321);
+    setRuntimePortSync('frontend', 9876, 999999999);
+
+    expect(getBackendPortSync(3001)).toBe(4321);
+    expect(getFrontendPortSync(DEFAULT_FRONTEND_PORT)).toBe(DEFAULT_FRONTEND_PORT);
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -31,7 +31,7 @@ const c = {
     dim: (text) => `${colors.dim}${text}${colors.reset}`,
 };
 
-console.log('PORT from env:', process.env.PORT);
+console.log('Requested PORT from env:', process.env.PORT);
 
 import express from 'express';
 import { WebSocketServer, WebSocket } from 'ws';
@@ -74,6 +74,14 @@ import { IS_PLATFORM } from './constants/config.js';
 import { enqueueTelemetryEvent } from './telemetry.js';
 import { resolveCursorCliCommand, isCursorLoginCommand, isGeminiLoginCommand, normalizeCursorLoginCommand } from './utils/cursorCommand.js';
 import { getGeminiApiKeyForUser, withGeminiApiKeyEnv } from './utils/geminiApiKey.js';
+import {
+    DEFAULT_BACKEND_PORT,
+    DEFAULT_FRONTEND_PORT,
+    getFrontendPortSync,
+    listenOnAvailablePort,
+    parsePortNumber,
+    setRuntimePortSync,
+} from './utils/runtimePorts.js';
 
 // File system watchers for provider project/session folders
 const PROVIDER_WATCH_PATHS = [
@@ -2727,7 +2735,7 @@ app.get('*', (req, res) => {
     res.sendFile(indexPath);
   } else {
     // In development, redirect to Vite dev server only if dist doesn't exist
-    res.redirect(`http://${DISPLAY_HOST}:${process.env.VITE_PORT || 5173}`);
+    res.redirect(`http://${DISPLAY_HOST}:${getFrontendPortSync(REQUESTED_VITE_PORT)}`);
   }
 });
 
@@ -2933,7 +2941,8 @@ async function getFileTree(dirPath, maxDepth = 3, currentDepth = 0, showHidden =
     });
 }
 
-const PORT = process.env.PORT || 3001;
+const REQUESTED_PORT = parsePortNumber(process.env.PORT, DEFAULT_BACKEND_PORT);
+const REQUESTED_VITE_PORT = parsePortNumber(process.env.VITE_PORT, DEFAULT_FRONTEND_PORT);
 const HOST = process.env.HOST || '0.0.0.0';
 // Show localhost when binding to all interfaces; 0.0.0.0 is not directly connectable.
 const DISPLAY_HOST = HOST === '0.0.0.0' ? 'localhost' : HOST;
@@ -2953,37 +2962,45 @@ async function startServer() {
         console.log(`${c.info('[INFO]')} Running in ${c.bright(isProduction ? 'PRODUCTION' : 'DEVELOPMENT')} mode`);
 
         if (!isProduction) {
-            console.log(`${c.warn('[WARN]')} Note: Requests will be proxied to Vite dev server at ${c.dim('http://' + DISPLAY_HOST + ':' + (process.env.VITE_PORT || 5173))}`);
+            console.log(`${c.warn('[WARN]')} Note: Requests will be proxied to Vite dev server at ${c.dim('http://' + DISPLAY_HOST + ':' + getFrontendPortSync(REQUESTED_VITE_PORT))}`);
         }
 
-        server.listen(PORT, HOST, async () => {
-            const appInstallPath = path.join(__dirname, '..');
-            const vitePort = process.env.VITE_PORT || 5173;
-
-            console.log('');
-            console.log(c.dim('═'.repeat(63)));
-            console.log(`  ${c.bright('Dr. Claw Server - Ready')}`);
-            console.log(c.dim('═'.repeat(63)));
-            console.log('');
-
-            if (isProduction) {
-                console.log(`${c.info('[INFO]')} Server URL:  ${c.bright('http://' + DISPLAY_HOST + ':' + PORT)}`);
-            } else {
-                console.log(`${c.info('[INFO]')} Backend URL: ${c.dim('http://' + DISPLAY_HOST + ':' + PORT)}`);
-                console.log(`${c.ok('[OK]')}   Frontend URL: ${c.bright('http://' + DISPLAY_HOST + ':' + vitePort)} (Use this for development)`);
-            }
-
-            console.log(`${c.info('[INFO]')} Installed at: ${c.dim(appInstallPath)}`);
-            console.log(`${c.tip('[TIP]')}  Run "dr-claw status" for full configuration details`);
-            console.log('');
-
-            // Ensure the workspaces root directory exists
-            const startupWorkspaceRoot = await getWorkspacesRoot();
-            await fsPromises.mkdir(startupWorkspaceRoot, { recursive: true });
-
-            // Start watching the projects folder for changes
-            await setupProjectsWatcher();
+        const activePort = await listenOnAvailablePort(server, {
+            startPort: REQUESTED_PORT,
+            host: HOST,
         });
+        setRuntimePortSync('backend', activePort);
+
+        const appInstallPath = path.join(__dirname, '..');
+        const vitePort = getFrontendPortSync(REQUESTED_VITE_PORT);
+
+        if (activePort !== REQUESTED_PORT) {
+            console.log(`${c.warn('[WARN]')} Port ${REQUESTED_PORT} is busy, switched backend to ${activePort}`);
+        }
+
+        console.log('');
+        console.log(c.dim('═'.repeat(63)));
+        console.log(`  ${c.bright('Dr. Claw Server - Ready')}`);
+        console.log(c.dim('═'.repeat(63)));
+        console.log('');
+
+        if (isProduction) {
+            console.log(`${c.info('[INFO]')} Server URL:  ${c.bright('http://' + DISPLAY_HOST + ':' + activePort)}`);
+        } else {
+            console.log(`${c.info('[INFO]')} Backend URL: ${c.dim('http://' + DISPLAY_HOST + ':' + activePort)}`);
+            console.log(`${c.ok('[OK]')}   Frontend URL: ${c.bright('http://' + DISPLAY_HOST + ':' + vitePort)} (Use this for development)`);
+        }
+
+        console.log(`${c.info('[INFO]')} Installed at: ${c.dim(appInstallPath)}`);
+        console.log(`${c.tip('[TIP]')}  Run "dr-claw status" for full configuration details`);
+        console.log('');
+
+        // Ensure the workspaces root directory exists
+        const startupWorkspaceRoot = await getWorkspacesRoot();
+        await fsPromises.mkdir(startupWorkspaceRoot, { recursive: true });
+
+        // Start watching the projects folder for changes
+        await setupProjectsWatcher();
     } catch (error) {
         console.error('[ERROR] Failed to start server:', error);
         process.exit(1);

--- a/server/utils/runtimePorts.js
+++ b/server/utils/runtimePorts.js
@@ -1,0 +1,212 @@
+import fs from 'fs';
+import net from 'net';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const DEFAULT_BACKEND_PORT = 3001;
+export const DEFAULT_FRONTEND_PORT = 5173;
+const DEFAULT_MAX_PORT_ATTEMPTS = 20;
+
+function getProjectRoot() {
+    return path.join(__dirname, '../..');
+}
+
+function getRuntimePortsPath() {
+    if (process.env.DR_CLAW_RUNTIME_FILE) {
+        return process.env.DR_CLAW_RUNTIME_FILE;
+    }
+
+    const runtimeDir = process.env.DR_CLAW_RUNTIME_DIR || path.join(getProjectRoot(), '.runtime');
+    return path.join(runtimeDir, 'ports.json');
+}
+
+function ensureRuntimeDirSync() {
+    fs.mkdirSync(path.dirname(getRuntimePortsPath()), { recursive: true });
+}
+
+function isPidAlive(pid) {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return false;
+    }
+
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch (error) {
+        return error.code === 'EPERM';
+    }
+}
+
+function sanitizeRuntimeEntry(entry) {
+    if (!entry || typeof entry !== 'object') {
+        return null;
+    }
+
+    const port = Number(entry.port);
+    if (!Number.isInteger(port) || port <= 0) {
+        return null;
+    }
+
+    const pid = Number(entry.pid);
+    if (Number.isInteger(pid) && pid > 0 && !isPidAlive(pid)) {
+        return null;
+    }
+
+    return {
+        port,
+        pid: Number.isInteger(pid) && pid > 0 ? pid : null,
+        updatedAt: typeof entry.updatedAt === 'string' ? entry.updatedAt : null,
+    };
+}
+
+function readRawRuntimePortsSync() {
+    try {
+        const content = fs.readFileSync(getRuntimePortsPath(), 'utf8');
+        const parsed = JSON.parse(content);
+        return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            console.warn('[runtimePorts] Failed to read runtime ports file:', error.message);
+        }
+        return {};
+    }
+}
+
+function writeRawRuntimePortsSync(state) {
+    ensureRuntimeDirSync();
+    fs.writeFileSync(getRuntimePortsPath(), `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+}
+
+export function parsePortNumber(value, fallback) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getRuntimePortStateSync() {
+    const rawState = readRawRuntimePortsSync();
+    return {
+        backend: sanitizeRuntimeEntry(rawState.backend),
+        frontend: sanitizeRuntimeEntry(rawState.frontend),
+    };
+}
+
+export function getRuntimePortSync(kind, fallback) {
+    const state = getRuntimePortStateSync();
+    return state[kind]?.port ?? fallback;
+}
+
+export function getBackendPortSync(fallback = DEFAULT_BACKEND_PORT) {
+    return getRuntimePortSync('backend', fallback);
+}
+
+export function getFrontendPortSync(fallback = DEFAULT_FRONTEND_PORT) {
+    return getRuntimePortSync('frontend', fallback);
+}
+
+export function setRuntimePortSync(kind, port, pid = process.pid) {
+    const normalizedPort = parsePortNumber(port, null);
+    if (!normalizedPort) {
+        throw new Error(`Invalid port for ${kind}: ${port}`);
+    }
+
+    const rawState = readRawRuntimePortsSync();
+    rawState[kind] = {
+        port: normalizedPort,
+        pid,
+        updatedAt: new Date().toISOString(),
+    };
+    writeRawRuntimePortsSync(rawState);
+}
+
+async function isPortAvailable(port, host) {
+    return new Promise((resolve, reject) => {
+        const probe = net.createServer();
+
+        const handleError = (error) => {
+            cleanup();
+            if (error.code === 'EADDRINUSE') {
+                resolve(false);
+                return;
+            }
+            reject(error);
+        };
+
+        const cleanup = () => {
+            probe.off('error', handleError);
+        };
+
+        probe.once('error', handleError);
+        probe.listen(port, host, () => {
+            probe.close((error) => {
+                cleanup();
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve(true);
+            });
+        });
+    });
+}
+
+async function listenOnce(server, port, host) {
+    await new Promise((resolve, reject) => {
+        const handleError = (error) => {
+            cleanup();
+            reject(error);
+        };
+
+        const cleanup = () => {
+            server.off('error', handleError);
+        };
+
+        server.once('error', handleError);
+        server.listen(port, host, () => {
+            cleanup();
+            resolve();
+        });
+    });
+}
+
+export async function listenOnAvailablePort(server, options = {}) {
+    const startPort = parsePortNumber(options.startPort, DEFAULT_BACKEND_PORT);
+    const host = options.host || '0.0.0.0';
+    const maxAttempts = Number.isInteger(options.maxAttempts) && options.maxAttempts > 0
+        ? options.maxAttempts
+        : DEFAULT_MAX_PORT_ATTEMPTS;
+
+    let lastError = null;
+
+    for (let offset = 0; offset < maxAttempts; offset += 1) {
+        const port = startPort + offset;
+
+        try {
+            const available = await isPortAvailable(port, host);
+            if (!available) {
+                const portBusyError = new Error(`Port ${port} is already in use.`);
+                portBusyError.code = 'EADDRINUSE';
+                lastError = portBusyError;
+                continue;
+            }
+
+            await listenOnce(server, port, host);
+
+            return port;
+        } catch (error) {
+            if (error.code !== 'EADDRINUSE') {
+                throw error;
+            }
+            lastError = error;
+        }
+    }
+
+    const endPort = startPort + maxAttempts - 1;
+    const error = new Error(`No available port found between ${startPort} and ${endPort}.`);
+    error.code = 'EADDRINUSE';
+    error.cause = lastError;
+    throw error;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,43 @@
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
+import {
+  DEFAULT_BACKEND_PORT,
+  DEFAULT_FRONTEND_PORT,
+  getBackendPortSync,
+  parsePortNumber,
+  setRuntimePortSync
+} from './server/utils/runtimePorts.js'
+
+function buildProxyTarget(protocol, host, fallbackPort) {
+  return `${protocol}://${host}:${getBackendPortSync(fallbackPort)}`
+}
+
+function configureDynamicProxy(proxy, protocol, host, fallbackPort, eventName = 'proxyReq') {
+  const syncTarget = () => {
+    proxy.options.target = buildProxyTarget(protocol, host, fallbackPort)
+  }
+
+  syncTarget()
+  proxy.on(eventName, syncTarget)
+}
+
+function runtimePortSyncPlugin() {
+  return {
+    name: 'runtime-port-sync',
+    configureServer(server) {
+      const recordFrontendPort = () => {
+        const address = server.httpServer?.address()
+        if (address && typeof address === 'object' && address.port) {
+          setRuntimePortSync('frontend', address.port)
+        }
+      }
+
+      if (server.httpServer) {
+        server.httpServer.once('listening', recordFrontendPort)
+      }
+    }
+  }
+}
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
@@ -9,22 +47,35 @@ export default defineConfig(({ command, mode }) => {
   // When binding to all interfaces (0.0.0.0), proxy should connect to localhost.
   // Otherwise, proxy to the specific host the backend is bound to.
   const proxyHost = host === '0.0.0.0' ? 'localhost' : host
-  const port = env.PORT || 3001
+  const backendPort = parsePortNumber(env.PORT, DEFAULT_BACKEND_PORT)
+  const frontendPort = parsePortNumber(env.VITE_PORT, DEFAULT_FRONTEND_PORT)
 
   return {
-    plugins: [react()],
+    plugins: [react(), runtimePortSyncPlugin()],
     server: {
       host,
-      port: parseInt(env.VITE_PORT) || 5173,
+      port: frontendPort,
+      strictPort: false,
       proxy: {
-        '/api': `http://${proxyHost}:${port}`,
+        '/api': {
+          target: buildProxyTarget('http', proxyHost, backendPort),
+          configure(proxy) {
+            configureDynamicProxy(proxy, 'http', proxyHost, backendPort)
+          }
+        },
         '/ws': {
-          target: `ws://${proxyHost}:${port}`,
-          ws: true
+          target: buildProxyTarget('ws', proxyHost, backendPort),
+          ws: true,
+          configure(proxy) {
+            configureDynamicProxy(proxy, 'ws', proxyHost, backendPort, 'proxyReqWs')
+          }
         },
         '/shell': {
-          target: `ws://${proxyHost}:${port}`,
-          ws: true
+          target: buildProxyTarget('ws', proxyHost, backendPort),
+          ws: true,
+          configure(proxy) {
+            configureDynamicProxy(proxy, 'ws', proxyHost, backendPort, 'proxyReqWs')
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- add shared runtime port tracking for backend and Vite dev server
- make the backend fall back to the next available port when the requested port is occupied
- make Vite record its actual port and dynamically proxy /api, /ws, and /shell to the backend's active port

## Testing
- npm test
- npm run typecheck
- manually blocked backend port 3101, then verified the server switched to 3102 and /health returned 200
- manually blocked frontend port 5301 on both IPv4 and IPv6, then verified Vite switched to 5302 and /api/auth/status still proxied successfully to the backend