### PR TITLE
feat(chat): add Claude /btw side-question

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dr-claw",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dr-claw",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "hasInstallScript": true,
       "license": "(GPL-3.0-only AND AGPL-3.0-only)",
       "dependencies": {
@@ -177,7 +177,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -595,7 +594,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
       "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -610,7 +608,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
       "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -646,7 +643,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -668,7 +664,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.16.tgz",
       "integrity": "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1700,6 +1695,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1721,6 +1717,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1737,6 +1734,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1751,6 +1749,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3202,8 +3201,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lezer/css": {
       "version": "1.3.1",
@@ -3221,7 +3219,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -3820,7 +3817,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5160,7 +5156,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5464,8 +5459,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -5582,7 +5576,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6423,7 +6416,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7037,7 +7029,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -7554,7 +7545,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7593,7 +7585,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8006,7 +7997,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8458,7 +8448,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -8852,6 +8841,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8872,6 +8862,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9278,7 +9269,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10573,7 +10563,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10748,7 +10737,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14221,7 +14209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14379,6 +14366,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14396,6 +14384,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14697,7 +14686,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14710,7 +14698,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17143,7 +17130,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17343,6 +17329,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17406,6 +17393,7 @@
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17418,6 +17406,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17439,6 +17428,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17452,6 +17442,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -17466,6 +17457,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -17568,7 +17560,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17765,7 +17756,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18145,7 +18135,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18254,7 +18243,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18790,7 +18778,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -872,6 +872,71 @@ function getActiveClaudeSDKSessions() {
   return getAllSessions();
 }
 
+const BTW_SYSTEM_PROMPT = `You answer a short side question for someone in the middle of a coding session.
+
+Rules:
+- You have NO tools. Do not claim to read files, run commands, or fetch URLs unless that information already appears in the conversation context below.
+- Use the "Conversation context" section plus general programming knowledge. If something is not in the context, say you do not see it there.
+- Be concise.`;
+
+/**
+ * One-shot, tool-free side question (Claude Code /btw-style). Does not resume the main SDK session.
+ */
+async function runClaudeBtw({ question, transcript, cwd, model }) {
+  const safeTranscript =
+    typeof transcript === 'string' && transcript.trim()
+      ? transcript
+      : '(No prior conversation in this session.)';
+  const userBlock = `## Conversation context\n\n${safeTranscript}\n\n---\n\n## Side question\n\n${question}`;
+
+  const sdkOptions = {
+    cwd: cwd || process.cwd(),
+    model: model || CLAUDE_MODELS.DEFAULT,
+    tools: [],
+    allowedTools: [],
+    settingSources: [],
+    systemPrompt: BTW_SYSTEM_PROMPT,
+    permissionMode: 'default',
+  };
+
+  const prevStreamTimeout = process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
+  process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = '120000';
+
+  const queryInstance = query({
+    prompt: userBlock,
+    options: sdkOptions,
+  });
+
+  if (prevStreamTimeout !== undefined) {
+    process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = prevStreamTimeout;
+  } else {
+    delete process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
+  }
+
+  let answer = '';
+  let lastError = null;
+
+  try {
+    for await (const message of queryInstance) {
+      if (message.type === 'result') {
+        if (message.subtype === 'success') {
+          answer = message.result || answer;
+        } else {
+          lastError = Array.isArray(message.errors) ? message.errors.join('\n') : 'Side question failed';
+        }
+      }
+    }
+  } catch (err) {
+    throw new Error(err?.message || String(err));
+  }
+
+  if (lastError) {
+    throw new Error(lastError);
+  }
+
+  return { answer: answer || '' };
+}
+
 // Export public API
 export {
   queryClaudeSDK,
@@ -880,5 +945,6 @@ export {
   getClaudeSDKSessionStartTime,
   getActiveClaudeSDKSessions,
   resolveToolApproval,
-  getContextWindowForModel
+  getContextWindowForModel,
+  runClaudeBtw,
 };

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -882,7 +882,7 @@ Rules:
 /**
  * One-shot, tool-free side question (Claude Code /btw-style). Does not resume the main SDK session.
  */
-async function runClaudeBtw({ question, transcript, cwd, model }) {
+async function runClaudeBtw({ question, transcript, cwd, model, signal }) {
   const safeTranscript =
     typeof transcript === 'string' && transcript.trim()
       ? transcript
@@ -902,22 +902,19 @@ async function runClaudeBtw({ question, transcript, cwd, model }) {
   const prevStreamTimeout = process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
   process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = '120000';
 
-  const queryInstance = query({
-    prompt: userBlock,
-    options: sdkOptions,
-  });
-
-  if (prevStreamTimeout !== undefined) {
-    process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = prevStreamTimeout;
-  } else {
-    delete process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
-  }
-
   let answer = '';
   let lastError = null;
 
   try {
+    const queryInstance = query({
+      prompt: userBlock,
+      options: sdkOptions,
+    });
+
     for await (const message of queryInstance) {
+      if (signal?.aborted) {
+        break;
+      }
       if (message.type === 'result') {
         if (message.subtype === 'success') {
           answer = message.result || answer;
@@ -927,7 +924,20 @@ async function runClaudeBtw({ question, transcript, cwd, model }) {
       }
     }
   } catch (err) {
+    if (signal?.aborted) {
+      return { answer: '' };
+    }
     throw new Error(err?.message || String(err));
+  } finally {
+    if (prevStreamTimeout !== undefined) {
+      process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT = prevStreamTimeout;
+    } else {
+      delete process.env.CLAUDE_CODE_STREAM_CLOSE_TIMEOUT;
+    }
+  }
+
+  if (signal?.aborted) {
+    return { answer: '' };
   }
 
   if (lastError) {

--- a/server/index.js
+++ b/server/index.js
@@ -58,6 +58,7 @@ import cursorRoutes from './routes/cursor.js';
 import taskmasterRoutes from './routes/taskmaster.js';
 import mcpUtilsRoutes from './routes/mcp-utils.js';
 import commandsRoutes from './routes/commands.js';
+import claudeBtwRoutes from './routes/claude-btw.js';
 import settingsRoutes from './routes/settings.js';
 import agentRoutes from './routes/agent.js';
 import projectsRoutes, { WORKSPACES_ROOT, getWorkspacesRoot, validateWorkspacePath } from './routes/projects.js';
@@ -502,6 +503,9 @@ app.use('/api/mcp-utils', authenticateToken, mcpUtilsRoutes);
 
 // Commands API Routes (protected)
 app.use('/api/commands', authenticateToken, commandsRoutes);
+
+// Claude ephemeral side question (/btw)
+app.use('/api/claude', authenticateToken, claudeBtwRoutes);
 
 // Settings API Routes (protected)
 app.use('/api/settings', authenticateToken, settingsRoutes);

--- a/server/routes/claude-btw.js
+++ b/server/routes/claude-btw.js
@@ -3,6 +3,9 @@ import { runClaudeBtw } from '../claude-sdk.js';
 
 const router = express.Router();
 
+const MAX_QUESTION_CHARS = 2000;
+const MAX_TRANSCRIPT_CHARS = 150_000;
+
 /**
  * POST /api/claude/btw
  * Ephemeral side question (no tools, separate from main chat session).
@@ -14,22 +17,38 @@ router.post('/btw', async (req, res) => {
     if (!q) {
       return res.status(400).json({ error: 'question is required' });
     }
+    if (q.length > MAX_QUESTION_CHARS) {
+      return res.status(400).json({ error: `question exceeds ${MAX_QUESTION_CHARS} character limit` });
+    }
 
-    const text = typeof transcript === 'string' ? transcript : '';
+    const raw = typeof transcript === 'string' ? transcript : '';
+    const text = raw.length > MAX_TRANSCRIPT_CHARS ? raw.slice(raw.length - MAX_TRANSCRIPT_CHARS) : raw;
     const cwd = typeof projectPath === 'string' && projectPath.trim() ? projectPath.trim() : undefined;
     const modelId = typeof model === 'string' && model.trim() ? model.trim() : undefined;
+
+    const ac = new AbortController();
+    res.on('close', () => {
+      if (!res.writableFinished) {
+        ac.abort();
+      }
+    });
 
     const { answer } = await runClaudeBtw({
       question: q,
       transcript: text,
       cwd,
       model: modelId,
+      signal: ac.signal,
     });
 
-    res.json({ answer });
+    if (!res.headersSent) {
+      res.json({ answer });
+    }
   } catch (error) {
-    console.error('[ERROR] /api/claude/btw:', error.message);
-    res.status(500).json({ error: error.message || 'btw request failed' });
+    if (!res.headersSent) {
+      console.error('[ERROR] /api/claude/btw:', error.message);
+      res.status(500).json({ error: error.message || 'btw request failed' });
+    }
   }
 });
 

--- a/server/routes/claude-btw.js
+++ b/server/routes/claude-btw.js
@@ -1,0 +1,36 @@
+import express from 'express';
+import { runClaudeBtw } from '../claude-sdk.js';
+
+const router = express.Router();
+
+/**
+ * POST /api/claude/btw
+ * Ephemeral side question (no tools, separate from main chat session).
+ */
+router.post('/btw', async (req, res) => {
+  try {
+    const { question, transcript, projectPath, model } = req.body || {};
+    const q = typeof question === 'string' ? question.trim() : '';
+    if (!q) {
+      return res.status(400).json({ error: 'question is required' });
+    }
+
+    const text = typeof transcript === 'string' ? transcript : '';
+    const cwd = typeof projectPath === 'string' && projectPath.trim() ? projectPath.trim() : undefined;
+    const modelId = typeof model === 'string' && model.trim() ? model.trim() : undefined;
+
+    const { answer } = await runClaudeBtw({
+      question: q,
+      transcript: text,
+      cwd,
+      model: modelId,
+    });
+
+    res.json({ answer });
+  } catch (error) {
+    console.error('[ERROR] /api/claude/btw:', error.message);
+    res.status(500).json({ error: error.message || 'btw request failed' });
+  }
+});
+
+export default router;

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -126,6 +126,12 @@ const builtInCommands = [
     description: 'Rewind the conversation to a previous state',
     namespace: 'builtin',
     metadata: { type: 'builtin' }
+  },
+  {
+    name: '/btw',
+    description: 'Ask a quick side question in an overlay (Claude only; does not add to chat history)',
+    namespace: 'builtin',
+    metadata: { type: 'builtin' }
   }
 ];
 
@@ -396,7 +402,25 @@ Custom commands can be created in:
         message: `Rewinding conversation by ${steps} step${steps > 1 ? 's' : ''}...`
       }
     };
-  }
+  },
+
+  '/btw': async (args) => {
+    const question = args.join(' ').trim();
+    if (!question) {
+      return {
+        type: 'builtin',
+        action: 'btw',
+        data: {
+          error: 'Usage: /btw <your question>',
+        },
+      };
+    }
+    return {
+      type: 'builtin',
+      action: 'btw',
+      data: { question },
+    };
+  },
 };
 
 /**

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -43,6 +43,14 @@ import { isAutoResearchScenario } from '../utils/autoResearch';
 import type { SessionMode } from '../../../types/app';
 import type { BtwOverlayState } from '../view/subcomponents/BtwOverlay';
 
+const CLOSED_BTW_OVERLAY: BtwOverlayState = {
+  open: false,
+  question: '',
+  answer: '',
+  loading: false,
+  error: null,
+};
+
 type PendingViewSession = {
   sessionId: string | null;
   startedAt: number;
@@ -196,8 +204,12 @@ function buildBtwTranscript(messages: ChatMessage[]): string {
   }
   let out = lines.join('\n\n');
   if (out.length > BTW_TRANSCRIPT_MAX_CHARS) {
-    out = out.slice(out.length - BTW_TRANSCRIPT_MAX_CHARS);
-    out = '…(earlier messages omitted)\n\n' + out;
+    let cutPos = out.length - BTW_TRANSCRIPT_MAX_CHARS;
+    const nextBoundary = out.indexOf('\n\n', cutPos);
+    if (nextBoundary !== -1 && nextBoundary < cutPos + 2000) {
+      cutPos = nextBoundary + 2;
+    }
+    out = '…(earlier messages omitted)\n\n' + out.slice(cutPos);
   }
   return out;
 }
@@ -299,21 +311,12 @@ export function useChatComposerState({
     }
   });
   const [intakeGreeting, setIntakeGreeting] = useState<string | null>(null);
-  const [btwOverlay, setBtwOverlay] = useState<BtwOverlayState>({
-    open: false,
-    question: '',
-    answer: '',
-    loading: false,
-    error: null,
-  });
+  const [btwOverlay, setBtwOverlay] = useState<BtwOverlayState>(CLOSED_BTW_OVERLAY);
+  const btwAbortRef = useRef<AbortController | null>(null);
   const closeBtwOverlay = useCallback(() => {
-    setBtwOverlay({
-      open: false,
-      question: '',
-      answer: '',
-      loading: false,
-      error: null,
-    });
+    btwAbortRef.current?.abort();
+    btwAbortRef.current = null;
+    setBtwOverlay(CLOSED_BTW_OVERLAY);
   }, []);
   const [pendingStageTagKeys, setPendingStageTagKeys] = useState<string[]>([]);
   const [attachedPrompt, setAttachedPrompt] = useState<AttachedPrompt | null>(null);
@@ -604,6 +607,9 @@ export function useChatComposerState({
           if (!question) {
             return;
           }
+          btwAbortRef.current?.abort();
+          const abortController = new AbortController();
+          btwAbortRef.current = abortController;
           setBtwOverlay({
             open: true,
             question,
@@ -624,6 +630,7 @@ export function useChatComposerState({
                 projectPath: selectedProject.fullPath || selectedProject.path,
                 model: claudeModel,
               }),
+              signal: abortController.signal,
             });
             const payload = (await btwResponse.json().catch(() => ({}))) as {
               answer?: string;
@@ -640,6 +647,9 @@ export function useChatComposerState({
               error: null,
             }));
           } catch (btwErr) {
+            if (abortController.signal.aborted) {
+              return;
+            }
             const msg = btwErr instanceof Error ? btwErr.message : 'Unknown error';
             setBtwOverlay((previous) => ({
               ...previous,
@@ -935,6 +945,9 @@ export function useChatComposerState({
         const matchedCommand = slashCommands.find((command: SlashCommand) => command.name === commandName);
 
         if (matchedCommand) {
+          if (isLoading && commandName !== '/btw') {
+            return;
+          }
           await executeCommand(matchedCommand, trimmedInput);
           setInput('');
           inputValueRef.current = '';

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -41,6 +41,7 @@ import type { Project, ProjectSession, SessionProvider } from '../../../types/ap
 import { escapeRegExp } from '../utils/chatFormatting';
 import { isAutoResearchScenario } from '../utils/autoResearch';
 import type { SessionMode } from '../../../types/app';
+import type { BtwOverlayState } from '../view/subcomponents/BtwOverlay';
 
 type PendingViewSession = {
   sessionId: string | null;
@@ -79,6 +80,8 @@ interface UseChatComposerStateArgs {
   setIsUserScrolledUp: (isScrolledUp: boolean) => void;
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
   newSessionMode?: SessionMode;
+  /** Current chat messages for /btw context (Claude provider). */
+  getChatMessagesForBtw?: () => ChatMessage[];
 }
 
 interface MentionableFile {
@@ -175,6 +178,30 @@ function formatRejectedFileMessage(rejection: FileRejection) {
 const isTemporarySessionId = (sessionId: string | null | undefined) =>
   Boolean(sessionId && sessionId.startsWith('new-session-'));
 
+const BTW_TRANSCRIPT_MAX_CHARS = 120_000;
+
+function buildBtwTranscript(messages: ChatMessage[]): string {
+  const lines: string[] = [];
+  for (const m of messages) {
+    if (m.type !== 'user' && m.type !== 'assistant') {
+      continue;
+    }
+    const raw = typeof m.content === 'string' ? m.content : '';
+    const text = raw.trim();
+    if (!text) {
+      continue;
+    }
+    const label = m.type === 'user' ? 'User' : 'Assistant';
+    lines.push(`${label}: ${text}`);
+  }
+  let out = lines.join('\n\n');
+  if (out.length > BTW_TRANSCRIPT_MAX_CHARS) {
+    out = out.slice(out.length - BTW_TRANSCRIPT_MAX_CHARS);
+    out = '…(earlier messages omitted)\n\n' + out;
+  }
+  return out;
+}
+
 const getRouteSessionId = () => {
   if (typeof window === 'undefined') {
     return null;
@@ -224,6 +251,7 @@ export function useChatComposerState({
   setIsUserScrolledUp,
   setPendingPermissionRequests,
   newSessionMode = 'research',
+  getChatMessagesForBtw,
 }: UseChatComposerStateArgs) {
   const { t } = useTranslation('chat');
   const [input, setInput] = useState(() => {
@@ -271,6 +299,22 @@ export function useChatComposerState({
     }
   });
   const [intakeGreeting, setIntakeGreeting] = useState<string | null>(null);
+  const [btwOverlay, setBtwOverlay] = useState<BtwOverlayState>({
+    open: false,
+    question: '',
+    answer: '',
+    loading: false,
+    error: null,
+  });
+  const closeBtwOverlay = useCallback(() => {
+    setBtwOverlay({
+      open: false,
+      question: '',
+      answer: '',
+      loading: false,
+      error: null,
+    });
+  }, []);
   const [pendingStageTagKeys, setPendingStageTagKeys] = useState<string[]>([]);
   const [attachedPrompt, setAttachedPrompt] = useState<AttachedPrompt | null>(null);
 
@@ -529,6 +573,83 @@ export function useChatComposerState({
         }
 
         const result = (await response.json()) as CommandExecutionResult;
+        if (result.type === 'builtin' && result.action === 'btw') {
+          const { data } = result;
+          setInput('');
+          inputValueRef.current = '';
+          if (data?.error) {
+            setChatMessages((previous) => [
+              ...previous,
+              {
+                type: 'assistant',
+                content: `⚠️ ${data.error}`,
+                timestamp: Date.now(),
+              },
+            ]);
+            return;
+          }
+          if (provider !== 'claude') {
+            setChatMessages((previous) => [
+              ...previous,
+              {
+                type: 'assistant',
+                content:
+                  '`/btw` is only available with the Claude Code provider. Switch to Claude in the chat controls, then try again.',
+                timestamp: Date.now(),
+              },
+            ]);
+            return;
+          }
+          const question = typeof data?.question === 'string' ? data.question.trim() : '';
+          if (!question) {
+            return;
+          }
+          setBtwOverlay({
+            open: true,
+            question,
+            answer: '',
+            loading: true,
+            error: null,
+          });
+          try {
+            const transcript = buildBtwTranscript(getChatMessagesForBtw?.() ?? []);
+            const btwResponse = await authenticatedFetch('/api/claude/btw', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                question,
+                transcript,
+                projectPath: selectedProject.fullPath || selectedProject.path,
+                model: claudeModel,
+              }),
+            });
+            const payload = (await btwResponse.json().catch(() => ({}))) as {
+              answer?: string;
+              error?: string;
+              message?: string;
+            };
+            if (!btwResponse.ok) {
+              throw new Error(payload?.error || payload?.message || `Request failed (${btwResponse.status})`);
+            }
+            setBtwOverlay((previous) => ({
+              ...previous,
+              loading: false,
+              answer: typeof payload.answer === 'string' ? payload.answer : '',
+              error: null,
+            }));
+          } catch (btwErr) {
+            const msg = btwErr instanceof Error ? btwErr.message : 'Unknown error';
+            setBtwOverlay((previous) => ({
+              ...previous,
+              loading: false,
+              error: msg,
+              answer: '',
+            }));
+          }
+          return;
+        }
         if (result.type === 'builtin') {
           handleBuiltInCommand(result);
           setInput('');
@@ -554,6 +675,7 @@ export function useChatComposerState({
       codexModel,
       currentSessionId,
       cursorModel,
+      getChatMessagesForBtw,
       handleBuiltInCommand,
       handleCustomCommand,
       input,
@@ -799,7 +921,10 @@ export function useChatComposerState({
     ) => {
       event.preventDefault();
       const currentInput = inputValueRef.current;
-      if ((!currentInput.trim() && attachedFiles.length === 0 && !attachedPrompt) || isLoading || !selectedProject) {
+      if (!selectedProject) {
+        return;
+      }
+      if (!currentInput.trim() && attachedFiles.length === 0 && !attachedPrompt) {
         return;
       }
 
@@ -824,6 +949,10 @@ export function useChatComposerState({
           }
           return;
         }
+      }
+
+      if (isLoading) {
+        return;
       }
 
       const normalizedInput =
@@ -1674,5 +1803,7 @@ export function useChatComposerState({
     setIntakeGreeting,
     setPendingStageTagKeys,
     submitProgrammaticInput,
+    btwOverlay,
+    closeBtwOverlay,
   };
 }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -6,6 +6,7 @@ import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { useTranslation } from 'react-i18next';
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
+import BtwOverlay from './subcomponents/BtwOverlay';
 import ChatContextSidebar from './subcomponents/ChatContextSidebar';
 import ChatContextFilePreview, { type PreviewFileTarget } from './subcomponents/ChatContextFilePreview';
 import GuidedPromptStarter from './subcomponents/GuidedPromptStarter';
@@ -237,6 +238,10 @@ function ChatInterface({
     pendingViewSessionRef,
   });
 
+  const chatMessagesForBtwRef = useRef(chatMessages);
+  chatMessagesForBtwRef.current = chatMessages;
+  const getChatMessagesForBtw = useCallback(() => chatMessagesForBtwRef.current, []);
+
   const {
     input,
     setInput,
@@ -325,7 +330,7 @@ function ChatInterface({
     setIsUserScrolledUp,
     setPendingPermissionRequests,
     newSessionMode,
-    getChatMessagesForBtw: () => chatMessages,
+    getChatMessagesForBtw,
   });
 
   useChatRealtimeHandlers({
@@ -354,11 +359,8 @@ function ChatInterface({
     onNavigateToSession,
   });
 
-  const chatMessagesRef = useRef(chatMessages);
-  chatMessagesRef.current = chatMessages;
-
   const handleRetry = useCallback(() => {
-    const msgs = chatMessagesRef.current;
+    const msgs = chatMessagesForBtwRef.current;
     let lastUserMessage: (typeof msgs)[number] | undefined;
     for (let i = msgs.length - 1; i >= 0; i--) {
       if (msgs[i].type === 'user') { lastUserMessage = msgs[i]; break; }
@@ -935,8 +937,6 @@ function ChatInterface({
           providerAvailability={providerAvailability}
           newSessionMode={newSessionMode}
           onNewSessionModeChange={onNewSessionModeChange}
-          btwOverlay={btwOverlay}
-          onCloseBtwOverlay={closeBtwOverlay}
         />
 
         {isEmpty && newSessionMode === 'research' && (
@@ -1024,6 +1024,7 @@ function ChatInterface({
       )}
 
       <QuickSettingsPanel />
+      <BtwOverlay state={btwOverlay} onClose={closeBtwOverlay} />
     </>
   );
 }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -291,6 +291,8 @@ function ChatInterface({
     setIntakeGreeting,
     setPendingStageTagKeys,
     submitProgrammaticInput,
+    btwOverlay,
+    closeBtwOverlay,
   } = useChatComposerState({
     selectedProject,
     selectedSession,
@@ -323,6 +325,7 @@ function ChatInterface({
     setIsUserScrolledUp,
     setPendingPermissionRequests,
     newSessionMode,
+    getChatMessagesForBtw: () => chatMessages,
   });
 
   useChatRealtimeHandlers({
@@ -932,6 +935,8 @@ function ChatInterface({
           providerAvailability={providerAvailability}
           newSessionMode={newSessionMode}
           onNewSessionModeChange={onNewSessionModeChange}
+          btwOverlay={btwOverlay}
+          onCloseBtwOverlay={closeBtwOverlay}
         />
 
         {isEmpty && newSessionMode === 'research' && (

--- a/src/components/chat/view/subcomponents/BtwOverlay.tsx
+++ b/src/components/chat/view/subcomponents/BtwOverlay.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from 'react';
+import { Markdown } from './Markdown';
+
+export type BtwOverlayState = {
+  open: boolean;
+  question: string;
+  answer: string;
+  loading: boolean;
+  error: string | null;
+};
+
+type BtwOverlayProps = {
+  state: BtwOverlayState;
+  onClose: () => void;
+};
+
+export default function BtwOverlay({ state, onClose }: BtwOverlayProps) {
+  const { open, question, answer, loading, error } = state;
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.repeat) {
+        return;
+      }
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      onClose();
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/50 backdrop-blur-[2px]"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="btw-overlay-title"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="w-full max-w-lg max-h-[min(80vh,560px)] flex flex-col rounded-2xl border border-border/60 bg-card shadow-xl">
+        <div className="flex items-start justify-between gap-3 px-4 pt-4 pb-2 border-b border-border/40">
+          <div className="min-w-0">
+            <h2 id="btw-overlay-title" className="text-sm font-semibold text-foreground">
+              Side question
+            </h2>
+            <p className="text-xs text-muted-foreground mt-0.5">Esc to close · not saved to chat</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-lg p-1.5 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-4 py-3 text-sm text-foreground/90 border-b border-border/30 bg-muted/20">
+          <span className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Question</span>
+          <p className="mt-1 whitespace-pre-wrap break-words">{question}</p>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3 text-sm min-h-[120px]">
+          {loading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <span className="inline-block h-4 w-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+              Thinking…
+            </div>
+          )}
+          {!loading && error && <p className="text-destructive whitespace-pre-wrap">{error}</p>}
+          {!loading && !error && answer && (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <Markdown>{answer}</Markdown>
+            </div>
+          )}
+          {!loading && !error && !answer && <p className="text-muted-foreground">No response.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -4,7 +4,7 @@ import { MicButton } from '../../../MicButton.jsx';
 import ImageAttachment from './ImageAttachment';
 import PermissionRequestsBanner from './PermissionRequestsBanner';
 import ChatInputControls from './ChatInputControls';
-import BtwOverlay, { type BtwOverlayState } from './BtwOverlay';
+
 import ReferencePicker from '../../../references/view/ReferencePicker';
 import PromptBadgeDropdown from './PromptBadgeDropdown';
 import { Plus } from 'lucide-react';
@@ -170,17 +170,7 @@ interface ChatComposerProps {
   providerAvailability?: Record<SessionProvider, ProviderAvailability>;
   newSessionMode?: SessionMode;
   onNewSessionModeChange?: (mode: SessionMode) => void;
-  btwOverlay?: BtwOverlayState;
-  onCloseBtwOverlay?: () => void;
 }
-
-const CLOSED_BTW_OVERLAY: BtwOverlayState = {
-  open: false,
-  question: '',
-  answer: '',
-  loading: false,
-  error: null,
-};
 
 export default function ChatComposer({
   pendingPermissionRequests,
@@ -265,8 +255,6 @@ export default function ChatComposer({
   providerAvailability,
   newSessionMode,
   onNewSessionModeChange,
-  btwOverlay = CLOSED_BTW_OVERLAY,
-  onCloseBtwOverlay = () => undefined,
 }: ChatComposerProps) {
   const { t } = useTranslation('chat');
   const [showReferencePicker, setShowReferencePicker] = useState(false);
@@ -368,7 +356,6 @@ export default function ChatComposer({
   ];
 
   return (
-    <>
     <div className={`p-2 sm:p-4 md:p-4 flex-shrink-0 ${centered ? 'pb-2 sm:pb-3' : 'pb-2 sm:pb-4 md:pb-6'} ${mobileFloatingClass}`}>
       <div className={`${centered ? 'max-w-3xl' : 'max-w-5xl'} mx-auto mb-3`}>
         <PermissionRequestsBanner
@@ -520,13 +507,9 @@ export default function ChatComposer({
               onBlur={() => onInputFocusChange?.(false)}
               onInput={onTextareaInput}
               placeholder={placeholder}
-              disabled={isLoading && !input.trim().startsWith('/btw ')}
-              className={`chat-input-placeholder block w-full pl-5 ${centered ? 'pr-16 pt-4 pb-2 min-h-[72px] max-h-[200px] text-sm' : 'pr-20 sm:pr-40 py-1.5 sm:py-4 min-h-[50px] sm:min-h-[80px] max-h-[40vh] sm:max-h-[300px] text-base'} bg-transparent rounded-3xl focus:outline-none text-foreground placeholder-muted-foreground/50 disabled:opacity-50 resize-none overflow-y-auto leading-6 transition-all duration-200`}
+              className={`chat-input-placeholder block w-full pl-5 ${centered ? 'pr-16 pt-4 pb-2 min-h-[72px] max-h-[200px] text-sm' : 'pr-20 sm:pr-40 py-1.5 sm:py-4 min-h-[50px] sm:min-h-[80px] max-h-[40vh] sm:max-h-[300px] text-base'} bg-transparent rounded-3xl focus:outline-none text-foreground placeholder-muted-foreground/50 resize-none overflow-y-auto leading-6 transition-all duration-200 ${isLoading && !input.trim().startsWith('/') ? 'opacity-50' : ''}`}
               style={{ height: centered ? '72px' : '50px' }}
             />
-
-
-
             <div className={`absolute ${centered ? 'right-11' : 'right-14'} top-1/2 transform -translate-y-1/2`}>
               <MicButton onTranscript={onTranscript} className={centered ? '!w-7 !h-7' : '!w-9 !h-9'} />
             </div>
@@ -535,7 +518,7 @@ export default function ChatComposer({
               type="submit"
               disabled={
                 (!input.trim() && attachedFiles.length === 0 && !attachedPrompt) ||
-                (isLoading && !input.trim().startsWith('/'))
+                (isLoading && !input.trim().startsWith('/btw '))
               }
               onMouseDown={(event) => {
                 event.preventDefault();
@@ -689,7 +672,5 @@ export default function ChatComposer({
         </div>
       </form>}
     </div>
-    <BtwOverlay state={btwOverlay} onClose={onCloseBtwOverlay} />
-    </>
   );
 }

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -4,6 +4,7 @@ import { MicButton } from '../../../MicButton.jsx';
 import ImageAttachment from './ImageAttachment';
 import PermissionRequestsBanner from './PermissionRequestsBanner';
 import ChatInputControls from './ChatInputControls';
+import BtwOverlay, { type BtwOverlayState } from './BtwOverlay';
 import ReferencePicker from '../../../references/view/ReferencePicker';
 import PromptBadgeDropdown from './PromptBadgeDropdown';
 import { Plus } from 'lucide-react';
@@ -155,7 +156,6 @@ interface ChatComposerProps {
   onUpdateAttachedPrompt: (promptText: string) => void;
   centered?: boolean;
   setAttachedPrompt?: (prompt: AttachedPrompt | null) => void;
-  // Provider selection props
   setProvider?: (next: SessionProvider) => void;
   claudeModel?: string;
   setClaudeModel?: (model: string) => void;
@@ -170,7 +170,17 @@ interface ChatComposerProps {
   providerAvailability?: Record<SessionProvider, ProviderAvailability>;
   newSessionMode?: SessionMode;
   onNewSessionModeChange?: (mode: SessionMode) => void;
+  btwOverlay?: BtwOverlayState;
+  onCloseBtwOverlay?: () => void;
 }
+
+const CLOSED_BTW_OVERLAY: BtwOverlayState = {
+  open: false,
+  question: '',
+  answer: '',
+  loading: false,
+  error: null,
+};
 
 export default function ChatComposer({
   pendingPermissionRequests,
@@ -255,6 +265,8 @@ export default function ChatComposer({
   providerAvailability,
   newSessionMode,
   onNewSessionModeChange,
+  btwOverlay = CLOSED_BTW_OVERLAY,
+  onCloseBtwOverlay = () => undefined,
 }: ChatComposerProps) {
   const { t } = useTranslation('chat');
   const [showReferencePicker, setShowReferencePicker] = useState(false);
@@ -356,6 +368,7 @@ export default function ChatComposer({
   ];
 
   return (
+    <>
     <div className={`p-2 sm:p-4 md:p-4 flex-shrink-0 ${centered ? 'pb-2 sm:pb-3' : 'pb-2 sm:pb-4 md:pb-6'} ${mobileFloatingClass}`}>
       <div className={`${centered ? 'max-w-3xl' : 'max-w-5xl'} mx-auto mb-3`}>
         <PermissionRequestsBanner
@@ -507,7 +520,7 @@ export default function ChatComposer({
               onBlur={() => onInputFocusChange?.(false)}
               onInput={onTextareaInput}
               placeholder={placeholder}
-              disabled={isLoading}
+              disabled={isLoading && !input.trim().startsWith('/btw ')}
               className={`chat-input-placeholder block w-full pl-5 ${centered ? 'pr-16 pt-4 pb-2 min-h-[72px] max-h-[200px] text-sm' : 'pr-20 sm:pr-40 py-1.5 sm:py-4 min-h-[50px] sm:min-h-[80px] max-h-[40vh] sm:max-h-[300px] text-base'} bg-transparent rounded-3xl focus:outline-none text-foreground placeholder-muted-foreground/50 disabled:opacity-50 resize-none overflow-y-auto leading-6 transition-all duration-200`}
               style={{ height: centered ? '72px' : '50px' }}
             />
@@ -520,7 +533,10 @@ export default function ChatComposer({
 
             <button
               type="submit"
-              disabled={(!input.trim() && attachedFiles.length === 0 && !attachedPrompt) || isLoading}
+              disabled={
+                (!input.trim() && attachedFiles.length === 0 && !attachedPrompt) ||
+                (isLoading && !input.trim().startsWith('/'))
+              }
               onMouseDown={(event) => {
                 event.preventDefault();
                 onSubmit(event);
@@ -673,5 +689,7 @@ export default function ChatComposer({
         </div>
       </form>}
     </div>
+    <BtwOverlay state={btwOverlay} onClose={onCloseBtwOverlay} />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Adds a Claude Code–style `/btw` side question: one-shot, tool-free answer in an overlay from current chat context, without appending to the main transcript. Only when the chat provider is **Claude**.

## Changes
- `runClaudeBtw` + `POST /api/claude/btw`
- Built-in `/btw` in commands API
- `BtwOverlay` UI; slash commands can run while the model is streaming (textarea not disabled for `/…`)

## Notes
- Other harnesses (Cursor, Codex, Gemini, etc.) still show the in-chat hint to switch to Claude.