### PR TITLE
feat: skill expansion, detection, and SKILL.md sidebar preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dr-claw",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dr-claw",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "hasInstallScript": true,
       "license": "(GPL-3.0-only AND AGPL-3.0-only)",
       "dependencies": {
@@ -177,7 +177,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -595,7 +594,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
       "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -610,7 +608,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
       "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -646,7 +643,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -668,7 +664,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.16.tgz",
       "integrity": "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1700,6 +1695,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1721,6 +1717,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1737,6 +1734,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1751,6 +1749,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3202,8 +3201,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@lezer/css": {
       "version": "1.3.1",
@@ -3221,7 +3219,6 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -3820,7 +3817,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5160,7 +5156,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5464,8 +5459,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -5582,7 +5576,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6423,7 +6416,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7037,7 +7029,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -7554,7 +7545,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7593,7 +7585,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8006,7 +7997,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8458,7 +8448,6 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -8852,6 +8841,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8872,6 +8862,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9278,7 +9269,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10573,7 +10563,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10748,7 +10737,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14221,7 +14209,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14379,6 +14366,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14396,6 +14384,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14697,7 +14686,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14710,7 +14698,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17143,7 +17130,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17343,6 +17329,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17406,6 +17393,7 @@
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17418,6 +17406,7 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17439,6 +17428,7 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17452,6 +17442,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -17466,6 +17457,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -17568,7 +17560,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17765,7 +17756,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18145,7 +18135,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18254,7 +18243,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18790,7 +18778,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dr-claw",
-  "version": "1.1.3",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dr-claw",
-      "version": "1.1.3",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "license": "(GPL-3.0-only AND AGPL-3.0-only)",
       "dependencies": {
@@ -177,6 +177,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -594,6 +595,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.2.tgz",
       "integrity": "sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -608,6 +610,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
       "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -643,6 +646,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
       "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -664,6 +668,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.16.tgz",
       "integrity": "sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -1695,7 +1700,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -1717,7 +1721,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1734,7 +1737,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -1749,7 +1751,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -3201,7 +3202,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
       "integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lezer/css": {
       "version": "1.3.1",
@@ -3219,6 +3221,7 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.3.0"
       }
@@ -3817,6 +3820,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -5156,6 +5160,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5459,7 +5464,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -5576,6 +5582,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6416,6 +6423,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7029,6 +7037,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -7545,8 +7554,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7585,6 +7593,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7997,6 +8006,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8448,6 +8458,7 @@
       "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.8.1",
         "builder-util": "26.8.1",
@@ -8841,7 +8852,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -8862,7 +8872,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -9269,6 +9278,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -10563,6 +10573,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10737,6 +10748,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -14209,6 +14221,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14366,7 +14379,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -14384,7 +14396,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -14686,6 +14697,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14698,6 +14710,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -17130,6 +17143,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -17329,7 +17343,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -17393,7 +17406,6 @@
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17406,7 +17418,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17428,7 +17439,6 @@
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17442,7 +17452,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -17457,7 +17466,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -17560,6 +17568,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17756,6 +17765,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18135,6 +18145,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18243,6 +18254,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18778,6 +18790,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -13,6 +13,7 @@ import { splitLegacyGeminiThoughtContent } from '../shared/geminiThoughtParser.j
 import { classifyError } from '../shared/errorClassifier.js';
 import { buildGeminiThinkingConfig } from '../shared/geminiThinkingSupport.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { expandSkillCommand } from './utils/skillExpander.js';
 
 // Use cross-spawn on Windows for better command execution
 const spawnFunction = process.platform === 'win32' ? crossSpawn : spawn;
@@ -607,8 +608,12 @@ export async function spawnGemini(command, options = {}, ws) {
     }
 
     if (command && command.trim()) {
+      // Expand /skill-name slash commands into full SKILL.md instructions
+      // so the Gemini model receives actionable procedures.
+      const expandedCommand = await expandSkillCommand(command.trim(), workingDir);
+
       const effectiveAttachments = attachments || images;
-      const attachmentResult = await handleGeminiAttachments(command, effectiveAttachments, workingDir);
+      const attachmentResult = await handleGeminiAttachments(expandedCommand, effectiveAttachments, workingDir);
       tempFilePaths = attachmentResult.tempFilePaths;
       if (attachmentResult.tempDir) {
         tempDirs.push(attachmentResult.tempDir);

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -22,6 +22,7 @@ import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIn
 import { classifyError, classifySDKError } from '../shared/errorClassifier.js';
 import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 import { buildCodexRealtimeTokenBudget } from './utils/sessionTokenUsage.js';
+import { expandSkillCommand } from './utils/skillExpander.js';
 
 // Track active sessions
 const activeCodexSessions = new Map();
@@ -446,14 +447,17 @@ export async function queryCodex(command, options = {}, ws) {
 
     publishSessionId(thread.id || sessionId || null);
 
-    const preparedInput = await prepareCodexInput(command, images, workingDirectory);
+    // Expand /skill-name slash commands into full SKILL.md instructions
+    const expandedCommand = await expandSkillCommand(command?.trim?.() || command, workingDirectory);
+
+    const preparedInput = await prepareCodexInput(expandedCommand, images, workingDirectory);
     tempImagePaths = preparedInput.tempImagePaths;
     tempDir = preparedInput.tempDir;
 
     // Execute with streaming
     // Prefer pre-uploaded attachments (buildCodexInput) over base64 temp images (prepareCodexInput)
     const codexInput = attachments
-      ? buildCodexInput(command, attachments)
+      ? buildCodexInput(expandedCommand, attachments)
       : preparedInput.input;
     const streamedTurn = await thread.runStreamed(codexInput, {
       signal: abortController.signal

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -448,7 +448,7 @@ export async function queryCodex(command, options = {}, ws) {
     publishSessionId(thread.id || sessionId || null);
 
     // Expand /skill-name slash commands into full SKILL.md instructions
-    const expandedCommand = await expandSkillCommand(command?.trim?.() || command, workingDirectory);
+    const expandedCommand = await expandSkillCommand(command?.trim() || command, workingDirectory);
 
     const preparedInput = await prepareCodexInput(expandedCommand, images, workingDirectory);
     tempImagePaths = preparedInput.tempImagePaths;

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -21,6 +21,7 @@ import { classifyError } from '../shared/errorClassifier.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
 import { createRequestId, waitForToolApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { expandSkillCommand } from './utils/skillExpander.js';
 
 const execAsync = promisify(exec);
 
@@ -659,8 +660,11 @@ export async function queryOpenRouter(command, options = {}, ws) {
       }
     }
 
-    messages.push({ role: 'user', content: command });
-    await appendSession(currentSessionId, { role: 'user', content: command }).catch(() => {});
+    // Expand /skill-name slash commands into full SKILL.md instructions
+    const expandedCommand = await expandSkillCommand(command?.trim?.() || command, workingDirectory);
+
+    messages.push({ role: 'user', content: expandedCommand });
+    await appendSession(currentSessionId, { role: 'user', content: expandedCommand }).catch(() => {});
 
     const tools = permissionMode === 'plan'
       ? TOOL_SCHEMAS.filter((t) => READ_ONLY_TOOLS.has(t.function.name))

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -661,7 +661,7 @@ export async function queryOpenRouter(command, options = {}, ws) {
     }
 
     // Expand /skill-name slash commands into full SKILL.md instructions
-    const expandedCommand = await expandSkillCommand(command?.trim?.() || command, workingDirectory);
+    const expandedCommand = await expandSkillCommand(command?.trim() || command, workingDirectory);
 
     messages.push({ role: 'user', content: expandedCommand });
     await appendSession(currentSessionId, { role: 'user', content: expandedCommand }).catch(() => {});

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -5,6 +5,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { extractProjectDirectory, ensureProjectSkillLinks } from '../projects.js';
 import { FORBIDDEN_PATHS } from './projects.js';
+import { findSkillMdPath } from '../utils/skillExpander.js';
 
 const GLOBAL_SKILLS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'skills');
 
@@ -222,6 +223,30 @@ async function validateZipBuffer(buffer) {
     zip,
   };
 }
+
+// GET /resolve — resolve a skill name to its SKILL.md path and content
+router.get('/resolve', async (req, res) => {
+  try {
+    const { name, workingDir } = req.query;
+    if (!name || typeof name !== 'string') {
+      return res.status(400).json({ error: 'name query parameter is required' });
+    }
+    // Prevent path traversal
+    if (/[/\\]|\.\./.test(name)) {
+      return res.status(400).json({ error: 'Invalid skill name' });
+    }
+    const effectiveWorkingDir = (typeof workingDir === 'string' && workingDir.trim()) || process.cwd();
+    const skillMdPath = await findSkillMdPath(name, effectiveWorkingDir);
+    if (!skillMdPath) {
+      return res.status(404).json({ error: 'Skill not found' });
+    }
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    res.json({ path: skillMdPath, content });
+  } catch (error) {
+    console.error('[skills] resolve error:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
 
 // GET / — return the file tree of the global skills/ directory
 router.get('/', async (req, res) => {

--- a/server/routes/skills.js
+++ b/server/routes/skills.js
@@ -236,6 +236,16 @@ router.get('/resolve', async (req, res) => {
       return res.status(400).json({ error: 'Invalid skill name' });
     }
     const effectiveWorkingDir = (typeof workingDir === 'string' && workingDir.trim()) || process.cwd();
+    // Validate workingDir: must be absolute and not a forbidden system path
+    if (effectiveWorkingDir !== process.cwd()) {
+      if (!path.isAbsolute(effectiveWorkingDir)) {
+        return res.status(400).json({ error: 'workingDir must be an absolute path' });
+      }
+      const normalized = path.normalize(effectiveWorkingDir);
+      if (FORBIDDEN_PATHS.some((fp) => normalized === fp || normalized.startsWith(fp + path.sep))) {
+        return res.status(400).json({ error: 'Invalid workingDir' });
+      }
+    }
     const skillMdPath = await findSkillMdPath(name, effectiveWorkingDir);
     if (!skillMdPath) {
       return res.status(404).json({ error: 'Skill not found' });

--- a/server/utils/skillExpander.js
+++ b/server/utils/skillExpander.js
@@ -1,0 +1,149 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Strip leading [Context: ...] prefixes the frontend injects for new sessions.
+ * Returns { prefix, body } so the prefix can be re-prepended after expansion.
+ */
+function splitContextPrefix(text) {
+  let prefix = '';
+  let body = text;
+  const contextPattern = /^\s*\[Context:[^\]]*\]\s*/i;
+  while (contextPattern.test(body)) {
+    const m = body.match(contextPattern);
+    prefix += m[0];
+    body = body.slice(m[0].length);
+  }
+  return { prefix, body };
+}
+
+/**
+ * Build the ordered list of directories to search for a skill SKILL.md.
+ */
+function buildSkillSearchPaths(skillName, workingDir) {
+  return [
+    path.join(workingDir, '.agents', 'skills', skillName),
+    path.join(workingDir, '.claude', 'skills', skillName),
+    path.join(workingDir, '.gemini', 'skills', skillName),
+    path.join(process.cwd(), 'skills', skillName),
+    path.join(os.homedir(), '.claude', 'skills', skillName),
+  ];
+}
+
+/**
+ * Try to find the SKILL.md path for a given skill name.
+ * Returns the absolute path or null if not found.
+ */
+async function findSkillMdPath(skillName, workingDir) {
+  const searchPaths = buildSkillSearchPaths(skillName, workingDir);
+  for (const skillDir of searchPaths) {
+    try {
+      const skillMdPath = path.join(skillDir, 'SKILL.md');
+      const stat = await fs.stat(skillMdPath);
+      if (stat.isFile()) return skillMdPath;
+    } catch {
+      // not found, try next
+    }
+  }
+  return null;
+}
+
+/**
+ * Read SKILL.md content for a given skill name.
+ */
+async function readSkillMd(skillName, workingDir) {
+  const skillMdPath = await findSkillMdPath(skillName, workingDir);
+  if (!skillMdPath) return null;
+  try {
+    const content = await fs.readFile(skillMdPath, 'utf-8');
+    if (!content.trim()) return null;
+    return { content, path: skillMdPath };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scan text for /skill-name references and return unique skill names found.
+ * Matches patterns like /aris-idea-discovery, /autoresearch:fix, etc.
+ * Skips matches that are clearly URLs (preceded by http:// or similar).
+ */
+function findNestedSkillRefs(text) {
+  const refs = new Set();
+  const pattern = /(?<![a-zA-Z0-9:.])\/([a-zA-Z][a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)\b/g;
+  let m;
+  while ((m = pattern.exec(text)) !== null) {
+    refs.add(m[1]);
+  }
+  return [...refs];
+}
+
+/**
+ * Build a sub-skill lookup table: for each /skill-name referenced in the
+ * top-level SKILL.md, resolve its file path so the model can read it on demand.
+ * Only scans one level deep — the model reads sub-skills progressively.
+ */
+async function buildSubSkillIndex(content, workingDir, topSkillName) {
+  const refs = findNestedSkillRefs(content);
+  const index = [];
+
+  for (const ref of refs) {
+    const skillName = ref.includes(':') ? ref.split(':')[0] : ref;
+    if (skillName === topSkillName) continue;
+
+    const skillMdPath = await findSkillMdPath(skillName, workingDir);
+    if (skillMdPath) {
+      index.push({ ref, path: skillMdPath });
+    }
+  }
+
+  return index;
+}
+
+/**
+ * Resolve a `/skill-name` or `/skill-name:variant` slash command into the
+ * full SKILL.md content so non-Claude providers receive explicit instructions
+ * instead of an opaque slash command they cannot interpret.
+ *
+ * Sub-skill references within the expanded content are NOT inlined. Instead,
+ * a lookup table is appended so the model can read each sub-skill file on
+ * demand (progressive expansion), keeping the initial prompt small.
+ *
+ * Returns the expanded prompt string, or the original command unchanged if
+ * no matching skill is found.
+ */
+export { findSkillMdPath };
+
+export async function expandSkillCommand(command, workingDir) {
+  if (!command || typeof command !== 'string') return command;
+
+  const { prefix, body } = splitContextPrefix(command);
+
+  const match = body.match(/^\/([a-zA-Z0-9_-]+(?::[a-zA-Z0-9_-]+)?)\s*([\s\S]*)$/);
+  if (!match) return command;
+
+  const skillCommand = match[1];
+  const remainder = (match[2] || '').trim();
+
+  const skillName = skillCommand.includes(':') ? skillCommand.split(':')[0] : skillCommand;
+  const variant = skillCommand.includes(':') ? skillCommand.split(':').slice(1).join(':') : null;
+
+  const result = await readSkillMd(skillName, workingDir);
+  if (!result) return command;
+
+  console.log(`[SkillExpander] Expanded /${skillCommand} from ${result.path}`);
+  const variantNote = variant ? `\n\n**Variant requested:** \`${variant}\`\n` : '';
+  const userContext = remainder ? `\n\n**User context:**\n${remainder}` : '';
+
+  // Build a path index for sub-skills referenced in this SKILL.md
+  const subSkillIndex = await buildSubSkillIndex(result.content, workingDir, skillName);
+
+  let subSkillNote = '';
+  if (subSkillIndex.length > 0) {
+    const lines = subSkillIndex.map(({ ref, path: p }) => `- \`/${ref}\` → \`${p}\``).join('\n');
+    subSkillNote = `\n\n## Sub-Skill Loading\n\nThis procedure references other skills via \`/skill-name\`. You are NOT running inside Claude Code CLI, so slash commands are not available. Instead, when you reach a step that calls a sub-skill, **read its SKILL.md file** and follow those instructions inline.\n\nSub-skill file locations:\n${lines}\n\nExample: when the procedure says "run \`/aris-idea-discovery\`", do:\n1. Read the corresponding SKILL.md path listed above\n2. Follow the instructions in that file\n3. Continue with the next step in the parent procedure`;
+  }
+
+  return `${prefix}# Skill: ${skillCommand}\n\nFollow the procedure below exactly.\n${variantNote}\n${result.content}${userContext}${subSkillNote}`;
+}

--- a/server/utils/skillExpander.js
+++ b/server/utils/skillExpander.js
@@ -7,15 +7,9 @@ import os from 'os';
  * Returns { prefix, body } so the prefix can be re-prepended after expansion.
  */
 function splitContextPrefix(text) {
-  let prefix = '';
-  let body = text;
-  const contextPattern = /^\s*\[Context:[^\]]*\]\s*/i;
-  while (contextPattern.test(body)) {
-    const m = body.match(contextPattern);
-    prefix += m[0];
-    body = body.slice(m[0].length);
-  }
-  return { prefix, body };
+  const m = text.match(/^(\s*\[Context:[^\]]*\]\s*)+/i);
+  if (!m) return { prefix: '', body: text };
+  return { prefix: m[0], body: text.slice(m[0].length) };
 }
 
 /**
@@ -86,19 +80,18 @@ function findNestedSkillRefs(text) {
  */
 async function buildSubSkillIndex(content, workingDir, topSkillName) {
   const refs = findNestedSkillRefs(content);
-  const index = [];
+  const candidates = refs
+    .map((ref) => ({ ref, skillName: ref.includes(':') ? ref.split(':')[0] : ref }))
+    .filter(({ skillName }) => skillName !== topSkillName);
 
-  for (const ref of refs) {
-    const skillName = ref.includes(':') ? ref.split(':')[0] : ref;
-    if (skillName === topSkillName) continue;
+  const results = await Promise.all(
+    candidates.map(async ({ ref, skillName }) => {
+      const skillMdPath = await findSkillMdPath(skillName, workingDir);
+      return skillMdPath ? { ref, path: skillMdPath } : null;
+    })
+  );
 
-    const skillMdPath = await findSkillMdPath(skillName, workingDir);
-    if (skillMdPath) {
-      index.push({ ref, path: skillMdPath });
-    }
-  }
-
-  return index;
+  return results.filter(Boolean);
 }
 
 /**
@@ -113,8 +106,6 @@ async function buildSubSkillIndex(content, workingDir, topSkillName) {
  * Returns the expanded prompt string, or the original command unchanged if
  * no matching skill is found.
  */
-export { findSkillMdPath };
-
 export async function expandSkillCommand(command, workingDir) {
   if (!command || typeof command !== 'string') return command;
 
@@ -147,3 +138,5 @@ export async function expandSkillCommand(command, workingDir) {
 
   return `${prefix}# Skill: ${skillCommand}\n\nFollow the procedure below exactly.\n${variantNote}\n${result.content}${userContext}${subSkillNote}`;
 }
+
+export { findSkillMdPath };

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -841,6 +841,11 @@ export function useChatComposerState({
         }
       }
 
+      // Auto-bypass permissions for autoresearch workflows
+      const effectivePermissionMode = attachedPrompt?.scenarioId?.startsWith('autoresearch-')
+        ? 'bypassPermissions'
+        : permissionMode;
+
       const selectedThinkingMode = thinkingModes.find((mode: { id: string; prefix?: string }) => mode.id === thinkingMode);
       if (selectedThinkingMode && selectedThinkingMode.prefix) {
         messageContent = `${selectedThinkingMode.prefix}: ${messageContent}`;
@@ -1080,7 +1085,7 @@ export function useChatComposerState({
             sessionId: effectiveSessionId,
             resume: Boolean(effectiveSessionId),
             model: geminiModel,
-            permissionMode,
+            permissionMode: effectivePermissionMode,
             thinkingMode: geminiThinkingMode,
             images: uploadedImages.length > 0 ? uploadedImages : undefined,
             toolsSettings,
@@ -1102,7 +1107,7 @@ export function useChatComposerState({
             sessionId: effectiveSessionId,
             resume: Boolean(effectiveSessionId),
             model: codexModel,
-            permissionMode: permissionMode === 'plan' ? 'default' : permissionMode,
+            permissionMode: effectivePermissionMode === 'plan' ? 'default' : effectivePermissionMode,
             modelReasoningEffort: codexReasoningEffort === 'default' ? undefined : codexReasoningEffort,
             attachments: codexAttachmentPayload,
             images: uploadedImages,
@@ -1124,7 +1129,7 @@ export function useChatComposerState({
             sessionId: effectiveSessionId,
             resume: Boolean(effectiveSessionId),
             model: openrouterModel,
-            permissionMode,
+            permissionMode: effectivePermissionMode,
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
@@ -1146,7 +1151,7 @@ export function useChatComposerState({
             model: localModel,
             serverUrl: localStorage.getItem('local-gpu-server-url') || 'http://localhost:11434',
             gpuId: localStorage.getItem('local-gpu-selected') || undefined,
-            permissionMode,
+            permissionMode: effectivePermissionMode,
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
@@ -1165,7 +1170,7 @@ export function useChatComposerState({
             sessionId: effectiveSessionId,
             resume: Boolean(effectiveSessionId),
             toolsSettings,
-            permissionMode,
+            permissionMode: effectivePermissionMode,
             model: claudeModel,
             images: uploadedImages.length > 0 ? uploadedImages : undefined,
             telemetryEnabled,

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -39,6 +39,7 @@ import { useFileMentions } from './useFileMentions';
 import { type SlashCommand, useSlashCommands } from './useSlashCommands';
 import type { Project, ProjectSession, SessionProvider } from '../../../types/app';
 import { escapeRegExp } from '../utils/chatFormatting';
+import { isAutoResearchScenario } from '../utils/autoResearch';
 import type { SessionMode } from '../../../types/app';
 
 type PendingViewSession = {
@@ -842,7 +843,7 @@ export function useChatComposerState({
       }
 
       // Auto-bypass permissions for autoresearch workflows
-      const effectivePermissionMode = attachedPrompt?.scenarioId?.startsWith('autoresearch-')
+      const effectivePermissionMode = isAutoResearchScenario(attachedPrompt?.scenarioId)
         ? 'bypassPermissions'
         : permissionMode;
 

--- a/src/components/chat/utils/autoResearch.ts
+++ b/src/components/chat/utils/autoResearch.ts
@@ -1,0 +1,6 @@
+/**
+ * Check whether a scenario ID represents an autoresearch workflow.
+ */
+export function isAutoResearchScenario(scenarioId: string | undefined | null): boolean {
+  return typeof scenarioId === 'string' && scenarioId.startsWith('autoresearch-');
+}

--- a/src/components/chat/utils/sessionContextSummary.ts
+++ b/src/components/chat/utils/sessionContextSummary.ts
@@ -20,6 +20,7 @@ export interface SessionContextTaskItem {
   key: string;
   label: string;
   detail?: string;
+  path?: string;
   kind: 'task' | 'todo' | 'skill' | 'directory';
   count: number;
   lastSeenAt: string;
@@ -54,6 +55,7 @@ type TaskAccumulator = {
   key: string;
   label: string;
   detail?: string;
+  path?: string;
   kind: 'task' | 'todo' | 'skill' | 'directory';
   count: number;
   lastSeenAt: string;
@@ -146,6 +148,9 @@ const KNOWN_FILE_EXTENSIONS = new Set([
 ]);
 
 const normalizePath = (value: string) => value.replace(/\\/g, '/').replace(/\/+/g, '/');
+
+/** Matches SKILL.md paths under .claude/, .agents/, .gemini/, or plain skills/ directories. */
+const SKILL_MD_PATH_RE = /\/(?:\.(?:claude|agents|gemini)\/)?skills\/([^/]+)\/SKILL\.md$/i;
 
 const trimTrailingPathPunctuation = (value: string) => {
   let normalized = normalizePath(value).replace(/[),:;]+$/, '');
@@ -318,6 +323,12 @@ const extractSkillName = (message: ChatMessage): string | null => {
   const commandMatch = message.content.match(/<command-name>([^<]+)<\/command-name>/i);
   if (commandMatch?.[1]?.trim()) {
     return commandMatch[1].trim();
+  }
+
+  // Detect skillExpander format: "# Skill: skill-name" heading
+  const skillHeadingMatch = message.content.match(/^#\s+Skill:\s*(\S+)/m);
+  if (skillHeadingMatch?.[1]?.trim()) {
+    return skillHeadingMatch[1].trim();
   }
 
   const pathMatch = message.content.match(/Base directory for this skill:\s*(\S+)/i);
@@ -689,6 +700,7 @@ const addTask = (
   label: string,
   detail: string | undefined,
   timestamp: string,
+  path?: string,
 ) => {
   const normalizedLabel = String(label || '').trim();
   if (!normalizedLabel) {
@@ -703,6 +715,7 @@ const addTask = (
       existing.lastSeenAt = timestamp;
       existing.detail = detail || existing.detail;
     }
+    existing.path = path || existing.path;
     return;
   }
 
@@ -710,6 +723,7 @@ const addTask = (
     key,
     label: normalizedLabel,
     detail: detail || undefined,
+    path: path || undefined,
     kind,
     count: 1,
     lastSeenAt: timestamp,
@@ -799,7 +813,15 @@ export function deriveSessionContextSummary(
     const timestamp = toIsoTimestamp(message.timestamp);
     const skillName = extractSkillName(message);
     if (skillName) {
-      addTask(skills, 'skill', skillName, undefined, timestamp);
+      // Try to extract SKILL.md path from "Base directory for this skill:" in isSkillContent messages
+      let skillPath: string | undefined;
+      if (message.isSkillContent && typeof message.content === 'string') {
+        const baseMatch = message.content.match(/Base directory for this skill:\s*(\S+)/i);
+        if (baseMatch?.[1]) {
+          skillPath = `${baseMatch[1].trim().replace(/\/$/, '')}/SKILL.md`;
+        }
+      }
+      addTask(skills, 'skill', skillName, undefined, timestamp, skillPath);
     }
 
     if (message.isTaskNotification && typeof message.taskOutputFile === 'string' && message.taskOutputFile.trim()) {
@@ -820,9 +842,9 @@ export function deriveSessionContextSummary(
       case 'Read': {
         extractToolInputPaths(parsedInput).forEach((filePath) => {
           addFile(contextFiles, filePath, effectiveProjectRoot, 'Read', timestamp);
-          const skillMatch = filePath.match(/\/(?:\.claude\/)?skills\/([^/]+)\/SKILL\.md$/i);
+          const skillMatch = filePath.match(SKILL_MD_PATH_RE);
           if (skillMatch?.[1]) {
-            addTask(skills, 'skill', skillMatch[1], undefined, timestamp);
+            addTask(skills, 'skill', skillMatch[1], undefined, timestamp, filePath);
           }
         });
         break;
@@ -842,6 +864,10 @@ export function deriveSessionContextSummary(
         const shellContext = extractShellContext(parsedInput, message.toolResult);
         shellContext.files.forEach((filePath) => {
           addFile(contextFiles, filePath, effectiveProjectRoot, 'Shell', timestamp);
+          const skillMatch = filePath.match(SKILL_MD_PATH_RE);
+          if (skillMatch?.[1]) {
+            addTask(skills, 'skill', skillMatch[1], undefined, timestamp, filePath);
+          }
         });
         shellContext.directories.forEach((directoryPath) => {
           addTask(directories, 'directory', toRelativePath(directoryPath, effectiveProjectRoot) || directoryPath, 'Referenced in shell command', timestamp);
@@ -920,6 +946,10 @@ export function deriveSessionContextSummary(
       case 'FileChanges': {
         parseFileChanges(message.toolInput).forEach((filePath) => {
           addFile(outputFiles, filePath, effectiveProjectRoot, 'File change', timestamp);
+          const skillMatch = filePath.match(SKILL_MD_PATH_RE);
+          if (skillMatch?.[1]) {
+            addTask(skills, 'skill', skillMatch[1], undefined, timestamp, filePath);
+          }
         });
         break;
       }

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -633,8 +633,8 @@ export default function ChatComposer({
                   {centered && <div className="h-4 border-l border-border/40 mx-1" />}
 
                   <ChatInputControls
-                    permissionMode={permissionMode}
-                    onModeSwitch={onModeSwitch}
+                    permissionMode={attachedPrompt?.scenarioId?.startsWith('autoresearch-') ? 'bypassPermissions' : permissionMode}
+                    onModeSwitch={attachedPrompt?.scenarioId?.startsWith('autoresearch-') ? undefined : onModeSwitch}
                     provider={provider}
                     codexModel={codexModel}
                     geminiModel={geminiModel}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -28,6 +28,7 @@ import type { ProviderAvailability } from '../../types/types';
 import type { SessionMode, SessionProvider } from '../../../../types/app';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, LOCAL_MODELS, OPENROUTER_MODELS } from '../../../../../shared/modelConstants';
 import { authenticatedFetch } from '../../../../utils/api';
+import { isAutoResearchScenario } from '../../utils/autoResearch';
 
 // New subcomponents
 import SkillDropdown from './SkillDropdown';
@@ -630,11 +631,20 @@ export default function ChatComposer({
                     </>
                   )}
 
+                  {isAutoResearchScenario(attachedPrompt?.scenarioId) && (
+                    <span
+                      className="text-[10px] text-amber-600 dark:text-amber-400 bg-amber-100 dark:bg-amber-900/30 px-1.5 py-0.5 rounded font-medium"
+                      title="Autoresearch mode: tool permissions are auto-approved"
+                    >
+                      Auto
+                    </span>
+                  )}
+
                   {centered && <div className="h-4 border-l border-border/40 mx-1" />}
 
                   <ChatInputControls
-                    permissionMode={attachedPrompt?.scenarioId?.startsWith('autoresearch-') ? 'bypassPermissions' : permissionMode}
-                    onModeSwitch={attachedPrompt?.scenarioId?.startsWith('autoresearch-') ? undefined : onModeSwitch}
+                    permissionMode={isAutoResearchScenario(attachedPrompt?.scenarioId) ? 'bypassPermissions' : permissionMode}
+                    onModeSwitch={onModeSwitch}
                     provider={provider}
                     codexModel={codexModel}
                     geminiModel={geminiModel}

--- a/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
@@ -87,6 +87,7 @@ interface ChatContextFilePreviewProps {
   file: PreviewFile;
   onOpenInEditor?: (filePath: string) => void;
   compact?: boolean;
+  preloadedContent?: string | null;
 }
 
 export default function ChatContextFilePreview({
@@ -94,6 +95,7 @@ export default function ChatContextFilePreview({
   file,
   onOpenInEditor,
   compact = false,
+  preloadedContent,
 }: ChatContextFilePreviewProps) {
   const { t } = useTranslation('chat');
   const [content, setContent] = useState('');
@@ -117,6 +119,12 @@ export default function ChatContextFilePreview({
     });
 
     if (!file) {
+      setLoading(false);
+      return undefined;
+    }
+
+    if (typeof preloadedContent === 'string') {
+      setContent(preloadedContent);
       setLoading(false);
       return undefined;
     }
@@ -188,7 +196,7 @@ export default function ChatContextFilePreview({
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [file, previewKind, projectName]);
+  }, [file, preloadedContent, previewKind, projectName]);
 
   const openPath = file?.absolutePath || file?.relativePath || '';
   const emptyHeightClass = compact ? 'min-h-[180px]' : 'min-h-[240px]';

--- a/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
@@ -336,6 +336,7 @@ export default function ChatContextSidebar({
   const [isResizing, setIsResizing] = useState(false);
   const [previewFile, setPreviewFile] = useState<SessionContextFileItem | SessionContextOutputItem | null>(null);
   const [previewTask, setPreviewTask] = useState<SessionContextTaskItem | null>(null);
+  const [previewContent, setPreviewContent] = useState<string | null>(null);
   const asideRef = useRef<HTMLElement | null>(null);
   const isCollapsed = controlledCollapsed ?? uncontrolledCollapsed;
   const isSidebarCollapsed = !isMobile && isCollapsed;
@@ -552,7 +553,7 @@ export default function ChatContextSidebar({
     }
     setPreviewFile(file);
   }, [markFileReviewed]);
-  const handleClosePreview = useCallback(() => { setPreviewFile(null); setPreviewTask(null); }, []);
+  const handleClosePreview = useCallback(() => { setPreviewFile(null); setPreviewTask(null); setPreviewContent(null); }, []);
   const handleOpenInEditor = useCallback((filePath: string) => {
     setPreviewFile(null);
     onFileOpen?.(filePath);
@@ -560,6 +561,44 @@ export default function ChatContextSidebar({
   const handleTaskPreview = useCallback((task: SessionContextTaskItem) => {
     setPreviewTask(task);
   }, []);
+  const handleSkillPreview = useCallback(async (entry: SessionContextTaskItem) => {
+    // If we already have a resolved path under the project, use the file preview directly
+    if (entry.path && sessionProjectPath && entry.path.startsWith(sessionProjectPath)) {
+      const relativePath = entry.path.slice(sessionProjectPath.length).replace(/^\//, '');
+      setPreviewContent(null);
+      setPreviewFile({
+        key: entry.key,
+        name: 'SKILL.md',
+        relativePath,
+        absolutePath: entry.path,
+        reasons: ['Skill'],
+        count: entry.count,
+        lastSeenAt: entry.lastSeenAt,
+      });
+      return;
+    }
+    // Resolve via API (handles paths outside project root and skills without stored path)
+    try {
+      const response = await api.resolveSkill(entry.label, sessionProjectPath);
+      if (!response.ok) {
+        setPreviewTask(entry);
+        return;
+      }
+      const data = await response.json();
+      setPreviewContent(data.content);
+      setPreviewFile({
+        key: entry.key,
+        name: 'SKILL.md',
+        relativePath: data.path,
+        absolutePath: data.path,
+        reasons: ['Skill'],
+        count: entry.count,
+        lastSeenAt: entry.lastSeenAt,
+      });
+    } catch {
+      setPreviewTask(entry);
+    }
+  }, [sessionProjectPath]);
   const toggleSection = useCallback((key: SidebarSectionKey) => {
     setCollapsedSections((current) => {
       const nextValue = { ...current, [key]: !current[key] };
@@ -831,16 +870,18 @@ export default function ChatContextSidebar({
                   <div className="h-px flex-1 bg-border/50" />
                 </div>
                 {(expandedLists.skills ? summary.skills : summary.skills.slice(0, 5)).map((entry) => (
-                  <div
+                  <button
+                    type="button"
                     key={entry.key}
-                    className="flex items-center gap-2 rounded-lg border border-violet-200/60 bg-violet-50/30 px-2.5 py-1.5 dark:border-violet-900/40 dark:bg-violet-950/20"
+                    onClick={() => handleSkillPreview(entry)}
+                    className="flex w-full items-center gap-2 rounded-lg border border-violet-200/60 bg-violet-50/30 px-2.5 py-1.5 text-left transition-all hover:border-violet-300 hover:bg-violet-50/50 dark:border-violet-900/40 dark:bg-violet-950/20 dark:hover:border-violet-800/60 dark:hover:bg-violet-950/30 cursor-pointer"
                   >
                     <Zap className="h-3 w-3 flex-shrink-0 text-violet-500/80" />
                     <span className="min-w-0 flex-1 truncate text-[12px] font-medium text-foreground">
                       {entry.label}
                     </span>
                     <ItemBadge>{formatTimeLabel(entry.lastSeenAt, i18n.language)}</ItemBadge>
-                  </div>
+                  </button>
                 ))}
                 {summary.skills.length > 5 && (
                   <button type="button" className="w-full rounded-lg px-2 py-1 text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors" onClick={() => toggleListExpansion('skills')}>
@@ -1025,6 +1066,7 @@ export default function ChatContextSidebar({
                   projectName={projectName}
                   file={previewFile}
                   onOpenInEditor={handleOpenInEditor}
+                  preloadedContent={previewContent}
                 />
               </div>
             )}

--- a/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
@@ -581,6 +581,7 @@ export default function ChatContextSidebar({
     try {
       const response = await api.resolveSkill(entry.label, sessionProjectPath);
       if (!response.ok) {
+        console.warn(`[Sidebar] Failed to resolve skill "${entry.label}": ${response.status}`);
         setPreviewTask(entry);
         return;
       }
@@ -595,7 +596,8 @@ export default function ChatContextSidebar({
         count: entry.count,
         lastSeenAt: entry.lastSeenAt,
       });
-    } catch {
+    } catch (err) {
+      console.warn('[Sidebar] Skill resolve error:', err);
       setPreviewTask(entry);
     }
   }, [sessionProjectPath]);

--- a/src/components/chat/view/subcomponents/ChatInputControls.tsx
+++ b/src/components/chat/view/subcomponents/ChatInputControls.tsx
@@ -12,7 +12,7 @@ import type { PermissionMode, Provider, TokenBudget } from '../../types/types';
 
 interface ChatInputControlsProps {
   permissionMode: PermissionMode | string;
-  onModeSwitch: () => void;
+  onModeSwitch?: (() => void) | undefined;
   provider: Provider | string;
   codexModel: string;
   geminiModel: string;
@@ -63,8 +63,9 @@ export default function ChatInputControls({
     <>
       <button
         type="button"
-        onClick={onModeSwitch}
-        className={`${compact ? 'w-[8.5rem] whitespace-nowrap truncate px-2 py-1 rounded-lg text-[11px] text-center justify-center' : 'px-2.5 py-1 sm:px-3 sm:py-1.5 rounded-lg text-xs sm:text-sm'} font-medium border transition-all duration-200 ${
+        onClick={onModeSwitch ?? undefined}
+        disabled={!onModeSwitch}
+        className={`${compact ? 'w-[8.5rem] whitespace-nowrap truncate px-2 py-1 rounded-lg text-[11px] text-center justify-center' : 'px-2.5 py-1 sm:px-3 sm:py-1.5 rounded-lg text-xs sm:text-sm'} font-medium border transition-all duration-200 ${!onModeSwitch ? 'cursor-not-allowed opacity-80' : ''} ${
           permissionMode === 'default'
             ? 'bg-muted/50 text-muted-foreground border-border/60 hover:bg-muted'
             : permissionMode === 'acceptEdits'
@@ -73,7 +74,7 @@ export default function ChatInputControls({
                 ? 'bg-orange-50 dark:bg-orange-900/15 text-orange-700 dark:text-orange-300 border-orange-300/60 dark:border-orange-600/40 hover:bg-orange-100 dark:hover:bg-orange-900/25'
                 : 'bg-primary/5 text-primary border-primary/20 hover:bg-primary/10'
         }`}
-        title={t('input.clickToChangeMode')}
+        title={onModeSwitch ? t('input.clickToChangeMode') : t('input.autoResearchBypass', { defaultValue: 'Locked to Bypass for Auto Research' })}
       >
         <div className={`flex items-center gap-1.5 ${compact ? 'justify-center' : ''}`}>
           <div

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -157,6 +157,8 @@ export const api = {
     }),
   readFile: (projectName, filePath) =>
     authenticatedFetch(`/api/projects/${projectName}/file?filePath=${encodeURIComponent(filePath)}`),
+  resolveSkill: (skillName, workingDir) =>
+    authenticatedFetch(`/api/skills/resolve?name=${encodeURIComponent(skillName)}&workingDir=${encodeURIComponent(workingDir || '')}`),
   /** Fetch binary file content (e.g. PDF) as Blob. absolutePath must be the full filesystem path. */
   getFileContentBlob: (projectName, absolutePath) =>
     authenticatedFetch(`/api/projects/${projectName}/files/content?path=${encodeURIComponent(absolutePath)}`).then((r) => {


### PR DESCRIPTION
## Summary

- **Skill expansion for non-Claude providers**: Codex, Gemini, and OpenRouter now receive full SKILL.md instructions when users invoke `/skill-name` commands, instead of opaque slash commands
- **Auto-bypass permissions**: Autoresearch workflows automatically lock to bypass mode across all providers
- **Improved skill detection in sidebar**: Skills are now detected from `.agents/`, `.gemini/`, `.claude/` directories, from skillExpander heading format, and from Bash/FileChanges events (critical for Codex which doesn't emit Read tool events)
- **SKILL.md preview**: Clicking a skill in the "Referenced Context" sidebar opens a markdown preview of its SKILL.md content, with API-based resolution for skills outside the project root

## Test plan

- [ ] Use `/skill-name` in Codex session → verify skill is expanded and detected in sidebar
- [ ] Use `/skill-name` in Gemini session → verify skill is detected from `read_file` tool
- [ ] Click a skill in the sidebar → verify SKILL.md preview modal renders markdown
- [ ] Verify skills under `.gemini/skills/` and `.agents/skills/` are detected
- [ ] Verify `GET /api/skills/resolve?name=xxx` returns 404 for nonexistent and 400 for traversal attempts
- [ ] Run `npx tsc --noEmit` — passes clean
