### PR TITLE
fix: use cross-spawn for Windows native runtime commands

### DIFF
--- a/electron/cli.mjs
+++ b/electron/cli.mjs
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import crossSpawn from 'cross-spawn';
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
@@ -8,6 +9,7 @@ const projectRoot = process.cwd();
 const electronGypDir = path.join(projectRoot, '.electron-gyp');
 const electronCacheDir = path.join(projectRoot, '.electron-cache');
 const electronHomeDir = path.join(projectRoot, '.electron-home');
+const spawnFunction = process.platform === 'win32' ? crossSpawn : spawn;
 
 fs.mkdirSync(electronGypDir, { recursive: true });
 fs.mkdirSync(electronCacheDir, { recursive: true });
@@ -30,7 +32,7 @@ function npxBin() {
 
 function run(bin, args, extraEnv = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(bin, args, {
+    const child = spawnFunction(bin, args, {
       cwd: projectRoot,
       env: {
         ...env,

--- a/scripts/native-runtime.mjs
+++ b/scripts/native-runtime.mjs
@@ -3,8 +3,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 import { createRequire } from 'node:module';
+import crossSpawn from 'cross-spawn';
 
 const require = createRequire(import.meta.url);
+const spawnFunction = process.platform === 'win32' ? crossSpawn : spawn;
 const command = process.argv[2];
 const projectRoot = process.cwd();
 const statePath = path.join(projectRoot, '.native-runtime.json');
@@ -40,7 +42,7 @@ function checkNodeModules() {
 
 function run(bin, args, extraEnv = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(bin, args, {
+    const child = spawnFunction(bin, args, {
       cwd: projectRoot,
       env: {
         ...process.env,


### PR DESCRIPTION
 ## Summary

  Fix Windows `spawn EINVAL` errors when preparing native runtime commands in development workflows.

  ## Cause

  On Windows, launching `.cmd` wrappers such as `npm.cmd` and `npx.cmd` through `child_process.spawn(..., { shell: false })` can fail with `spawn EINVAL`.

  ## Changes

  - use `cross-spawn` in `scripts/native-runtime.mjs`
  - use `cross-spawn` in `electron/cli.mjs`

  ## Verification

  - reproduced the failure on Windows with `node scripts/native-runtime.mjs node`
  - verified the command succeeds after this change
  - confirmed the native module rebuild step completes normally

  ## Notes

  This is a small Windows compatibility fix and does not change behavior on non-Windows platforms.