### PR TITLE
fix: close Auto Research dropdown on outside click

### DIFF
--- a/src/components/chat/view/subcomponents/GuidedPromptStarter.tsx
+++ b/src/components/chat/view/subcomponents/GuidedPromptStarter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   GUIDED_PROMPT_SCENARIOS,
@@ -50,6 +50,18 @@ export default function GuidedPromptStarter({
   const [availableSkills, setAvailableSkills] = useState<Set<string> | null>(null);
   const [autoResearchOpen, setAutoResearchOpen] = useState(false);
   const [expandedGuidedPack, setExpandedGuidedPack] = useState<string | null>(null);
+  const autoResearchRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (autoResearchRef.current && !autoResearchRef.current.contains(e.target as Node)) {
+        setAutoResearchOpen(false);
+        setExpandedGuidedPack(null);
+      }
+    };
+    if (autoResearchOpen) document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [autoResearchOpen]);
 
   useEffect(() => {
     let cancelled = false;
@@ -152,7 +164,7 @@ export default function GuidedPromptStarter({
   return (
     <div className="flex flex-wrap justify-center gap-2.5 max-w-3xl mx-auto px-4 mt-6">
       {/* Auto Research dropdown button — reads from Research Hub packs */}
-      <div className="relative">
+      <div ref={autoResearchRef} className="relative">
         <button
           type="button"
           onClick={() => setAutoResearchOpen(!autoResearchOpen)}


### PR DESCRIPTION
Summary
Add click-outside-to-close behavior for the Auto Research dropdown in the guided prompt starter (empty chat state)

Before
When clicking the 🧪 Auto Research button in the chat empty state, the dropdown opens but can only be closed by clicking the button again. Clicking anywhere else on the page leaves the dropdown open.

After
Clicking anywhere outside the dropdown now closes it. This is consistent with how all other dropdowns in the project already behave (e.g., AutoResearchDropdown in the chat toolbar, GitPanel, etc.), which use the same mousedown outside-click pattern.