### PR TITLE
feat(autoresearch): add Dr. Claw research pack

### DIFF
--- a/server/routes/community-tools.js
+++ b/server/routes/community-tools.js
@@ -121,27 +121,28 @@ router.post('/configure', async (req, res) => {
     // ── Step 2: Register MCP server ──
     if (mcpBackend) {
       try {
-        // Check if already registered
-        let alreadyRegistered = false;
-        try {
-          const { stdout } = await spawnAsync('claude', ['mcp', 'list'], { env: EXTENDED_ENV });
-          alreadyRegistered = stdout.includes(mcpBackend);
-        } catch {
-          // claude mcp list failed, proceed with registration
-        }
+        const mcpCommands = {
+          codex: ['mcp', 'add', 'codex', '-s', 'user', '--', 'codex', 'mcp-server'],
+          'llm-chat': ['mcp', 'add', 'llm-chat', '-s', 'user', '--', 'python3', path.join(resolvedPath, 'skills/aris-infra/mcp-servers/llm-chat/server.py')],
+          gemini: ['mcp', 'add', 'gemini-review', '-s', 'user', '--', 'python3', path.join(resolvedPath, 'skills/aris-infra/mcp-servers/gemini-review/server.py')],
+        };
 
-        if (alreadyRegistered) {
-          results.steps.push({ step: 'mcp', status: 'skipped', message: `${mcpBackend} MCP already registered` });
+        const args = mcpCommands[mcpBackend];
+        if (!args) {
+          // No MCP server to register (env-only config like gemini-figure)
+          results.steps.push({ step: 'mcp', status: 'skipped', message: `No MCP server needed for ${mcpBackend}` });
         } else {
-          const mcpCommands = {
-            codex: ['mcp', 'add', 'codex', '-s', 'user', '--', 'codex', 'mcp-server'],
-            'llm-chat': ['mcp', 'add', 'llm-chat', '-s', 'user', '--', 'python3', path.join(resolvedPath, 'skills/aris-infra/mcp-servers/llm-chat/server.py')],
-            gemini: ['mcp', 'add', 'gemini-review', '-s', 'user', '--', 'python3', path.join(resolvedPath, 'skills/aris-infra/mcp-servers/gemini-review/server.py')],
-          };
+          // Check if already registered
+          let alreadyRegistered = false;
+          try {
+            const { stdout } = await spawnAsync('claude', ['mcp', 'list'], { env: EXTENDED_ENV });
+            alreadyRegistered = stdout.includes(mcpBackend);
+          } catch {
+            // claude mcp list failed, proceed with registration
+          }
 
-          const args = mcpCommands[mcpBackend];
-          if (!args) {
-            results.errors.push({ step: 'mcp', error: `Unknown backend: ${mcpBackend}` });
+          if (alreadyRegistered) {
+            results.steps.push({ step: 'mcp', status: 'skipped', message: `${mcpBackend} MCP already registered` });
           } else {
             await spawnAsync('claude', args, { env: EXTENDED_ENV });
             results.steps.push({ step: 'mcp', status: 'ok', message: `Registered ${mcpBackend} MCP server` });
@@ -200,7 +201,7 @@ router.post('/configure', async (req, res) => {
       let linked = 0;
       const entries = await fs.readdir(skillsDir, { withFileTypes: true });
       for (const entry of entries) {
-        if (entry.isDirectory() && (entry.name.startsWith('aris-') || entry.name === 'autoresearch')) {
+        if (entry.isDirectory() && (entry.name.startsWith('aris-') || entry.name.startsWith('inno-') || entry.name === 'autoresearch')) {
           const target = path.join(claudeSkillsDir, entry.name);
           try {
             await fs.access(target);

--- a/server/routes/community-tools.js
+++ b/server/routes/community-tools.js
@@ -127,10 +127,14 @@ router.post('/configure', async (req, res) => {
           gemini: ['mcp', 'add', 'gemini-review', '-s', 'user', '--', 'python3', path.join(resolvedPath, 'skills/aris-infra/mcp-servers/gemini-review/server.py')],
         };
 
+        const ENV_ONLY_BACKENDS = ['gemini-figure'];
         const args = mcpCommands[mcpBackend];
         if (!args) {
-          // No MCP server to register (env-only config like gemini-figure)
-          results.steps.push({ step: 'mcp', status: 'skipped', message: `No MCP server needed for ${mcpBackend}` });
+          if (ENV_ONLY_BACKENDS.includes(mcpBackend)) {
+            results.steps.push({ step: 'mcp', status: 'skipped', message: `No MCP server needed for ${mcpBackend}` });
+          } else {
+            results.errors.push({ step: 'mcp', error: `Unknown backend: ${mcpBackend}` });
+          }
         } else {
           // Check if already registered
           let alreadyRegistered = false;

--- a/src/components/AutoResearchHub.tsx
+++ b/src/components/AutoResearchHub.tsx
@@ -395,8 +395,9 @@ export default function AutoResearchHub() {
                       <div className="space-y-4 px-5 pb-5">
                         {/* MCP */}
                         <div>
-                          <h4 className="mb-1 text-sm font-semibold text-foreground">{t.configMcp}</h4>
-                          <p className="mb-2 text-xs text-muted-foreground">{t.configMcpDesc}</p>
+                          <h4 className="mb-1 text-sm font-semibold text-foreground">{pack.configLabel?.[locale]?.title ?? t.configMcp}</h4>
+                          <p className="mb-2 text-xs text-muted-foreground">{pack.configLabel?.[locale]?.desc ?? t.configMcpDesc}</p>
+                          {pack.mcp.length > 1 && (
                           <div className="mb-2 flex flex-wrap gap-1.5">
                             {pack.mcp.map(opt => (
                               <button key={opt.key} type="button" onClick={() => setSelectedMcp(p => ({ ...p, [pack.name]: opt.key }))}
@@ -405,6 +406,7 @@ export default function AutoResearchHub() {
                               </button>
                             ))}
                           </div>
+                          )}
                           {mcpOpt && (
                             <div className="space-y-2 rounded-xl border border-sky-200/50 bg-sky-50/30 p-3 dark:border-sky-800/30 dark:bg-sky-950/10">
                               {mcpOpt.install && (
@@ -418,6 +420,7 @@ export default function AutoResearchHub() {
                                   </button>
                                 </div>
                               )}
+                              {mcpOpt.register && (
                               <div className="flex items-center justify-between gap-2">
                                 <div className="min-w-0 flex-1">
                                   <p className="mb-0.5 text-xs font-medium text-muted-foreground">{t.register}</p>
@@ -427,6 +430,7 @@ export default function AutoResearchHub() {
                                   {copiedCommand === mcpOpt.register ? <Check className="h-3.5 w-3.5 text-green-600" /> : <Copy className="h-3.5 w-3.5" />}
                                 </button>
                               </div>
+                              )}
                               {mcpOpt.envVars.map(ev => (
                                 <div key={ev.name}>
                                   <p className="mb-1 text-xs font-medium text-muted-foreground">{ev.name}</p>

--- a/src/components/AutoResearchHub.tsx
+++ b/src/components/AutoResearchHub.tsx
@@ -426,7 +426,7 @@ export default function AutoResearchHub() {
                                   <p className="mb-0.5 text-xs font-medium text-muted-foreground">{t.register}</p>
                                   <code className="block truncate rounded bg-slate-100 px-2 py-1 text-xs text-foreground dark:bg-slate-800">{mcpOpt.register}</code>
                                 </div>
-                                <button type="button" onClick={() => copyToClipboard(mcpOpt.register)} className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-sky-100 hover:text-sky-700 dark:hover:bg-sky-900/30">
+                                <button type="button" onClick={() => copyToClipboard(mcpOpt.register!)} className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-sky-100 hover:text-sky-700 dark:hover:bg-sky-900/30">
                                   {copiedCommand === mcpOpt.register ? <Check className="h-3.5 w-3.5 text-green-600" /> : <Copy className="h-3.5 w-3.5" />}
                                 </button>
                               </div>

--- a/src/components/SkillsDashboard.tsx
+++ b/src/components/SkillsDashboard.tsx
@@ -2361,6 +2361,7 @@ export default function SkillsDashboard({ onSendToChat }: SkillsDashboardProps =
                                     </button>
                                   </div>
                                 )}
+                                {mcpOpt.register && (
                                 <div className="flex items-center justify-between gap-2">
                                   <div className="min-w-0 flex-1">
                                     <p className="mb-0.5 text-xs font-medium text-muted-foreground">{text.configRegister}</p>
@@ -2370,6 +2371,7 @@ export default function SkillsDashboard({ onSendToChat }: SkillsDashboardProps =
                                     {copiedCommand === mcpOpt.register ? <Check className="h-3.5 w-3.5 text-green-600" /> : <Copy className="h-3.5 w-3.5" />}
                                   </button>
                                 </div>
+                                )}
                                 {mcpOpt.envVars.map((ev) => (
                                   <div key={ev.name}>
                                     <p className="mb-1 text-xs font-medium text-muted-foreground">{ev.name}</p>

--- a/src/constants/autoResearchPacks.ts
+++ b/src/constants/autoResearchPacks.ts
@@ -4,7 +4,7 @@ export type PackConfigOption = {
   key: string;
   label: string;
   install?: string;
-  register: string;
+  register?: string;
   envVars: Array<{ name: string; example: string }>;
 };
 
@@ -70,7 +70,7 @@ export const AUTO_RESEARCH_PACKS: PackDef[] = [
       { name: 'Figure Gen', command: '/inno-figure-gen', description: { zh: 'Gemini 图像生成/编辑', en: 'Gemini image generation/editing', ko: 'Gemini image generation/editing' } },
     ],
     mcp: [
-      { key: 'gemini-figure', label: 'Gemini (Figure Gen)', register: '', envVars: [{ name: 'GEMINI_API_KEY', example: 'your-gemini-api-key' }] },
+      { key: 'gemini-figure', label: 'Gemini (Figure Gen)', envVars: [{ name: 'GEMINI_API_KEY', example: 'your-gemini-api-key' }] },
     ],
     configLabel: {
       zh: { title: '① 环境变量', desc: '配置图片生成所需的 API Key' },

--- a/src/constants/autoResearchPacks.ts
+++ b/src/constants/autoResearchPacks.ts
@@ -30,9 +30,56 @@ export type PackDef = {
   gpu: PackGpuOption[];
   setupScript: string;
   repoUrl?: string;
+  configLabel?: Record<LocaleKey, { title: string; desc: string }>;
 };
 
 export const AUTO_RESEARCH_PACKS: PackDef[] = [
+  {
+    name: 'Dr. Claw',
+    description: {
+      zh: '自研全流程研究工具包，覆盖完整研究生命周期的 16 个技能：从课题规划、文献调研、实验开发到论文撰写与投稿。',
+      en: '16 in-house skills covering the full research lifecycle: from project planning, literature survey, experiment development to paper writing and submission.',
+      ko: '16 in-house skills covering the full research lifecycle: planning, survey, experiments, paper writing.',
+    },
+    skills: [
+      'inno-pipeline-planner',
+      'inno-prepare-resources',
+      'inno-idea-generation',
+      'inno-idea-eval',
+      'inno-deep-research',
+      'inno-code-survey',
+      'inno-experiment-dev',
+      'inno-experiment-analysis',
+      'inno-paper-writing',
+      'inno-paper-reviewer',
+      'inno-humanizer',
+      'inno-reference-audit',
+      'inno-figure-gen',
+      'inno-rclone-to-overleaf',
+      'inno-rebuttal',
+      'inno-grant-proposal',
+    ],
+    workflows: [
+      { name: 'Pipeline Planner', command: '/inno-pipeline-planner', description: { zh: '交互式项目定义 → research_brief.json + tasks.json', en: 'Interactive project definition → research_brief.json + tasks.json', ko: 'Interactive project definition → research_brief.json + tasks.json' } },
+      { name: 'Deep Research', command: '/inno-deep-research', description: { zh: '综合多源文献调研', en: 'Comprehensive multi-source literature survey', ko: 'Comprehensive multi-source literature survey' } },
+      { name: 'Idea Generation', command: '/inno-idea-generation', description: { zh: 'SCAMPER/SWOT 结构化头脑风暴', en: 'Structured brainstorming with SCAMPER/SWOT frameworks', ko: 'Structured brainstorming with SCAMPER/SWOT' } },
+      { name: 'Experiment Dev', command: '/inno-experiment-dev', description: { zh: '实现 + Judge 反馈循环', en: 'Implementation + judge feedback loop', ko: 'Implementation + judge feedback loop' } },
+      { name: 'Paper Writing', command: '/inno-paper-writing', description: { zh: 'IEEE/ACM 学术论文撰写', en: 'IEEE/ACM academic paper writing', ko: 'IEEE/ACM academic paper writing' } },
+      { name: 'Paper Review', command: '/inno-paper-reviewer', description: { zh: '清单式论文审阅', en: 'Checklist-based paper review', ko: 'Checklist-based paper review' } },
+      { name: 'Rebuttal', command: '/inno-rebuttal', description: { zh: '学术反驳信撰写', en: 'Academic rebuttal drafting', ko: 'Academic rebuttal drafting' } },
+      { name: 'Figure Gen', command: '/inno-figure-gen', description: { zh: 'Gemini 图像生成/编辑', en: 'Gemini image generation/editing', ko: 'Gemini image generation/editing' } },
+    ],
+    mcp: [
+      { key: 'gemini-figure', label: 'Gemini (Figure Gen)', register: '', envVars: [{ name: 'GEMINI_API_KEY', example: 'your-gemini-api-key' }] },
+    ],
+    configLabel: {
+      zh: { title: '① 环境变量', desc: '配置图片生成所需的 API Key' },
+      en: { title: '① Environment', desc: 'API key required for image generation' },
+      ko: { title: '① Environment', desc: 'API key for image generation' },
+    },
+    gpu: [],
+    setupScript: '',
+  },
   {
     name: 'ARIS',
     repoUrl: 'https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep',


### PR DESCRIPTION
## Summary
- Add **Dr. Claw** as the first pack in AutoResearch Hub, featuring 16 in-house `inno-` skills covering the full research lifecycle (planning → survey → ideation → experiment → paper writing → review → rebuttal)
- Add `GEMINI_API_KEY` environment configuration for image generation (Figure Gen skill), with Hub UI adapted to show env-only config instead of MCP reviewer labels
- Backend: support `inno-` prefix in skills symlinking; gracefully skip MCP registration for env-only packs

## Changes
- `src/constants/autoResearchPacks.ts` — new `Dr. Claw` PackDef (first in array), add optional `configLabel` field to PackDef type
- `src/components/AutoResearchHub.tsx` — use `configLabel` for per-pack config section title/desc; hide MCP selector when single option; hide register command when empty
- `server/routes/community-tools.js` — skip MCP registration for unknown backends (env-only); add `inno-` to skills symlink filter

## Test plan
- [ ] Open AutoResearch Hub, verify Dr. Claw card appears first with correct description
- [ ] Expand config section, verify it shows "环境变量" / "Environment" (not "MCP 审稿服务")
- [ ] Verify only GEMINI_API_KEY input is shown (no MCP selector buttons, no register command)
- [ ] Enter a key and click "一键配置", verify key is saved to `~/.openclaw/community-tools.json`
- [ ] Check chat dropdown shows Dr. Claw workflows
- [ ] Verify ARIS/Autoresearch/DeepScientist packs still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)