### PR TITLE
Add abortable loading for chat file preview

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -180,6 +180,12 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
   const [candidates, setCandidates] = useState(null);
   const [resolvedPath, setResolvedPath] = useState(null);
   const editorRef = useRef(null);
+  const abortRef = useRef(null);
+
+  const handleAbortAndClose = () => {
+    abortRef.current?.abort();
+    onClose();
+  };
 
   // Check if file is markdown
   const isMarkdownFile = useMemo(() => {
@@ -488,6 +494,10 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
 
   // Load file content
   useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const signal = controller.signal;
+
     const loadFileContent = async () => {
       try {
         setLoading(true);
@@ -500,7 +510,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
 
         // Binary files (PDF, image): fetch as blob
         if (isBinary) {
-          const blob = await api.getFileContentBlob(file.projectName, absoluteFilePath);
+          const blob = await api.getFileContentBlob(file.projectName, absoluteFilePath, { signal });
           const url = URL.createObjectURL(blob);
           setBlobUrl(url);
           setLoading(false);
@@ -519,7 +529,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
 
         // Otherwise, load from disk (use resolved path if available after disambiguation)
         const actualPath = resolvedPath || file.path;
-        const response = await api.readFile(file.projectName, actualPath);
+        const response = await api.readFile(file.projectName, actualPath, { signal });
 
         if (!response.ok) {
           if (response.status === 404) {
@@ -539,16 +549,20 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
 
         setContent(data.content);
       } catch (error) {
+        if (error.name === 'AbortError') return;
         console.error('Error loading file:', error);
         setContent(`// Error loading file: ${error.message}\n// File: ${file.name}\n// Path: ${file.path}`);
       } finally {
-        setLoading(false);
+        if (!signal.aborted) {
+          setLoading(false);
+        }
       }
     };
 
     loadFileContent();
 
     return () => {
+      controller.abort();
       if (blobUrl) URL.revokeObjectURL(blobUrl);
     };
   }, [absoluteFilePath, file, projectPath, isBinary, isUnsupported, resolvedPath]);
@@ -704,7 +718,10 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
           `}
         </style>
         {isSidebar ? (
-          <div className="w-full h-full flex items-center justify-center bg-background">
+          <div className="w-full h-full flex items-center justify-center bg-background relative">
+            <button onClick={handleAbortAndClose} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
+              <X className="w-4 h-4 text-gray-500" />
+            </button>
             <div className="flex items-center gap-3">
               <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
               <span className="text-gray-900 dark:text-white">{t('loading', { fileName: file.name })}</span>
@@ -712,7 +729,10 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
           </div>
         ) : (
           <div className="fixed inset-0 z-[9999] md:bg-black/50 md:flex md:items-center md:justify-center">
-            <div className="code-editor-loading w-full h-full md:rounded-lg md:w-auto md:h-auto p-8 flex items-center justify-center">
+            <div className="code-editor-loading w-full h-full md:rounded-lg md:w-auto md:h-auto p-8 flex items-center justify-center relative">
+              <button onClick={handleAbortAndClose} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
+                <X className="w-4 h-4 text-gray-500" />
+              </button>
               <div className="flex items-center gap-3">
                 <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
                 <span className="text-gray-900 dark:text-white">{t('loading', { fileName: file.name })}</span>

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 import ChatContextSidebar from './subcomponents/ChatContextSidebar';
+import ChatContextFilePreview, { type PreviewFileTarget } from './subcomponents/ChatContextFilePreview';
 import GuidedPromptStarter from './subcomponents/GuidedPromptStarter';
 import { RESUMING_STATUS_TEXT } from '../types/types';
 import type { ChatInterfaceProps } from '../types/types';
@@ -22,10 +23,9 @@ import { Button } from '../../ui/button';
 import type { PendingAutoIntake } from '../../../types/app';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, OPENROUTER_MODELS } from '../../../../shared/modelConstants';
 import { getProviderDisplayName } from '../utils/chatFormatting';
-const CodeEditor = React.lazy(() => import('../../CodeEditor'));
-import type { EditingFile } from '../../main-content/types/types';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
+import { X } from 'lucide-react';
 
 
 const DEFAULT_PROVIDER_AVAILABILITY: Record<Provider, ProviderAvailability> = {
@@ -111,19 +111,28 @@ function ChatInterface({
   const { t } = useTranslation('chat');
   const { isMobile } = useDeviceSettings({ trackPWA: false });
   const [isShellEditPromptOpen, setIsShellEditPromptOpen] = useState(false);
-  const [previewFile, setPreviewFile] = useState<EditingFile | null>(null);
+  const [previewFile, setPreviewFile] = useState<PreviewFileTarget | null>(null);
 
   const handleFilePreview = useCallback((filePath: string) => {
     const root = selectedProject?.fullPath || selectedProject?.path || '';
     const relative = toRelativePath(filePath, root);
     if (!relative || !isSafePath(relative)) return;
     const name = fileNameFromPath(normalizePath(filePath));
-    setPreviewFile({ name, path: relative, projectName: selectedProject?.name });
+    setPreviewFile({
+      name,
+      relativePath: relative,
+      absolutePath: normalizePath(filePath),
+    });
   }, [selectedProject]);
 
   const handleClosePreview = useCallback(() => {
     setPreviewFile(null);
   }, []);
+
+  const handleOpenPreviewInEditor = useCallback((filePath: string) => {
+    setPreviewFile(null);
+    onFileOpen?.(filePath);
+  }, [onFileOpen]);
 
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>(() => {
     if (typeof window === 'undefined') return 'context';
@@ -557,6 +566,24 @@ function ChatInterface({
   }, [selectedSession?.id, selectedProject?.name]);
 
   useEffect(() => {
+    if (!previewFile) {
+      return undefined;
+    }
+
+    const handlePreviewEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.repeat || event.defaultPrevented) {
+        return;
+      }
+
+      event.stopPropagation();
+      setPreviewFile(null);
+    };
+
+    document.addEventListener('keydown', handlePreviewEscape);
+    return () => document.removeEventListener('keydown', handlePreviewEscape);
+  }, [previewFile]);
+
+  useEffect(() => {
     if (!isLoading || !canAbortSession) {
       return;
     }
@@ -710,29 +737,7 @@ function ChatInterface({
     <>
       <div className={`h-full flex min-h-0 ${isMobile ? 'flex-col' : 'flex-row'}`}>
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {previewFile && (
-            <div className="flex-1 min-h-0 overflow-hidden">
-              <React.Suspense fallback={
-                <div className="w-full h-full flex items-center justify-center bg-background relative">
-                  <button onClick={handleClosePreview} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
-                    <svg className="w-4 h-4 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
-                  </button>
-                  <div className="flex items-center gap-3">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-                  </div>
-                </div>
-              }>
-                <CodeEditor
-                  file={previewFile}
-                  onClose={handleClosePreview}
-                  projectPath={selectedProject?.path}
-                  selectedProject={selectedProject}
-                  isSidebar
-                />
-              </React.Suspense>
-            </div>
-          )}
-          <div className={previewFile ? 'hidden' : `flex min-h-0 flex-1 flex-col ${isEmpty ? 'justify-start pt-[18vh] overflow-y-auto' : ''}`}>
+          <div className={`flex min-h-0 flex-1 flex-col ${isEmpty ? 'justify-start pt-[18vh] overflow-y-auto' : ''}`}>
         {shouldShowImportedProjectAnalysisPrompt && (
           <div className="mx-auto mt-4 w-full max-w-3xl px-3 sm:px-4">
             <div className="rounded-xl border border-border bg-card/95 shadow-sm px-4 py-4 sm:px-5">
@@ -957,6 +962,34 @@ function ChatInterface({
           onStartTask={handleStartTaskInChat}
         />
       </div>
+
+      {previewFile && selectedProject && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+          onClick={handleClosePreview}
+        >
+          <div
+            className="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={handleClosePreview}
+              className="absolute right-3 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+              title={t('sessionContext.preview.closePreview')}
+            >
+              <X className="h-5 w-5" />
+            </button>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <ChatContextFilePreview
+                projectName={selectedProject.name}
+                file={previewFile}
+                onOpenInEditor={handleOpenPreviewInEditor}
+              />
+            </div>
+          </div>
+        </div>
+      )}
 
       {isShellEditPromptOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-4">

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -22,7 +22,7 @@ import { Button } from '../../ui/button';
 import type { PendingAutoIntake } from '../../../types/app';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, OPENROUTER_MODELS } from '../../../../shared/modelConstants';
 import { getProviderDisplayName } from '../utils/chatFormatting';
-import CodeEditor from '../../CodeEditor';
+const CodeEditor = React.lazy(() => import('../../CodeEditor'));
 import type { EditingFile } from '../../main-content/types/types';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
@@ -712,13 +712,24 @@ function ChatInterface({
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {previewFile && (
             <div className="flex-1 min-h-0 overflow-hidden">
-              <CodeEditor
-                file={previewFile}
-                onClose={handleClosePreview}
-                projectPath={selectedProject?.path}
-                selectedProject={selectedProject}
-                isSidebar
-              />
+              <React.Suspense fallback={
+                <div className="w-full h-full flex items-center justify-center bg-background relative">
+                  <button onClick={handleClosePreview} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
+                    <svg className="w-4 h-4 text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M18 6L6 18M6 6l12 12" /></svg>
+                  </button>
+                  <div className="flex items-center gap-3">
+                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+                  </div>
+                </div>
+              }>
+                <CodeEditor
+                  file={previewFile}
+                  onClose={handleClosePreview}
+                  projectPath={selectedProject?.path}
+                  selectedProject={selectedProject}
+                  isSidebar
+                />
+              </React.Suspense>
             </div>
           )}
           <div className={previewFile ? 'hidden' : `flex min-h-0 flex-1 flex-col ${isEmpty ? 'justify-start pt-[18vh] overflow-y-auto' : ''}`}>

--- a/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
@@ -8,10 +8,15 @@ import { ExternalLink, FileText } from 'lucide-react';
 
 import { Button } from '../../../ui/button';
 import { api } from '../../../../utils/api';
-import type { SessionContextFileItem, SessionContextOutputItem } from '../../utils/sessionContextSummary';
 import { IMAGE_EXTENSIONS, AUDIO_EXTENSIONS, VIDEO_EXTENSIONS, MARKDOWN_EXTENSIONS, HTML_EXTENSIONS } from '../../utils/fileExtensions';
 
-type PreviewFile = SessionContextFileItem | SessionContextOutputItem | null;
+export interface PreviewFileTarget {
+  name: string;
+  relativePath: string;
+  absolutePath: string | null;
+}
+
+type PreviewFile = PreviewFileTarget | null;
 
 type PreviewKind = 'empty' | 'loading' | 'text' | 'json' | 'markdown' | 'html' | 'pdf' | 'image' | 'audio' | 'video' | 'error';
 
@@ -133,7 +138,7 @@ export default function ChatContextFilePreview({
       try {
         if (previewKind === 'pdf' || previewKind === 'image' || previewKind === 'audio' || previewKind === 'video') {
           const absolutePath = file.absolutePath || file.relativePath;
-          const blob = await api.getFileContentBlob(projectName, absolutePath);
+          const blob = await api.getFileContentBlob(projectName, absolutePath, { signal: abortController.signal });
           if (abortController.signal.aborted) {
             return;
           }
@@ -143,7 +148,7 @@ export default function ChatContextFilePreview({
           return;
         }
 
-        const response = await api.readFile(projectName, file.relativePath);
+        const response = await api.readFile(projectName, file.relativePath, { signal: abortController.signal });
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -155,13 +155,13 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(workspaceData),
     }),
-  readFile: (projectName, filePath) =>
-    authenticatedFetch(`/api/projects/${projectName}/file?filePath=${encodeURIComponent(filePath)}`),
+  readFile: (projectName, filePath, options = {}) =>
+    authenticatedFetch(`/api/projects/${projectName}/file?filePath=${encodeURIComponent(filePath)}`, options),
   resolveSkill: (skillName, workingDir) =>
     authenticatedFetch(`/api/skills/resolve?name=${encodeURIComponent(skillName)}&workingDir=${encodeURIComponent(workingDir || '')}`),
   /** Fetch binary file content (e.g. PDF) as Blob. absolutePath must be the full filesystem path. */
-  getFileContentBlob: (projectName, absolutePath) =>
-    authenticatedFetch(`/api/projects/${projectName}/files/content?path=${encodeURIComponent(absolutePath)}`).then((r) => {
+  getFileContentBlob: (projectName, absolutePath, options = {}) =>
+    authenticatedFetch(`/api/projects/${projectName}/files/content?path=${encodeURIComponent(absolutePath)}`, options).then((r) => {
       if (!r.ok) throw new Error(r.status === 404 ? 'Not found' : `HTTP ${r.status}`);
       return r.blob();
     }),


### PR DESCRIPTION
## Summary
- add loading-state close actions for chat file previews and full-screen file editor loading
- abort in-flight file content requests when the preview is closed or unmounted
- lazy-load the chat preview editor and show a suspense fallback while it initializes

## Testing
- npm run typecheck
- npm run build

## Notes
- Vite build still reports that `CodeEditor` remains statically imported elsewhere, so the dynamic import in chat does not currently split it into a separate chunk.