### PR TITLE
fix: index CLI-created Claude sessions into Web UI

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,7 @@ import pty from 'node-pty';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 
-import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache } from './projects.js';
+import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, reconcileClaudeSessionIndex } from './projects.js';
 import { getProjectTokenUsageSummary } from './project-token-usage.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, resolveToolApproval, getContextWindowForModel } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getCursorSessionStartTime, getActiveCursorSessions } from './cursor-cli.js';
@@ -108,6 +108,7 @@ const connectedClients = new Set();
 let isGetProjectsRunning = false; // Flag to prevent reentrant calls
 let hasPendingProjectsUpdate = false;
 let lastWatcherEvent = null;
+let pendingClaudeSessionEvents = [];
 let lastProjectsUpdateSignature = '';
 
 function shouldProcessProjectsWatcherEvent(eventType, filePath, provider) {
@@ -160,11 +161,12 @@ async function setupProjectsWatcher() {
             try {
                 await watcher.close();
             } catch (error) {
-                console.error('[WARN] Failed to close watcher:', error);
+                console.warn('[WARN] Failed to close watcher:', error);
             }
         })
     );
     projectsWatchers = [];
+    pendingClaudeSessionEvents = [];
 
     const debouncedUpdate = (eventType, filePath, provider, rootPath) => {
         if (!shouldProcessProjectsWatcherEvent(eventType, filePath, provider)) {
@@ -172,6 +174,15 @@ async function setupProjectsWatcher() {
         }
 
         lastWatcherEvent = { eventType, filePath, provider, rootPath };
+
+        // Accumulate Claude .jsonl events during debounce window
+        if (provider === 'claude' && (eventType === 'add' || eventType === 'change') && filePath.endsWith('.jsonl')) {
+            const sessionId = path.basename(filePath, '.jsonl');
+            const projectName = path.basename(path.dirname(filePath));
+            if (!sessionId.startsWith('agent-') && /^[\w-]+$/.test(sessionId) && projectName && projectName !== '.' && projectName !== '..') {
+                pendingClaudeSessionEvents.push({ projectName, sessionId });
+            }
+        }
 
         if (projectsWatcherDebounceTimer) {
             clearTimeout(projectsWatcherDebounceTimer);
@@ -190,6 +201,16 @@ async function setupProjectsWatcher() {
 
                 // Clear project directory cache when files change
                 clearProjectDirectoryCache();
+
+                // Index CLI-created sessions accumulated during debounce window
+                const eventsToProcess = pendingClaudeSessionEvents.splice(0);
+                for (const { projectName, sessionId } of eventsToProcess) {
+                    try {
+                        await reconcileClaudeSessionIndex(projectName, sessionId);
+                    } catch (err) {
+                        console.warn(`[WARN] Failed to reconcile session ${sessionId} for ${projectName}:`, err.message);
+                    }
+                }
 
                 // Get updated projects list
                 const updatedProjects = await getProjects();
@@ -3139,6 +3160,25 @@ async function startServer() {
         // Ensure the workspaces root directory exists
         const startupWorkspaceRoot = await getWorkspacesRoot();
         await fsPromises.mkdir(startupWorkspaceRoot, { recursive: true });
+
+        // Reconcile CLI-created sessions on startup
+        try {
+            const allProjects = await getProjects();
+            let reconciledCount = 0;
+            for (const project of allProjects) {
+                if (project.name) {
+                    try {
+                        await reconcileClaudeSessionIndex(project.name);
+                        reconciledCount++;
+                    } catch (err) {
+                        console.warn(`[WARN] Failed to reconcile sessions for project ${project.name}:`, err.message);
+                    }
+                }
+            }
+            console.log(`${c.ok('[OK]')}   Reconciled session index for ${reconciledCount}/${allProjects.length} projects`);
+        } catch (err) {
+            console.warn('[WARN] Failed to reconcile sessions on startup:', err.message);
+        }
 
         // Start watching the projects folder for changes
         await setupProjectsWatcher();

--- a/server/projects.js
+++ b/server/projects.js
@@ -1172,7 +1172,7 @@ async function reconcileClaudeSessionIndex(projectName, targetSessionId = null) 
     };
   }
 
-  return getSessions(projectName, 0, 0);
+  return getSessions(projectName, 0, Infinity);
 }
 
 async function reconcileGeminiSessionIndex(projectPath, options = {}) {


### PR DESCRIPTION
## Summary

Supersedes #93 — rebased on latest main and addresses all review feedback.

CLI sessions created via the `claude` binary were not visible in the Web UI because they bypass the dr-claw server and write `.jsonl` files directly to `~/.claude/projects/`. This PR adds two hooks to index them:

- **Startup reconcile**: on server boot, scan all registered projects and index any existing CLI sessions into the database
- **File watcher accumulation**: during the debounce window, accumulate `.jsonl` change events and call `reconcileClaudeSessionIndex()` for each before broadcasting

## Changes from #93

All review feedback from @Zhang-Henry addressed:

| Feedback | Fix |
|----------|-----|
| Single `reconcileClaudeSessionIndex` failure aborts entire batch | Per-item try/catch in both watcher and startup loops |
| `pendingClaudeSessionEvents` not cleared on watcher reinit | Reset alongside `projectsWatchers = []` |
| `projectName` path traversal (`.`, `..`) | Explicit guard before pushing event |
| Temp files (`.#session.jsonl`) pass through | `sessionId` validated with `/^[\w-]+$/` regex |
| `console.error('[WARN]')` inconsistency | All warnings use `console.warn` |
| Startup log shows total count even if some failed | Track `reconciledCount` separately |

Additionally fixed: `reconcileClaudeSessionIndex()` full-scan passed `limit=0` to `getSessions()`, which triggered the early-exit optimization immediately (`allSessions.size >= 0` is always true). Changed to `limit=Infinity` so full scans read all `.jsonl` files.

## Test plan

- [ ] Register a project via Web UI
- [ ] Open a CLI session in that project directory (`cd /path/to/project && claude`)
- [ ] Chat briefly, then exit the CLI session
- [ ] Verify the CLI session appears in the Web UI without manual refresh
- [ ] Restart the server and verify CLI sessions still appear
- [ ] Verify existing Web UI sessions are not affected (display name, starred status preserved)
- [ ] Create two CLI sessions rapidly (within 1 second) and verify both appear