### PR TITLE
fix: Fix Codex PDF attachment handling

### DIFF
--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -225,6 +225,42 @@ function mapPermissionModeToCodexOptions(permissionMode) {
   }
 }
 
+function buildCodexInput(command, attachments) {
+  const imagePaths = Array.isArray(attachments?.imagePaths)
+    ? attachments.imagePaths.filter((value) => typeof value === 'string' && value.trim())
+    : [];
+  const documentPaths = Array.isArray(attachments?.documentPaths)
+    ? attachments.documentPaths.filter((value) => typeof value === 'string' && value.trim())
+    : [];
+
+  if (imagePaths.length === 0 && documentPaths.length === 0) {
+    return command;
+  }
+
+  const textSections = [command];
+
+  if (documentPaths.length > 0) {
+    textSections.push(
+      `Attached workspace PDF path(s):\n${documentPaths
+        .map((filePath) => `- ${filePath}`)
+        .join('\n')}`,
+    );
+  }
+
+  if (imagePaths.length > 0) {
+    textSections.push(
+      imagePaths.length === 1
+        ? 'An image is attached below.'
+        : `There are ${imagePaths.length} attached images below.`,
+    );
+  }
+
+  return [
+    { type: 'text', text: textSections.join('\n\n') },
+    ...imagePaths.map((filePath) => ({ type: 'local_image', path: filePath })),
+  ];
+}
+
 /**
  * Execute a Codex query with streaming
  * @param {string} command - The prompt to send
@@ -238,6 +274,7 @@ export async function queryCodex(command, options = {}, ws) {
     projectPath,
     model,
     env,
+    attachments,
     permissionMode = 'default',
     sessionMode
   } = options;
@@ -299,7 +336,8 @@ export async function queryCodex(command, options = {}, ws) {
     });
 
     // Execute with streaming
-    const streamedTurn = await thread.runStreamed(command, {
+    const codexInput = buildCodexInput(command, attachments);
+    const streamedTurn = await thread.runStreamed(codexInput, {
       signal: abortController.signal
     });
 

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -19,6 +19,8 @@ import { grantToolPermission } from '../utils/chatPermissions';
 import { getProviderSettingsKey, persistSessionTimerStart, safeLocalStorage } from '../utils/chatStorage';
 import { consumeWorkspaceQaDraft, WORKSPACE_QA_DRAFT_EVENT } from '../../../utils/workspaceQa';
 import type {
+  ChatAttachment,
+  ChatImage,
   ChatMessage,
   PendingPermissionRequest,
   PermissionMode,
@@ -80,12 +82,63 @@ interface CommandExecutionResult {
   hasFileIncludes?: boolean;
 }
 
+interface UploadedProjectFile {
+  name?: string;
+  path?: string;
+  size?: number;
+}
+
 const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
 
 const PROGRAMMATIC_SUBMIT_MAX_RETRIES = 12;
 const PROGRAMMATIC_SUBMIT_RETRY_DELAY_MS = 50;
+const MAX_ATTACHMENTS = 5;
+const MAX_ATTACHMENT_SIZE_BYTES = 10 * 1024 * 1024;
+const CODEX_ATTACHMENT_DIR = '.dr-claw/chat-attachments';
+
+const IMAGE_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.bmp',
+  '.svg',
+  '.heic',
+  '.heif',
+]);
+
+const PDF_EXTENSION = '.pdf';
+
+function getAttachmentKey(file: File) {
+  return `${file.name}:${file.size}:${file.lastModified}`;
+}
+
+function getFileExtension(file: File) {
+  const lowerName = file.name.toLowerCase();
+  const lastDot = lowerName.lastIndexOf('.');
+  return lastDot >= 0 ? lowerName.slice(lastDot) : '';
+}
+
+function isImageAttachment(file: File) {
+  return file.type.startsWith('image/') || IMAGE_EXTENSIONS.has(getFileExtension(file));
+}
+
+function isPdfAttachment(file: File) {
+  return file.type === 'application/pdf' || getFileExtension(file) === PDF_EXTENSION;
+}
+
+function getAttachmentKind(file: File) {
+  if (isImageAttachment(file)) {
+    return 'image';
+  }
+  if (isPdfAttachment(file)) {
+    return 'pdf';
+  }
+  return 'unsupported';
+}
 
 const isTemporarySessionId = (sessionId: string | null | undefined) =>
   Boolean(sessionId && sessionId.startsWith('new-session-'));
@@ -144,9 +197,9 @@ export function useChatComposerState({
     }
     return '';
   });
-  const [attachedImages, setAttachedImages] = useState<File[]>([]);
-  const [uploadingImages, setUploadingImages] = useState<Map<string, number>>(new Map());
-  const [imageErrors, setImageErrors] = useState<Map<string, string>>(new Map());
+  const [attachedFiles, setAttachedFiles] = useState<File[]>([]);
+  const [uploadingFiles, setUploadingFiles] = useState<Map<string, number>>(new Map());
+  const [fileErrors, setFileErrors] = useState<Map<string, string>>(new Map());
   const [isTextareaExpanded, setIsTextareaExpanded] = useState(false);
   const [thinkingMode, setThinkingMode] = useState('none');
   const [intakeGreeting, setIntakeGreeting] = useState<string | null>(null);
@@ -459,34 +512,78 @@ export function useChatComposerState({
     inputHighlightRef.current.scrollLeft = target.scrollLeft;
   }, []);
 
-  const handleImageFiles = useCallback((files: File[]) => {
-    const validFiles = files.filter((file) => {
+  const handleAttachmentFiles = useCallback((files: File[]) => {
+    const validFiles: File[] = [];
+
+    files.forEach((file) => {
       try {
         if (!file || typeof file !== 'object') {
           console.warn('Invalid file object:', file);
-          return false;
+          return;
         }
 
-        if (!file.size || file.size > 10 * 1024 * 1024) {
-          const fileName = file.name || 'Unknown file';
-          setImageErrors((previous) => {
+        const attachmentKey = getAttachmentKey(file);
+        const attachmentKind = getAttachmentKind(file);
+
+        if (!file.size || file.size > MAX_ATTACHMENT_SIZE_BYTES) {
+          setFileErrors((previous) => {
             const next = new Map(previous);
-            next.set(fileName, 'File too large (max 10MB)');
+            next.set(attachmentKey, 'File too large (max 10MB)');
             return next;
           });
-          return false;
+          return;
         }
 
-        return true;
+        if (attachmentKind === 'unsupported') {
+          setFileErrors((previous) => {
+            const next = new Map(previous);
+            next.set(attachmentKey, 'Only images and PDF files are supported');
+            return next;
+          });
+          return;
+        }
+
+        validFiles.push(file);
       } catch (error) {
         console.error('Error validating file:', error, file);
-        return false;
       }
     });
 
     if (validFiles.length > 0) {
-      setAttachedImages((previous) => [...previous, ...validFiles].slice(0, 5));
+      setAttachedFiles((previous) => {
+        const deduped = [...previous];
+        validFiles.forEach((file) => {
+          const nextKey = getAttachmentKey(file);
+          if (!deduped.some((existing) => getAttachmentKey(existing) === nextKey)) {
+            deduped.push(file);
+          }
+        });
+        return deduped.slice(0, MAX_ATTACHMENTS);
+      });
     }
+  }, []);
+
+  const removeAttachedFile = useCallback((index: number) => {
+    setAttachedFiles((previous) => {
+      const next = [...previous];
+      const [removedFile] = next.splice(index, 1);
+
+      if (removedFile) {
+        const attachmentKey = getAttachmentKey(removedFile);
+        setFileErrors((previousErrors) => {
+          const nextErrors = new Map(previousErrors);
+          nextErrors.delete(attachmentKey);
+          return nextErrors;
+        });
+        setUploadingFiles((previousUploads) => {
+          const nextUploads = new Map(previousUploads);
+          nextUploads.delete(attachmentKey);
+          return nextUploads;
+        });
+      }
+
+      return next;
+    });
   }, []);
 
   const handlePaste = useCallback(
@@ -499,28 +596,88 @@ export function useChatComposerState({
         }
         const file = item.getAsFile();
         if (file) {
-          handleImageFiles([file]);
+          handleAttachmentFiles([file]);
         }
       });
 
       if (items.length === 0 && event.clipboardData.files.length > 0) {
         const files = Array.from(event.clipboardData.files);
         if (files.length > 0) {
-          handleImageFiles(files);
+          handleAttachmentFiles(files);
         }
       }
     },
-    [handleImageFiles],
+    [handleAttachmentFiles],
   );
 
 
   const { getRootProps, getInputProps, isDragActive, open } = useDropzone({
-    maxSize: 10 * 1024 * 1024,
-    maxFiles: 5,
-    onDrop: handleImageFiles,
+    accept: {
+      'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg', '.heic', '.heif'],
+      'application/pdf': ['.pdf'],
+    },
+    maxSize: MAX_ATTACHMENT_SIZE_BYTES,
+    maxFiles: MAX_ATTACHMENTS,
+    onDrop: handleAttachmentFiles,
     noClick: true,
     noKeyboard: true,
   });
+
+  const uploadPreviewImages = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) {
+        return [];
+      }
+
+      const formData = new FormData();
+      files.forEach((file) => {
+        formData.append('images', file);
+      });
+
+      const response = await authenticatedFetch(`/api/projects/${encodeURIComponent(selectedProject?.name || '')}/upload-images`, {
+        method: 'POST',
+        headers: {},
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to upload images');
+      }
+
+      const result = await response.json();
+      return Array.isArray(result.images) ? (result.images as ChatImage[]) : [];
+    },
+    [selectedProject?.name],
+  );
+
+  const uploadFilesToProject = useCallback(
+    async (files: File[]) => {
+      if (!selectedProject || files.length === 0) {
+        return [];
+      }
+
+      const formData = new FormData();
+      const targetDir = `${CODEX_ATTACHMENT_DIR}/${Date.now()}`;
+      formData.append('targetDir', targetDir);
+      files.forEach((file) => {
+        formData.append('files', file);
+      });
+
+      const response = await authenticatedFetch(`/api/projects/${encodeURIComponent(selectedProject.name)}/upload-files`, {
+        method: 'POST',
+        headers: {},
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to upload files');
+      }
+
+      const result = await response.json();
+      return Array.isArray(result.files) ? (result.files as UploadedProjectFile[]) : [];
+    },
+    [selectedProject],
+  );
 
   const handleSubmit = useCallback(
     async (
@@ -542,9 +699,9 @@ export function useChatComposerState({
           await executeCommand(matchedCommand, trimmedInput);
           setInput('');
           inputValueRef.current = '';
-          setAttachedImages([]);
-          setUploadingImages(new Map());
-          setImageErrors(new Map());
+          setAttachedFiles([]);
+          setUploadingFiles(new Map());
+          setFileErrors(new Map());
           resetCommandMenuState();
           setIsTextareaExpanded(false);
           if (textareaRef.current) {
@@ -574,26 +731,87 @@ export function useChatComposerState({
         setIntakeGreeting(null);
       }
 
-      let uploadedImages: unknown[] = [];
-      if (attachedImages.length > 0) {
-        const formData = new FormData();
-        attachedImages.forEach((file) => {
-          formData.append('images', file);
-        });
-
-        try {
-          const response = await authenticatedFetch(`/api/projects/${selectedProject.name}/upload-images`, {
-            method: 'POST',
-            headers: {},
-            body: formData,
-          });
-
-          if (!response.ok) {
-            throw new Error('Failed to upload images');
+      let uploadedImages: ChatImage[] = [];
+      let codexAttachmentPayload:
+        | {
+            imagePaths: string[];
+            documentPaths: string[];
           }
+        | undefined;
+      let messageAttachments: ChatAttachment[] = [];
 
-          const result = await response.json();
-          uploadedImages = result.images;
+      if (provider === 'cursor' && attachedFiles.length > 0) {
+        setChatMessages((previous) => [
+          ...previous,
+          {
+            type: 'error',
+            content: 'Cursor chat attachments are not supported yet.',
+            timestamp: new Date(),
+          },
+        ]);
+        return;
+      }
+
+      if (provider === 'codex' && attachedFiles.length > 0) {
+        try {
+          const uploadedFiles = await uploadFilesToProject(attachedFiles);
+          codexAttachmentPayload = uploadedFiles.reduce(
+            (
+              accumulator: {
+                imagePaths: string[];
+                documentPaths: string[];
+              },
+              uploadedFile: UploadedProjectFile,
+              index: number,
+            ) => {
+              const sourceFile = attachedFiles[index];
+              const uploadedPath =
+                uploadedFile?.path && typeof uploadedFile.path === 'string' ? uploadedFile.path : null;
+
+              if (!sourceFile || !uploadedPath) {
+                return accumulator;
+              }
+
+              if (isImageAttachment(sourceFile)) {
+                accumulator.imagePaths.push(uploadedPath);
+              } else if (isPdfAttachment(sourceFile)) {
+                accumulator.documentPaths.push(uploadedPath);
+              }
+
+              return accumulator;
+            },
+            {
+              imagePaths: [] as string[],
+              documentPaths: [] as string[],
+            },
+          );
+          messageAttachments = attachedFiles.map((file, index) => {
+            const uploadedFile = uploadedFiles[index];
+            const uploadedPath = uploadedFile?.path && typeof uploadedFile.path === 'string' ? uploadedFile.path : undefined;
+
+            return {
+              name: file.name,
+              kind: isImageAttachment(file) ? 'image' : 'pdf',
+              mimeType: file.type || undefined,
+              path: uploadedPath,
+            };
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          console.error('Codex attachment upload failed:', error);
+          setChatMessages((previous) => [
+            ...previous,
+            {
+              type: 'error',
+              content: `Failed to upload attachments for Codex: ${message}`,
+              timestamp: new Date(),
+            },
+          ]);
+          return;
+        }
+      } else if (attachedFiles.length > 0) {
+        try {
+          uploadedImages = await uploadPreviewImages(attachedFiles);
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';
           console.error('Image upload failed:', error);
@@ -612,7 +830,8 @@ export function useChatComposerState({
       const userMessage: ChatMessage = {
         type: 'user',
         content: currentInput,
-        images: uploadedImages as any,
+        images: uploadedImages,
+        attachments: messageAttachments.length > 0 ? messageAttachments : undefined,
         timestamp: new Date(),
       };
 
@@ -755,6 +974,7 @@ export function useChatComposerState({
             resume: Boolean(effectiveSessionId),
             model: codexModel,
             permissionMode: permissionMode === 'plan' ? 'default' : permissionMode,
+            attachments: codexAttachmentPayload,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
           },
@@ -782,9 +1002,9 @@ export function useChatComposerState({
       setInput('');
       inputValueRef.current = '';
       resetCommandMenuState();
-      setAttachedImages([]);
-      setUploadingImages(new Map());
-      setImageErrors(new Map());
+      setAttachedFiles([]);
+      setUploadingFiles(new Map());
+      setFileErrors(new Map());
       setIsTextareaExpanded(false);
       setThinkingMode('none');
 
@@ -795,7 +1015,7 @@ export function useChatComposerState({
       safeLocalStorage.removeItem(`draft_input_${selectedProject.name}`);
     },
     [
-      attachedImages,
+      attachedFiles,
       claudeModel,
       codexModel,
       currentSessionId,
@@ -820,6 +1040,8 @@ export function useChatComposerState({
       slashCommands,
       thinkingMode,
       intakeGreeting,
+      uploadFilesToProject,
+      uploadPreviewImages,
     ],
   );
 
@@ -1181,14 +1403,14 @@ export function useChatComposerState({
     selectedFileIndex,
     renderInputWithMentions,
     selectFile,
-    attachedImages,
-    setAttachedImages,
-    uploadingImages,
-    imageErrors,
+    attachedFiles,
+    removeAttachedFile,
+    uploadingFiles,
+    fileErrors,
     getRootProps,
     getInputProps,
     isDragActive,
-    openImagePicker: open,
+    openFilePicker: open,
     handleSubmit,
     handleInputChange,
     handleKeyDown,

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -19,6 +19,14 @@ export interface ChatImage {
   mimeType?: string;
 }
 
+export interface ChatAttachment {
+  name: string;
+  kind: 'image' | 'pdf';
+  mimeType?: string;
+  path?: string;
+  extractedTextPreview?: string;
+}
+
 export interface ToolResult {
   content?: unknown;
   isError?: boolean;
@@ -40,6 +48,7 @@ export interface ChatMessage {
   content?: string;
   timestamp: string | number | Date;
   images?: ChatImage[];
+  attachments?: ChatAttachment[];
   reasoning?: string;
   isThinking?: boolean;
   isStreaming?: boolean;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -202,14 +202,14 @@ function ChatInterface({
     selectedFileIndex,
     renderInputWithMentions,
     selectFile,
-    attachedImages,
-    setAttachedImages,
-    uploadingImages,
-    imageErrors,
+    attachedFiles,
+    removeAttachedFile,
+    uploadingFiles,
+    fileErrors,
     getRootProps,
     getInputProps,
     isDragActive,
-    openImagePicker,
+    openFilePicker,
     handleSubmit,
     handleInputChange,
     handleKeyDown,
@@ -776,14 +776,10 @@ function ChatInterface({
           onScrollToBottom={scrollToBottomAndReset}
           onSubmit={handleSubmit}
           isDragActive={isDragActive}
-          attachedImages={attachedImages}
-          onRemoveImage={(index) =>
-            setAttachedImages((previous) =>
-              previous.filter((_, currentIndex) => currentIndex !== index),
-            )
-          }
-          uploadingImages={uploadingImages}
-          imageErrors={imageErrors}
+          attachedFiles={attachedFiles}
+          onRemoveFile={removeAttachedFile}
+          uploadingFiles={uploadingFiles}
+          fileErrors={fileErrors}
           showFileDropdown={showFileDropdown}
           filteredFiles={filteredFiles}
           selectedFileIndex={selectedFileIndex}
@@ -796,7 +792,7 @@ function ChatInterface({
           frequentCommands={commandQuery ? [] : frequentCommands}
           getRootProps={getRootProps as (...args: unknown[]) => Record<string, unknown>}
           getInputProps={getInputProps as (...args: unknown[]) => Record<string, unknown>}
-          openImagePicker={openImagePicker}
+          openFilePicker={openFilePicker}
           inputHighlightRef={inputHighlightRef}
           renderInputWithMentions={renderInputWithMentions}
           textareaRef={textareaRef}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -59,10 +59,10 @@ interface ChatComposerProps {
   onScrollToBottom: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement> | MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>) => void;
   isDragActive: boolean;
-  attachedImages: File[];
-  onRemoveImage: (index: number) => void;
-  uploadingImages: Map<string, number>;
-  imageErrors: Map<string, string>;
+  attachedFiles: File[];
+  onRemoveFile: (index: number) => void;
+  uploadingFiles: Map<string, number>;
+  fileErrors: Map<string, string>;
   showFileDropdown: boolean;
   filteredFiles: MentionableFile[];
   selectedFileIndex: number;
@@ -75,7 +75,7 @@ interface ChatComposerProps {
   frequentCommands: SlashCommand[];
   getRootProps: (...args: unknown[]) => Record<string, unknown>;
   getInputProps: (...args: unknown[]) => Record<string, unknown>;
-  openImagePicker: () => void;
+  openFilePicker: () => void;
   inputHighlightRef: RefObject<HTMLDivElement>;
   renderInputWithMentions: (text: string) => ReactNode;
   textareaRef: RefObject<HTMLTextAreaElement>;
@@ -116,10 +116,10 @@ export default function ChatComposer({
   onScrollToBottom,
   onSubmit,
   isDragActive,
-  attachedImages,
-  onRemoveImage,
-  uploadingImages,
-  imageErrors,
+  attachedFiles,
+  onRemoveFile,
+  uploadingFiles,
+  fileErrors,
   showFileDropdown,
   filteredFiles,
   selectedFileIndex,
@@ -132,7 +132,7 @@ export default function ChatComposer({
   frequentCommands,
   getRootProps,
   getInputProps,
-  openImagePicker,
+  openFilePicker,
   inputHighlightRef,
   renderInputWithMentions,
   textareaRef,
@@ -221,16 +221,16 @@ export default function ChatComposer({
           </div>
         )}
 
-        {attachedImages.length > 0 && (
+        {attachedFiles.length > 0 && (
           <div className="mb-2 p-2 bg-muted/40 rounded-xl">
             <div className="flex flex-wrap gap-2">
-              {attachedImages.map((file, index) => (
+              {attachedFiles.map((file, index) => (
                 <ImageAttachment
                   key={index}
                   file={file}
-                  onRemove={() => onRemoveImage(index)}
-                  uploadProgress={uploadingImages.get(file.name)}
-                  error={imageErrors.get(file.name)}
+                  onRemove={() => onRemoveFile(index)}
+                  uploadProgress={uploadingFiles.get(`${file.name}:${file.size}:${file.lastModified}`)}
+                  error={fileErrors.get(`${file.name}:${file.size}:${file.lastModified}`)}
                 />
               ))}
             </div>
@@ -307,7 +307,7 @@ export default function ChatComposer({
 
             <button
               type="button"
-              onClick={openImagePicker}
+              onClick={openFilePicker}
               className="absolute left-2 top-1/2 transform -translate-y-1/2 p-2 hover:bg-accent/60 rounded-xl transition-colors"
               title={t('input.attachFiles')}
             >

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { User } from 'lucide-react';
+import { FileImage, FileText, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import SessionProviderLogo from '../../../SessionProviderLogo';
 import type {
@@ -116,6 +116,8 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
     return null;
   }
 
+  const visibleAttachments = Array.isArray(message.attachments) ? message.attachments : [];
+
   return (
     <div
       ref={messageRef}
@@ -202,6 +204,32 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
                       </svg>
                       <span className="text-sm truncate">{img.name || 'file'}</span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {visibleAttachments.length > 0 && (
+              <div className="mt-2 flex flex-col gap-2">
+                {visibleAttachments.map((attachment, idx) => {
+                  const Icon = attachment.kind === 'pdf' ? FileText : FileImage;
+                  return (
+                    <div
+                      key={`${attachment.name}:${attachment.path || idx}`}
+                      className="flex items-start gap-2 rounded-lg bg-white/10 px-3 py-2"
+                    >
+                      <Icon className="mt-0.5 h-4 w-4 flex-shrink-0 opacity-80" />
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium">{attachment.name}</div>
+                        <div className="text-xs opacity-75">
+                          {attachment.kind === 'pdf' ? 'PDF uploaded to workspace' : 'Image uploaded to workspace'}
+                        </div>
+                        {attachment.path && (
+                          <div className="mt-1 break-all font-mono text-[11px] opacity-70">
+                            {attachment.path}
+                          </div>
+                        )}
+                      </div>
                     </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
- route chat attachments through a shared file flow and keep Codex PDF uploads in the workspace
- send Codex only attachment paths instead of PDF text previews, while still showing uploaded files in the user message UI
- restore PDF attachment passthrough for Claude and Gemini instead of blocking them

## Testing
- npm run typecheck
- npm run build