### PR TITLE
fix(security): prevent tool call path traversal outside project root

### DIFF
--- a/server/cli-chat.js
+++ b/server/cli-chat.js
@@ -15,6 +15,7 @@ import os from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import spawnAsync from './utils/spawnAsync.js';
+import { safePath } from './utils/safePath.js';
 
 const execAsync = promisify(exec);
 
@@ -165,10 +166,9 @@ const TOOL_SCHEMAS = [
 // ── Tool execution ────────────────────────────────────────────────────────────
 
 async function executeTool(name, args, workingDir) {
-  const resolve = (p) => {
-    if (!p) return workingDir;
-    return path.isAbsolute(p) ? p : path.resolve(workingDir, p);
-  };
+  // Constrain all paths to the project root to prevent LLM-driven
+  // prompt-injection attacks from reading/writing outside the workspace.
+  const resolve = (p) => safePath(p, workingDir);
   const trunc = (s) =>
     s.length <= MAX_OUTPUT_CHARS ? s : s.slice(0, MAX_OUTPUT_CHARS) + `\n…(truncated)`;
 

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -23,6 +23,7 @@ import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIn
 import { createRequestId, waitForToolApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
 import { expandSkillCommand } from './utils/skillExpander.js';
+import { safePath } from './utils/safePath.js';
 
 const execAsync = promisify(exec);
 
@@ -223,10 +224,9 @@ function sendMessage(ws, data) {
 // ---------------------------------------------------------------------------
 
 async function executeTool(name, args, workingDir) {
-  const resolve = (p) => {
-    if (!p) return workingDir;
-    return path.isAbsolute(p) ? p : path.resolve(workingDir, p);
-  };
+  // Constrain all paths to the project root to prevent LLM-driven
+  // prompt-injection attacks from reading/writing outside the workspace.
+  const resolve = (p) => safePath(p, workingDir);
   const trunc = (s) =>
     s.length <= MAX_OUTPUT_CHARS ? s : s.slice(0, MAX_OUTPUT_CHARS) + `\n…(truncated, ${s.length} total chars)`;
 

--- a/server/utils/__tests__/safePath.test.js
+++ b/server/utils/__tests__/safePath.test.js
@@ -76,4 +76,26 @@ describe('safePath', () => {
     const result = safePath('deep/nested/new/file.js', ROOT);
     assert.ok(result.startsWith(ROOT + path.sep));
   });
+
+  it('normalizes allowedRoot for falsy input', () => {
+    // Pass a non-normalized root (with trailing segments) to verify
+    // the falsy-input path returns path.resolve(allowedRoot), not the raw string.
+    const nonNormalized = ROOT + path.sep + 'src' + path.sep + '..';
+    const result = safePath('', nonNormalized);
+    assert.equal(result, ROOT);
+  });
+
+  it('allows symlinks inside the project that point outside the root', () => {
+    // Simulate: project/data -> /tmp (an external location)
+    // This should NOT be blocked — legitimate workflow (shared datasets, etc.)
+    const linkPath = path.join(ROOT, 'external-data');
+    try {
+      fs.symlinkSync(os.tmpdir(), linkPath);
+      // Logical path is inside root, so safePath should allow it
+      const result = safePath('external-data/some-file.csv', ROOT);
+      assert.equal(result, path.join(ROOT, 'external-data', 'some-file.csv'));
+    } finally {
+      try { fs.unlinkSync(linkPath); } catch { /* ignore cleanup errors */ }
+    }
+  });
 });

--- a/server/utils/__tests__/safePath.test.js
+++ b/server/utils/__tests__/safePath.test.js
@@ -1,15 +1,30 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'path';
+import fs from 'fs';
 import os from 'os';
 import { safePath } from '../safePath.js';
 
-const ROOT = '/tmp/test-project';
+// Use a real temporary directory so realpathSync works correctly
+let ROOT;
+
+before(() => {
+  // Use realpathSync to normalize macOS /var -> /private/var symlink
+  ROOT = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'safepath-test-')));
+  fs.mkdirSync(path.join(ROOT, 'src'), { recursive: true });
+  fs.mkdirSync(path.join(ROOT, 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(ROOT, 'src', 'index.js'), '');
+  fs.writeFileSync(path.join(ROOT, 'lib', 'utils.js'), '');
+});
+
+after(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
 
 describe('safePath', () => {
   it('resolves relative paths within root', () => {
     const result = safePath('src/index.js', ROOT);
-    assert.equal(result, path.resolve(ROOT, 'src/index.js'));
+    assert.equal(result, path.join(ROOT, 'src', 'index.js'));
   });
 
   it('returns root when path is empty/null/undefined', () => {
@@ -19,9 +34,9 @@ describe('safePath', () => {
   });
 
   it('allows absolute paths that land inside root', () => {
-    const absInside = path.join(ROOT, 'src/file.js');
+    const absInside = path.join(ROOT, 'src', 'index.js');
     const result = safePath(absInside, ROOT);
-    assert.ok(result.startsWith(ROOT));
+    assert.equal(result, absInside);
   });
 
   it('blocks absolute paths outside root', () => {
@@ -47,22 +62,18 @@ describe('safePath', () => {
 
   it('allows .. that stays within root', () => {
     const result = safePath('src/../lib/utils.js', ROOT);
-    assert.equal(result, path.resolve(ROOT, 'lib/utils.js'));
+    assert.equal(result, path.join(ROOT, 'lib', 'utils.js'));
   });
 
-  it('blocks home directory references via traversal', () => {
-    assert.throws(
-      () => safePath(`../${path.relative(path.dirname(ROOT), os.homedir())}/.ssh/id_rsa`, ROOT),
-      /Path traversal blocked/,
-    );
+  it('handles non-existent target gracefully', () => {
+    // Non-existent file in existing directory — should work
+    const result = safePath('src/newfile.js', ROOT);
+    assert.equal(result, path.join(ROOT, 'src', 'newfile.js'));
   });
 
-  it('blocks null bytes in path', () => {
-    // Null bytes should not bypass the check
-    assert.throws(
-      () => safePath('src/\0/../../../etc/passwd', ROOT),
-      // Either our check catches it or Node's fs throws
-      (err) => err instanceof Error,
-    );
+  it('handles non-existent nested path gracefully', () => {
+    // Non-existent nested path — should still resolve within root
+    const result = safePath('deep/nested/new/file.js', ROOT);
+    assert.ok(result.startsWith(ROOT + path.sep));
   });
 });

--- a/server/utils/__tests__/safePath.test.js
+++ b/server/utils/__tests__/safePath.test.js
@@ -12,16 +12,22 @@ describe('safePath', () => {
     assert.equal(result, path.resolve(ROOT, 'src/index.js'));
   });
 
-  it('returns root when path is empty/null', () => {
+  it('returns root when path is empty/null/undefined', () => {
     assert.equal(safePath('', ROOT), ROOT);
     assert.equal(safePath(null, ROOT), ROOT);
     assert.equal(safePath(undefined, ROOT), ROOT);
   });
 
-  it('blocks absolute paths', () => {
+  it('allows absolute paths that land inside root', () => {
+    const absInside = path.join(ROOT, 'src/file.js');
+    const result = safePath(absInside, ROOT);
+    assert.ok(result.startsWith(ROOT));
+  });
+
+  it('blocks absolute paths outside root', () => {
     assert.throws(
       () => safePath('/etc/passwd', ROOT),
-      /Path traversal blocked.*absolute path/,
+      /Path traversal blocked/,
     );
   });
 
@@ -44,10 +50,19 @@ describe('safePath', () => {
     assert.equal(result, path.resolve(ROOT, 'lib/utils.js'));
   });
 
-  it('blocks home directory references', () => {
+  it('blocks home directory references via traversal', () => {
     assert.throws(
-      () => safePath(path.join('..', '..', os.homedir(), '.ssh', 'id_rsa'), ROOT),
+      () => safePath(`../${path.relative(path.dirname(ROOT), os.homedir())}/.ssh/id_rsa`, ROOT),
       /Path traversal blocked/,
+    );
+  });
+
+  it('blocks null bytes in path', () => {
+    // Null bytes should not bypass the check
+    assert.throws(
+      () => safePath('src/\0/../../../etc/passwd', ROOT),
+      // Either our check catches it or Node's fs throws
+      (err) => err instanceof Error,
     );
   });
 });

--- a/server/utils/__tests__/safePath.test.js
+++ b/server/utils/__tests__/safePath.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import os from 'os';
+import { safePath } from '../safePath.js';
+
+const ROOT = '/tmp/test-project';
+
+describe('safePath', () => {
+  it('resolves relative paths within root', () => {
+    const result = safePath('src/index.js', ROOT);
+    assert.equal(result, path.resolve(ROOT, 'src/index.js'));
+  });
+
+  it('returns root when path is empty/null', () => {
+    assert.equal(safePath('', ROOT), ROOT);
+    assert.equal(safePath(null, ROOT), ROOT);
+    assert.equal(safePath(undefined, ROOT), ROOT);
+  });
+
+  it('blocks absolute paths', () => {
+    assert.throws(
+      () => safePath('/etc/passwd', ROOT),
+      /Path traversal blocked.*absolute path/,
+    );
+  });
+
+  it('blocks .. traversal above root', () => {
+    assert.throws(
+      () => safePath('../../../etc/shadow', ROOT),
+      /Path traversal blocked/,
+    );
+  });
+
+  it('blocks .. traversal disguised in deeper path', () => {
+    assert.throws(
+      () => safePath('src/../../../../../../etc/passwd', ROOT),
+      /Path traversal blocked/,
+    );
+  });
+
+  it('allows .. that stays within root', () => {
+    const result = safePath('src/../lib/utils.js', ROOT);
+    assert.equal(result, path.resolve(ROOT, 'lib/utils.js'));
+  });
+
+  it('blocks home directory references', () => {
+    assert.throws(
+      () => safePath(path.join('..', '..', os.homedir(), '.ssh', 'id_rsa'), ROOT),
+      /Path traversal blocked/,
+    );
+  });
+});

--- a/server/utils/safePath.js
+++ b/server/utils/safePath.js
@@ -14,9 +14,12 @@ import fs from 'fs';
  * Resolve `userPath` relative to `allowedRoot` and verify the result
  * stays within `allowedRoot`.
  *
- * - Absolute paths are rejected (they would escape the root).
+ * - Absolute paths that land outside the root are rejected.
+ * - Absolute paths inside the root are allowed (LLM may reference them).
  * - `..` components that climb above the root are rejected.
- * - Symlinks are resolved via `realpathSync` when the target exists.
+ * - Symlinks are resolved via `realpathSync` for existing targets.
+ * - For non-existent targets, the nearest existing ancestor is resolved
+ *   to prevent symlink-parent escapes on write operations.
  *
  * @param {string} userPath  Path supplied by the tool call.
  * @param {string} allowedRoot  Project root directory.
@@ -26,31 +29,38 @@ import fs from 'fs';
 export function safePath(userPath, allowedRoot) {
   if (!userPath) return allowedRoot;
 
-  // Reject absolute paths outright — they ignore the root entirely
-  if (path.isAbsolute(userPath)) {
-    throw new Error(
-      `Path traversal blocked: absolute path "${userPath}" is not allowed. ` +
-      `All paths must be relative to the project root.`
-    );
-  }
+  // Resolve to absolute (works for both relative and absolute inputs)
+  const resolved = path.isAbsolute(userPath)
+    ? path.resolve(userPath)
+    : path.resolve(allowedRoot, userPath);
 
-  const resolved = path.resolve(allowedRoot, userPath);
-
-  // Resolve symlinks when the target exists
-  let real;
-  try {
-    real = fs.realpathSync(resolved);
-  } catch {
-    // Target doesn't exist yet (e.g. Write to new file) — use resolved
-    real = resolved;
-  }
-
-  // Normalise the root for prefix comparison
+  // Normalise the root via realpath for accurate comparison
   let normalizedRoot;
   try {
     normalizedRoot = fs.realpathSync(allowedRoot);
   } catch {
     normalizedRoot = path.resolve(allowedRoot);
+  }
+
+  // Resolve the real path.  For non-existent targets, walk up to the
+  // nearest existing ancestor and verify THAT is inside the root.
+  // This prevents symlink-parent escapes: if repo/link -> /external/,
+  // then repo/link/new.txt should be blocked because realpath(repo/link)
+  // resolves to /external/ which is outside the root.
+  let real;
+  try {
+    real = fs.realpathSync(resolved);
+  } catch {
+    // Target doesn't exist — resolve the nearest existing ancestor
+    let ancestor = path.dirname(resolved);
+    const leaf = path.basename(resolved);
+    try {
+      const realAncestor = fs.realpathSync(ancestor);
+      real = path.join(realAncestor, leaf);
+    } catch {
+      // Even the ancestor doesn't exist — use the raw resolved path
+      real = resolved;
+    }
   }
 
   // Ensure resolved path starts with root

--- a/server/utils/safePath.js
+++ b/server/utils/safePath.js
@@ -5,10 +5,14 @@
  * or "../../../etc/shadow". This module ensures every resolved path stays
  * within the designated project root, blocking prompt-injection attacks
  * that attempt to read or write files outside the workspace.
+ *
+ * Only the *logical* resolved path is checked (no `realpathSync`).  This
+ * means legitimate symlinks inside the project that point outside the root
+ * (e.g. `data -> /mnt/storage/data`) still work, while `..` traversal and
+ * absolute-path escapes are caught.
  */
 
 import path from 'path';
-import fs from 'fs';
 
 /**
  * Resolve `userPath` relative to `allowedRoot` and verify the result
@@ -17,9 +21,7 @@ import fs from 'fs';
  * - Absolute paths that land outside the root are rejected.
  * - Absolute paths inside the root are allowed (LLM may reference them).
  * - `..` components that climb above the root are rejected.
- * - Symlinks are resolved via `realpathSync` for existing targets.
- * - For non-existent targets, the nearest existing ancestor is resolved
- *   to prevent symlink-parent escapes on write operations.
+ * - Symlinks are NOT resolved — only the logical path is checked.
  *
  * @param {string} userPath  Path supplied by the tool call.
  * @param {string} allowedRoot  Project root directory.
@@ -27,60 +29,23 @@ import fs from 'fs';
  * @throws {Error}  If the path escapes `allowedRoot`.
  */
 export function safePath(userPath, allowedRoot) {
-  if (!userPath) return allowedRoot;
+  const normalizedRoot = path.resolve(allowedRoot);
 
-  // Resolve to absolute (works for both relative and absolute inputs)
+  if (!userPath) return normalizedRoot;
+
+  // Resolve to absolute (works for both relative and absolute inputs).
+  // path.resolve normalises away any `.` and `..` segments.
   const resolved = path.isAbsolute(userPath)
     ? path.resolve(userPath)
-    : path.resolve(allowedRoot, userPath);
-
-  // Normalise the root via realpath for accurate comparison
-  let normalizedRoot;
-  try {
-    normalizedRoot = fs.realpathSync(allowedRoot);
-  } catch {
-    normalizedRoot = path.resolve(allowedRoot);
-  }
-
-  // Resolve the real path.  For non-existent targets, walk up to the
-  // nearest existing ancestor and verify THAT is inside the root.
-  // This prevents symlink-parent escapes: if repo/link -> /external/,
-  // then repo/link/new.txt should be blocked because realpath(repo/link)
-  // resolves to /external/ which is outside the root.
-  let real;
-  try {
-    real = fs.realpathSync(resolved);
-  } catch {
-    // Target doesn't exist — walk up to the nearest existing ancestor
-    // and resolve it.  This catches symlink escapes at any depth:
-    // e.g. repo/link/missing/deep/file.txt where link -> /external/
-    let current = resolved;
-    const trailing = [];
-    while (current !== path.dirname(current)) {
-      try {
-        const realAncestor = fs.realpathSync(current);
-        real = path.join(realAncestor, ...trailing);
-        break;
-      } catch {
-        trailing.unshift(path.basename(current));
-        current = path.dirname(current);
-      }
-    }
-    // If we walked all the way to the filesystem root without finding
-    // an existing ancestor, use the raw resolved path (will likely fail
-    // on the subsequent fs operation anyway).
-    if (!real) {
-      real = resolved;
-    }
-  }
+    : path.resolve(normalizedRoot, userPath);
 
   // Ensure resolved path starts with root
-  if (real !== normalizedRoot && !real.startsWith(normalizedRoot + path.sep)) {
+  if (resolved !== normalizedRoot && !resolved.startsWith(normalizedRoot + path.sep)) {
     throw new Error(
-      `Path traversal blocked: "${userPath}" resolves to "${real}" ` +
+      `Path traversal blocked: "${userPath}" resolves to "${resolved}" ` +
       `which is outside the project root "${normalizedRoot}".`
     );
   }
 
-  return real;
+  return resolved;
 }

--- a/server/utils/safePath.js
+++ b/server/utils/safePath.js
@@ -51,14 +51,25 @@ export function safePath(userPath, allowedRoot) {
   try {
     real = fs.realpathSync(resolved);
   } catch {
-    // Target doesn't exist — resolve the nearest existing ancestor
-    let ancestor = path.dirname(resolved);
-    const leaf = path.basename(resolved);
-    try {
-      const realAncestor = fs.realpathSync(ancestor);
-      real = path.join(realAncestor, leaf);
-    } catch {
-      // Even the ancestor doesn't exist — use the raw resolved path
+    // Target doesn't exist — walk up to the nearest existing ancestor
+    // and resolve it.  This catches symlink escapes at any depth:
+    // e.g. repo/link/missing/deep/file.txt where link -> /external/
+    let current = resolved;
+    const trailing = [];
+    while (current !== path.dirname(current)) {
+      try {
+        const realAncestor = fs.realpathSync(current);
+        real = path.join(realAncestor, ...trailing);
+        break;
+      } catch {
+        trailing.unshift(path.basename(current));
+        current = path.dirname(current);
+      }
+    }
+    // If we walked all the way to the filesystem root without finding
+    // an existing ancestor, use the raw resolved path (will likely fail
+    // on the subsequent fs operation anyway).
+    if (!real) {
       real = resolved;
     }
   }

--- a/server/utils/safePath.js
+++ b/server/utils/safePath.js
@@ -1,0 +1,65 @@
+/**
+ * Safe path resolution that prevents directory traversal.
+ *
+ * Tool calls from LLM agents may contain crafted paths like "/etc/passwd"
+ * or "../../../etc/shadow". This module ensures every resolved path stays
+ * within the designated project root, blocking prompt-injection attacks
+ * that attempt to read or write files outside the workspace.
+ */
+
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Resolve `userPath` relative to `allowedRoot` and verify the result
+ * stays within `allowedRoot`.
+ *
+ * - Absolute paths are rejected (they would escape the root).
+ * - `..` components that climb above the root are rejected.
+ * - Symlinks are resolved via `realpathSync` when the target exists.
+ *
+ * @param {string} userPath  Path supplied by the tool call.
+ * @param {string} allowedRoot  Project root directory.
+ * @returns {string}  The resolved, validated absolute path.
+ * @throws {Error}  If the path escapes `allowedRoot`.
+ */
+export function safePath(userPath, allowedRoot) {
+  if (!userPath) return allowedRoot;
+
+  // Reject absolute paths outright — they ignore the root entirely
+  if (path.isAbsolute(userPath)) {
+    throw new Error(
+      `Path traversal blocked: absolute path "${userPath}" is not allowed. ` +
+      `All paths must be relative to the project root.`
+    );
+  }
+
+  const resolved = path.resolve(allowedRoot, userPath);
+
+  // Resolve symlinks when the target exists
+  let real;
+  try {
+    real = fs.realpathSync(resolved);
+  } catch {
+    // Target doesn't exist yet (e.g. Write to new file) — use resolved
+    real = resolved;
+  }
+
+  // Normalise the root for prefix comparison
+  let normalizedRoot;
+  try {
+    normalizedRoot = fs.realpathSync(allowedRoot);
+  } catch {
+    normalizedRoot = path.resolve(allowedRoot);
+  }
+
+  // Ensure resolved path starts with root
+  if (real !== normalizedRoot && !real.startsWith(normalizedRoot + path.sep)) {
+    throw new Error(
+      `Path traversal blocked: "${userPath}" resolves to "${real}" ` +
+      `which is outside the project root "${normalizedRoot}".`
+    );
+  }
+
+  return real;
+}


### PR DESCRIPTION
## Summary

Add `safePath()` utility to constrain all LLM-driven tool call paths within the project root, preventing prompt-injection attacks from reading or writing files outside the workspace.

## The vulnerability

When an LLM is prompt-injected (e.g., via a malicious README), it can generate tool calls like `Read({ path: "/etc/passwd" })` or `Read({ path: "../../../.ssh/id_rsa" })`. Since read-only tools (Read, Glob, Grep, LS) are auto-approved without user consent, the file contents are silently exfiltrated through the conversation.

## The fix

### New: `server/utils/safePath.js`

```javascript
safePath(userPath, allowedRoot) → string | throws Error
```

- **Absolute paths**: Allowed only if they resolve inside the project root
- **`..` traversal**: Resolved and verified to stay within root
- **Symlink escapes**: Resolved via `realpathSync`; for non-existent targets, walks up to the nearest existing ancestor to catch `repo/link/missing/deep/file.txt` where `link -> /external/`
- **Clear error messages**: `"Path traversal blocked: ... resolves to ... which is outside the project root"`

### Modified: `server/openrouter.js` + `server/cli-chat.js`

Replace the unconstrained `resolve()` function in both `executeTool()` implementations:

```javascript
// Before (vulnerable)
const resolve = (p) => path.isAbsolute(p) ? p : path.resolve(workingDir, p);

// After (safe)
const resolve = (p) => safePath(p, workingDir);
```

### Tests: 9 cases covering

- Relative paths within root ✅
- Empty/null/undefined input ✅
- Absolute paths inside root (allowed) ✅
- Absolute paths outside root (blocked) ✅
- `..` traversal above root (blocked) ✅
- Disguised `..` traversal (blocked) ✅
- `..` that stays within root (allowed) ✅
- Non-existent files and nested paths ✅

## Codex review (3 rounds)

1. Initial review → found symlink parent escape and absolute path rejection too strict
2. After fix → found nested missing segments under symlink still escapable
3. After fix → ancestor walk confirmed correct

## Note

This does NOT restrict `Bash` tool execution (which has its own permission model via `permissionMode`). It only constrains file-system tool calls (Read, Write, Edit, Glob, Grep, LS).