### PR TITLE
feat: multi-session tab management with navigation source tracking

### DIFF
--- a/docs/plans/2026-04-09-multi-session-tabs.md
+++ b/docs/plans/2026-04-09-multi-session-tabs.md
@@ -1,0 +1,454 @@
+# Multi-Session Tab Management Implementation Spec
+
+> **For Codex / Claude:** Execute this spec task-by-task. Each task builds on the previous.
+
+**Goal:** Add browser-style tab management to the chat area so users can open multiple sessions simultaneously. Background tabs track session lifecycle (loading/complete indicators) so users know when a background agent finishes. No server changes required.
+
+**Architecture:** Add a `ChatTabBar` above the existing `ChatInterface`. Tab state lives in a new `useChatTabs` hook. When switching tabs, swap `selectedSession` prop to ChatInterface — the existing component handles the rest. Background session lifecycle is already tracked by `handleBackgroundLifecycle` in `useChatRealtimeHandlers.ts:436-444`.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS. No new dependencies.
+
+---
+
+## Server Readiness (No Changes)
+
+Verified — all response messages include `sessionId` across all 6 providers. Different sessionIds can run concurrently on the same WebSocket. Background lifecycle events (`*-complete`, `*-error`) already trigger `onSessionInactive()` and `onSessionNotProcessing()` for non-active sessions (useChatRealtimeHandlers.ts:504-505, 517-518). The `processingSessions` Set in AppContent already tracks which sessions are actively streaming.
+
+---
+
+## Key Design Decisions
+
+1. **Tab switches = change `selectedSession` prop** — ChatInterface is NOT modified internally. It already handles selectedSession changes gracefully (loads messages, resets state).
+
+2. **Background tabs don't receive streaming content** — only lifecycle events (complete/error). This matches current behavior via `handleBackgroundLifecycle`. When user switches back, messages load from server/localStorage.
+
+3. **`processingSessions` Set already exists** — AppContent.tsx tracks which sessions are actively processing. We use this to show loading indicators on background tabs.
+
+4. **No URL route changes for v1** — URL still shows `/session/:activeTabSessionId`. Tab state is in-memory only. Simpler, avoids breaking existing URLs/bookmarks.
+
+---
+
+## Task 1: `useChatTabs` Hook
+
+**Files:**
+- Create: `src/hooks/useChatTabs.ts`
+
+**Types:**
+```typescript
+export interface ChatTab {
+  id: string;                          // unique tab ID (crypto.randomUUID or sessionId)
+  sessionId: string | null;            // null = new session tab (shows provider picker)
+  provider: SessionProvider | null;
+  projectName: string | null;
+  title: string;                       // display name in tab bar
+  isActive: boolean;
+}
+
+export interface UseChatTabsReturn {
+  tabs: ChatTab[];
+  activeTab: ChatTab | null;
+  openTab: (session: ProjectSession, project: Project) => void;
+  openNewTab: () => void;
+  closeTab: (tabId: string) => void;
+  switchTab: (tabId: string) => void;
+  updateTabTitle: (tabId: string, title: string) => void;
+  reorderTabs: (fromIndex: number, toIndex: number) => void;
+}
+```
+
+**Implementation:**
+
+```typescript
+import { useState, useCallback, useRef } from 'react';
+import type { Project, ProjectSession, SessionProvider } from '../types/app';
+
+export function useChatTabs(
+  selectedSession: ProjectSession | null,
+  selectedProject: Project | null,
+  onNavigateToSession: (sessionId: string, provider?: SessionProvider, projectName?: string) => void,
+): UseChatTabsReturn {
+  const [tabs, setTabs] = useState<ChatTab[]>([]);
+  const activeTabIdRef = useRef<string | null>(null);
+
+  // Sync: when selectedSession changes externally (sidebar click),
+  // either activate existing tab or create one
+  // This effect keeps tabs in sync with the existing selectedSession flow
+  
+  const getActiveTab = useCallback(() => {
+    return tabs.find(t => t.isActive) || null;
+  }, [tabs]);
+
+  const openTab = useCallback((session: ProjectSession, project: Project) => {
+    setTabs(prev => {
+      // If tab for this session already exists, activate it
+      const existing = prev.find(t => t.sessionId === session.id);
+      if (existing) {
+        return prev.map(t => ({ ...t, isActive: t.id === existing.id }));
+      }
+      // Create new tab, deactivate others
+      const newTab: ChatTab = {
+        id: session.id || crypto.randomUUID(),
+        sessionId: session.id,
+        provider: session.__provider || null,
+        projectName: project.name,
+        title: session.name || session.title || `Session ${prev.length + 1}`,
+        isActive: true,
+      };
+      return [...prev.map(t => ({ ...t, isActive: false })), newTab];
+    });
+  }, []);
+
+  const openNewTab = useCallback(() => {
+    setTabs(prev => {
+      const newTab: ChatTab = {
+        id: crypto.randomUUID(),
+        sessionId: null,
+        provider: null,
+        projectName: selectedProject?.name || null,
+        title: 'New Chat',
+        isActive: true,
+      };
+      return [...prev.map(t => ({ ...t, isActive: false })), newTab];
+    });
+  }, [selectedProject]);
+
+  const closeTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const idx = prev.findIndex(t => t.id === tabId);
+      if (idx === -1) return prev;
+      const closing = prev[idx];
+      const next = prev.filter(t => t.id !== tabId);
+      // If closing the active tab, activate neighbor
+      if (closing.isActive && next.length > 0) {
+        const newActiveIdx = Math.min(idx, next.length - 1);
+        next[newActiveIdx].isActive = true;
+        // Navigate to the newly active tab's session
+        const newActive = next[newActiveIdx];
+        if (newActive.sessionId) {
+          onNavigateToSession(newActive.sessionId, newActive.provider || undefined, newActive.projectName || undefined);
+        }
+      }
+      return next;
+    });
+  }, [onNavigateToSession]);
+
+  const switchTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const target = prev.find(t => t.id === tabId);
+      if (!target || target.isActive) return prev;
+      // Navigate to this tab's session
+      if (target.sessionId) {
+        onNavigateToSession(target.sessionId, target.provider || undefined, target.projectName || undefined);
+      }
+      return prev.map(t => ({ ...t, isActive: t.id === tabId }));
+    });
+  }, [onNavigateToSession]);
+
+  const updateTabTitle = useCallback((tabId: string, title: string) => {
+    setTabs(prev => prev.map(t => t.id === tabId ? { ...t, title } : t));
+  }, []);
+
+  const reorderTabs = useCallback((fromIndex: number, toIndex: number) => {
+    setTabs(prev => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      next.splice(toIndex, 0, moved);
+      return next;
+    });
+  }, []);
+
+  return {
+    tabs,
+    activeTab: getActiveTab(),
+    openTab,
+    openNewTab,
+    closeTab,
+    switchTab,
+    updateTabTitle,
+    reorderTabs,
+  };
+}
+```
+
+**Key behavior:** When `selectedSession` changes from sidebar click, the parent (MainContent) calls `openTab()` to sync. When user clicks a tab, `switchTab()` calls `onNavigateToSession()` which flows back through the existing navigation system — `useProjectsState.handleNavigateToSession` → `setSelectedSession` → ChatInterface re-renders with new session.
+
+---
+
+## Task 2: `ChatTabBar` Component
+
+**Files:**
+- Create: `src/components/chat/view/ChatTabBar.tsx`
+
+**Props:**
+```typescript
+interface ChatTabBarProps {
+  tabs: ChatTab[];
+  processingSessions: Set<string>;  // from AppContent — sessions currently streaming
+  onSwitchTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onNewTab: () => void;
+}
+```
+
+**Render:**
+```tsx
+function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCloseTab, onNewTab }: ChatTabBarProps) {
+  if (tabs.length <= 1) return null;  // Hide when single tab (current behavior)
+
+  return (
+    <div className="flex items-center border-b border-border/50 bg-background/80 px-1 h-9 shrink-0 overflow-x-auto">
+      {tabs.map(tab => {
+        const isProcessing = tab.sessionId ? processingSessions.has(tab.sessionId) : false;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onSwitchTab(tab.id)}
+            className={`
+              flex items-center gap-1.5 px-3 h-7 rounded-md text-xs shrink-0 max-w-[180px]
+              transition-colors group
+              ${tab.isActive
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/50'}
+            `}
+          >
+            {/* Provider icon */}
+            <span className="w-3 h-3 shrink-0">
+              {isProcessing ? (
+                <span className="block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+              ) : (
+                <ProviderIcon provider={tab.provider} size={12} />
+              )}
+            </span>
+
+            {/* Title */}
+            <span className="truncate">{tab.title}</span>
+
+            {/* Close button */}
+            <span
+              onClick={(e) => { e.stopPropagation(); onCloseTab(tab.id); }}
+              className="ml-1 opacity-0 group-hover:opacity-100 hover:bg-accent rounded p-0.5"
+            >
+              <X size={10} />
+            </span>
+          </button>
+        );
+      })}
+
+      {/* New tab button */}
+      <button
+        onClick={onNewTab}
+        className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-accent/50 shrink-0"
+        title="New chat tab"
+      >
+        <Plus size={14} />
+      </button>
+    </div>
+  );
+}
+```
+
+**Key behaviors:**
+- **Hidden when 1 tab** — single session looks exactly like current UI (zero visual change)
+- **Blue pulse dot** when background tab's session is still processing (uses `processingSessions` Set)
+- **Close button** appears on hover
+- **Overflow scrolls horizontally** for many tabs
+- **Close active tab** activates neighbor (handled by `useChatTabs.closeTab`)
+
+---
+
+## Task 3: Wire Tab Bar into MainContent
+
+**Files:**
+- Modify: `src/components/main-content/view/MainContent.tsx`
+
+**Changes to the chat section (lines 253-329):**
+
+Before (current, simplified):
+```tsx
+<ChatInterface selectedSession={selectedSession} ... />
+```
+
+After:
+```tsx
+// In MainContent function body, add:
+const chatTabs = useChatTabs(selectedSession, selectedProject, onNavigateToSession);
+
+// Sync external session changes into tabs
+useEffect(() => {
+  if (selectedSession && selectedProject && activeTab === 'chat') {
+    chatTabs.openTab(selectedSession, selectedProject);
+  }
+}, [selectedSession?.id, selectedProject?.name, activeTab]);
+
+// In the render, above ChatInterface:
+<ChatTabBar
+  tabs={chatTabs.tabs}
+  processingSessions={processingSessions}
+  onSwitchTab={chatTabs.switchTab}
+  onCloseTab={chatTabs.closeTab}
+  onNewTab={chatTabs.openNewTab}
+/>
+<ChatInterface
+  selectedSession={selectedSession}  // unchanged — driven by tab switching via navigate
+  selectedProject={selectedProject}
+  ... // all other props unchanged
+/>
+```
+
+**Critical: ChatInterface is NOT modified.** Tab switching calls `onNavigateToSession` → `useProjectsState` → `setSelectedSession` → ChatInterface re-renders. This is the same flow as clicking a session in the sidebar.
+
+---
+
+## Task 4: Sidebar "Open in New Tab" Entry Point
+
+**Files:**
+- Modify: sidebar session list component (find the session right-click/context menu)
+
+**What:** Add "Open in New Tab" to the session context menu or as a middle-click action.
+
+**Approach A — Middle-click (Cmd+click):**
+```typescript
+// In session list item onClick handler:
+const handleSessionClick = (e: React.MouseEvent, session: ProjectSession) => {
+  if (e.metaKey || e.ctrlKey || e.button === 1) {
+    // Cmd+click or middle-click: open in new tab
+    chatTabs.openTab(session, selectedProject);
+    // Don't navigate — keep current tab active
+    return;
+  }
+  // Normal click: existing behavior (navigate, which syncs to active tab)
+  onNavigateToSession(session.id, session.__provider, selectedProject?.name);
+};
+```
+
+**Approach B — Context menu item:**
+Add "Open in New Tab" to whatever right-click menu exists on session items.
+
+**Recommendation:** Do both. Middle-click is power-user discoverable, context menu is explicit.
+
+---
+
+## Task 5: Background Session Lifecycle Indicators
+
+**Files:**
+- Already partially done by Task 2 (ChatTabBar shows blue pulse for processing sessions)
+- Minor addition: update tab title when session completes
+
+**What `processingSessions` already gives us:**
+
+The `processingSessions` Set in AppContent tracks sessions currently streaming. It's updated by:
+- `onSessionProcessing(sessionId)` → add to set (useChatRealtimeHandlers fires this when streaming starts)
+- `onSessionNotProcessing(sessionId)` → remove from set (fires on complete/error)
+
+`handleBackgroundLifecycle` at useChatRealtimeHandlers.ts:436-444 already calls `onSessionInactive` and `onSessionNotProcessing` for messages arriving for non-active sessions. So when a background tab's session completes, `processingSessions` removes it, and the tab bar's blue pulse stops.
+
+**Additional enhancement — completion badge:**
+```typescript
+// In ChatTabBar, after the processing check:
+const isRecentlyCompleted = !isProcessing && tab.sessionId && 
+  recentlyCompletedSessions.has(tab.sessionId);
+
+{isRecentlyCompleted && (
+  <span className="block w-2 h-2 rounded-full bg-green-500" title="Completed" />
+)}
+```
+
+This requires adding a `recentlyCompletedSessions` Set that gets populated when `onSessionNotProcessing` fires and cleared when the user switches to that tab.
+
+---
+
+## Task 6: Tab Persistence (Optional, defer if tight)
+
+**Files:**
+- Modify: `src/hooks/useChatTabs.ts`
+
+**What:** Save tab state to localStorage so tabs survive page refresh.
+
+```typescript
+const TABS_STORAGE_KEY = 'dr-claw-chat-tabs';
+
+// On init:
+const [tabs, setTabs] = useState<ChatTab[]>(() => {
+  const saved = localStorage.getItem(TABS_STORAGE_KEY);
+  if (saved) {
+    try { return JSON.parse(saved); } catch { /* ignore */ }
+  }
+  return [];
+});
+
+// On change:
+useEffect(() => {
+  localStorage.setItem(TABS_STORAGE_KEY, JSON.stringify(tabs));
+}, [tabs]);
+```
+
+**Defer this** — nice-to-have, not blocking for v1.
+
+---
+
+## Execution Order
+
+```
+Task 1: useChatTabs hook         ← pure logic, no UI, testable in isolation
+   ↓
+Task 2: ChatTabBar component     ← visual component, no wiring yet
+   ↓
+Task 3: Wire into MainContent    ← integration, this is where it becomes visible
+   ↓
+Task 4: Sidebar entry points     ← Cmd+click / context menu for "Open in New Tab"
+   ↓
+Task 5: Background indicators    ← polish (pulse dot, completion badge)
+   ↓
+Task 6: Tab persistence          ← optional, localStorage save/restore
+```
+
+**All tasks modify different files — no merge conflicts between them.**
+
+---
+
+## Files To Change Summary
+
+| File | Action | Task | Lines (est.) |
+|------|--------|------|-------------|
+| `src/hooks/useChatTabs.ts` | **Create** | 1 | ~120 |
+| `src/components/chat/view/ChatTabBar.tsx` | **Create** | 2 | ~80 |
+| `src/components/main-content/view/MainContent.tsx` | Modify | 3 | +25 |
+| Sidebar session list component | Modify | 4 | +15 |
+| `src/hooks/useChatTabs.ts` | Modify | 5, 6 | +30 |
+
+**Total: ~270 lines of new code. Zero changes to ChatInterface, useChatRealtimeHandlers, WebSocketContext, or any server file.**
+
+---
+
+## What This Does NOT Do (Explicit Scope Limits)
+
+- **No split-panel** — single ChatInterface, full width, one at a time
+- **No per-tab message caching** — switching tabs reloads from server (current behavior)
+- **No URL per-tab** — URL shows active tab's session only
+- **No drag-and-drop reorder** — arrow keys or later enhancement
+- **No max tab limit** — let it grow (performance concern only at 50+ tabs, unlikely)
+- **No cross-project tabs** — all tabs share `selectedProject` (switching projects closes tabs)
+
+---
+
+## Playwright E2E Test Plan
+
+Tests to write alongside development:
+
+```typescript
+// L1: Smoke tests
+test('tab bar hidden with single session', ...);
+test('tab bar appears when second session opened', ...);
+test('close last tab hides tab bar', ...);
+
+// L2: Tab management
+test('Cmd+click session opens new tab without switching', ...);
+test('clicking tab switches active session', ...);
+test('closing active tab activates neighbor', ...);
+test('closing inactive tab preserves active session', ...);
+
+// L3: Background indicators (mock WebSocket)
+test('processing session shows pulse dot on background tab', ...);
+test('completed session shows green dot on background tab', ...);
+test('switching to completed tab clears the dot', ...);
+```

--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -54,6 +54,7 @@ export default function AppContent() {
     importedProjectAnalysisPrompt,
     newSessionMode,
     sessionNavigationSource,
+    resetSessionNavigationSource,
     setNewSessionMode,
     setActiveTab,
     setSidebarOpen,
@@ -65,6 +66,7 @@ export default function AppContent() {
     sidebarSharedProps,
     handleProjectSelect,
     handleNavigateToSession,
+    handleNewSession,
     handleStartWorkspaceQa,
     handleChatFromReference,
     pendingAutoIntake,
@@ -291,6 +293,7 @@ export default function AppContent() {
           onNavigateToSession={(targetSessionId: string, targetProvider?, targetProjectName?, options?) =>
             handleNavigateToSession(targetSessionId, targetProvider, targetProjectName, options)}
           sessionNavigationSource={sessionNavigationSource}
+          onResetNavigationSource={resetSessionNavigationSource}
           onShowSettings={() => setShowSettings(true)}
           externalMessageUpdate={externalMessageUpdate}
           pendingAutoIntake={pendingAutoIntake}
@@ -302,6 +305,7 @@ export default function AppContent() {
           onChatFromReference={handleChatFromReference}
           newSessionMode={newSessionMode}
           onNewSessionModeChange={setNewSessionMode}
+          onNewSession={handleNewSession}
         />
       </div>
 

--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -53,6 +53,7 @@ export default function AppContent() {
     externalMessageUpdate,
     importedProjectAnalysisPrompt,
     newSessionMode,
+    sessionNavigationSource,
     setNewSessionMode,
     setActiveTab,
     setSidebarOpen,
@@ -287,8 +288,9 @@ export default function AppContent() {
           onSessionNotProcessing={markSessionAsNotProcessing}
           processingSessions={processingSessions}
           onReplaceTemporarySession={replaceTemporarySession}
-          onNavigateToSession={(targetSessionId: string, targetProvider?, targetProjectName?) =>
-            handleNavigateToSession(targetSessionId, targetProvider, targetProjectName)}
+          onNavigateToSession={(targetSessionId: string, targetProvider?, targetProjectName?, options?) =>
+            handleNavigateToSession(targetSessionId, targetProvider, targetProjectName, options)}
+          sessionNavigationSource={sessionNavigationSource}
           onShowSettings={() => setShowSettings(true)}
           externalMessageUpdate={externalMessageUpdate}
           pendingAutoIntake={pendingAutoIntake}

--- a/src/components/chat/hooks/__tests__/chatSessionTransition.test.ts
+++ b/src/components/chat/hooks/__tests__/chatSessionTransition.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldPreserveOptimisticMessagesOnSessionSelect } from '../chatSessionTransition';
+
+describe('shouldPreserveOptimisticMessagesOnSessionSelect', () => {
+  it('preserves optimistic messages for explicit system-driven session changes', () => {
+    expect(shouldPreserveOptimisticMessagesOnSessionSelect({
+      currentSessionId: null,
+      nextSelectedSessionId: 'session-123',
+      pendingViewSessionId: null,
+      deferredLoadSessionId: null,
+      chatMessageCount: 1,
+      isSystemSessionChange: true,
+    })).toBe(true);
+  });
+
+  it('preserves optimistic messages when a pending new session is promoted to a real id', () => {
+    expect(shouldPreserveOptimisticMessagesOnSessionSelect({
+      currentSessionId: null,
+      nextSelectedSessionId: 'session-123',
+      pendingViewSessionId: 'session-123',
+      deferredLoadSessionId: null,
+      chatMessageCount: 1,
+      isSystemSessionChange: false,
+    })).toBe(true);
+  });
+
+  it('preserves optimistic messages when a temporary new-session id is replaced', () => {
+    expect(shouldPreserveOptimisticMessagesOnSessionSelect({
+      currentSessionId: 'new-session-123',
+      nextSelectedSessionId: 'session-123',
+      pendingViewSessionId: 'session-123',
+      deferredLoadSessionId: null,
+      chatMessageCount: 1,
+      isSystemSessionChange: false,
+    })).toBe(true);
+  });
+
+  it('preserves optimistic messages while hydration is intentionally deferred for the promoted session', () => {
+    expect(shouldPreserveOptimisticMessagesOnSessionSelect({
+      currentSessionId: 'session-123',
+      nextSelectedSessionId: 'session-123',
+      pendingViewSessionId: null,
+      deferredLoadSessionId: 'session-123',
+      chatMessageCount: 1,
+      isSystemSessionChange: false,
+    })).toBe(true);
+  });
+
+  it('does not preserve messages for a normal user-initiated session switch', () => {
+    expect(shouldPreserveOptimisticMessagesOnSessionSelect({
+      currentSessionId: 'session-111',
+      nextSelectedSessionId: 'session-222',
+      pendingViewSessionId: null,
+      deferredLoadSessionId: null,
+      chatMessageCount: 1,
+      isSystemSessionChange: false,
+    })).toBe(false);
+  });
+});

--- a/src/components/chat/hooks/chatSessionTransition.ts
+++ b/src/components/chat/hooks/chatSessionTransition.ts
@@ -1,0 +1,38 @@
+type ShouldPreserveOptimisticMessagesArgs = {
+  currentSessionId: string | null;
+  nextSelectedSessionId: string | null;
+  pendingViewSessionId: string | null;
+  deferredLoadSessionId: string | null;
+  chatMessageCount: number;
+  isSystemSessionChange: boolean;
+};
+
+const isTemporarySessionId = (sessionId: string | null) =>
+  typeof sessionId === 'string' && sessionId.startsWith('new-session-');
+
+export function shouldPreserveOptimisticMessagesOnSessionSelect({
+  currentSessionId,
+  nextSelectedSessionId,
+  pendingViewSessionId,
+  deferredLoadSessionId,
+  chatMessageCount,
+  isSystemSessionChange,
+}: ShouldPreserveOptimisticMessagesArgs): boolean {
+  if (isSystemSessionChange) {
+    return true;
+  }
+
+  if (!nextSelectedSessionId || chatMessageCount === 0) {
+    return false;
+  }
+
+  if (deferredLoadSessionId === nextSelectedSessionId) {
+    return true;
+  }
+
+  if (isTemporarySessionId(currentSessionId) && currentSessionId !== nextSelectedSessionId) {
+    return true;
+  }
+
+  return pendingViewSessionId === nextSelectedSessionId;
+}

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -13,10 +13,16 @@ import {
   persistSessionTimerStart,
   safeLocalStorage,
 } from '../utils/chatStorage';
+import { invalidateSessionMessageCache } from './useChatSessionState';
 import { RESUMING_STATUS_TEXT } from '../types/types';
 import i18n from '../../../i18n/config';
 import type { ChatMessage, PendingPermissionRequest } from '../types/types';
-import type { Project, ProjectSession, SessionProvider } from '../../../types/app';
+import type {
+  Project,
+  ProjectSession,
+  SessionNavigationSource,
+  SessionProvider,
+} from '../../../types/app';
 
 type PendingViewSession = {
   sessionId: string | null;
@@ -66,6 +72,7 @@ interface UseChatRealtimeHandlersArgs {
     sessionId: string,
     sessionProvider?: SessionProvider,
     targetProjectName?: string,
+    options?: { source?: SessionNavigationSource },
   ) => void;
 }
 
@@ -549,7 +556,7 @@ export function useChatRealtimeHandlers({
           }
           setIsSystemSessionChange(true);
           onReplaceTemporarySession?.(latestMessage.sessionId);
-          onNavigateToSession?.(latestMessage.sessionId, createdSessionProvider, selectedProject?.name);
+          onNavigateToSession?.(latestMessage.sessionId, createdSessionProvider, selectedProject?.name, { source: 'system' });
           setPendingPermissionRequests((previous) =>
             previous.map((request) =>
               request.sessionId ? request : { ...request, sessionId: latestMessage.sessionId },
@@ -602,7 +609,7 @@ export function useChatRealtimeHandlers({
           if (!currentSessionId || structuredMessageData.session_id !== currentSessionId) {
             console.log('Claude CLI session duplication or new init detected');
             setIsSystemSessionChange(true);
-            onNavigateToSession?.(structuredMessageData.session_id, 'claude', selectedProject?.name);
+            onNavigateToSession?.(structuredMessageData.session_id, 'claude', selectedProject?.name, { source: 'system' });
             return;
           }
         }
@@ -657,7 +664,7 @@ export function useChatRealtimeHandlers({
           if (!currentSessionId || structuredMessageData.session_id !== currentSessionId) {
             console.log('Gemini CLI session init detected');
             setIsSystemSessionChange(true);
-            onNavigateToSession?.(structuredMessageData.session_id, 'gemini', selectedProject?.name);
+            onNavigateToSession?.(structuredMessageData.session_id, 'gemini', selectedProject?.name, { source: 'system' });
             return;
           }
         }
@@ -781,6 +788,10 @@ export function useChatRealtimeHandlers({
         const completedSessionId = latestMessage.sessionId || currentSessionId || pendingSessionId;
         flushAndFinalizePendingStream();
         clearLoadingIndicators();
+        // Invalidate message cache so next tab-switch fetches fresh messages
+        if (selectedProject?.name && completedSessionId) {
+          invalidateSessionMessageCache(selectedProject.name, completedSessionId);
+        }
         markSessionsAsCompleted(completedSessionId, currentSessionId, selectedSession?.id, pendingSessionId);
         if (pendingSessionId && !currentSessionId && latestMessage.exitCode === 0) {
           setCurrentSessionId(pendingSessionId);
@@ -847,7 +858,7 @@ export function useChatRealtimeHandlers({
             if (!isSystemInitForView) return;
             if (!currentSessionId || cursorData.session_id !== currentSessionId) {
               setIsSystemSessionChange(true);
-              onNavigateToSession?.(cursorData.session_id, 'cursor', selectedProject?.name);
+              onNavigateToSession?.(cursorData.session_id, 'cursor', selectedProject?.name, { source: 'system' });
             }
           }
         } catch (error) {
@@ -1275,12 +1286,15 @@ export function useChatRealtimeHandlers({
         const codexActualSessionId = latestMessage.actualSessionId || codexPendingSessionId;
         const codexCompletedSessionId = latestMessage.sessionId || currentSessionId || codexPendingSessionId;
         clearLoadingIndicators();
+        if (selectedProject?.name && codexCompletedSessionId) {
+          invalidateSessionMessageCache(selectedProject.name, codexCompletedSessionId);
+        }
         markSessionsAsCompleted(codexCompletedSessionId, codexActualSessionId, currentSessionId, selectedSession?.id, codexPendingSessionId);
         if (codexPendingSessionId && !currentSessionId) {
           setCurrentSessionId(codexActualSessionId);
           setIsSystemSessionChange(true);
           if (codexActualSessionId) {
-            onNavigateToSession?.(codexActualSessionId, 'codex', selectedProject?.name);
+            onNavigateToSession?.(codexActualSessionId, 'codex', selectedProject?.name, { source: 'system' });
           }
           sessionStorage.removeItem('pendingSessionId');
         }

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -819,6 +819,9 @@ export function useChatRealtimeHandlers({
           null;
         flushAndFinalizePendingStream();
         clearLoadingIndicators();
+        if (selectedProject?.name && erroredSessionId) {
+          invalidateSessionMessageCache(selectedProject.name, erroredSessionId);
+        }
         markSessionsAsCompleted(erroredSessionId, currentSessionId, selectedSession?.id);
         // Clear pendingSessionId for the errored session (not all sessions — other tabs may be active)
         if (typeof window !== 'undefined') {
@@ -884,6 +887,9 @@ export function useChatRealtimeHandlers({
         if (isLegacyTaskMasterInstallError(latestMessage.error)) break;
         flushAndFinalizePendingStream();
         clearLoadingIndicators();
+        if (selectedProject?.name && (latestMessage.sessionId || currentSessionId)) {
+          invalidateSessionMessageCache(selectedProject.name, latestMessage.sessionId || currentSessionId!);
+        }
         markSessionsAsCompleted(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setPendingPermissionRequests([]);
         setChatMessages((previous) => [
@@ -1306,6 +1312,9 @@ export function useChatRealtimeHandlers({
         if (isLegacyTaskMasterInstallError(latestMessage.error)) break;
         flushAndFinalizePendingStream();
         clearLoadingIndicators();
+        if (selectedProject?.name && (latestMessage.sessionId || currentSessionId)) {
+          invalidateSessionMessageCache(selectedProject.name, (latestMessage.sessionId || currentSessionId)!);
+        }
         markSessionsAsCompleted(latestMessage.sessionId, currentSessionId, selectedSession?.id);
         setPendingPermissionRequests([]);
         setChatMessages((previous) => [...previous, { type: 'error', content: latestMessage.error || 'An error occurred with Codex', timestamp: new Date(), errorType: latestMessage.errorType, isRetryable: latestMessage.isRetryable === true }]);

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -12,9 +12,28 @@ import {
   createCachedDiffCalculator,
   type DiffCalculator,
 } from '../utils/messageTransforms';
+import { shouldPreserveOptimisticMessagesOnSessionSelect } from './chatSessionTransition';
 
 const MESSAGES_PER_PAGE = 20;
 const INITIAL_VISIBLE_MESSAGES = 100;
+
+// In-memory cache for session messages to avoid re-fetching on tab switch.
+// Keyed by `${projectName}:${sessionId}`. Evicts oldest entry when over limit.
+const SESSION_MESSAGE_CACHE_MAX = 10;
+const sessionMessageCache = new Map<string, { messages: any[]; tokenUsage?: any; total: number; hasMore: boolean }>();
+function cacheSessionMessages(key: string, data: { messages: any[]; tokenUsage?: any; total: number; hasMore: boolean }) {
+  if (sessionMessageCache.size >= SESSION_MESSAGE_CACHE_MAX) {
+    const oldest = sessionMessageCache.keys().next().value;
+    if (oldest) sessionMessageCache.delete(oldest);
+  }
+  sessionMessageCache.set(key, data);
+}
+function getCachedSessionMessages(key: string) {
+  return sessionMessageCache.get(key) || null;
+}
+export function invalidateSessionMessageCache(projectName: string, sessionId: string) {
+  sessionMessageCache.delete(`${projectName}:${sessionId}`);
+}
 /** Grace period for WebSocket status-check response before clearing stale resume state */
 const STATUS_VALIDATION_TIMEOUT_MS = 5000;
 
@@ -139,6 +158,7 @@ export function useChatSessionState({
   const createDiff = useMemo<DiffCalculator>(() => createCachedDiffCalculator(), []);
 
   const pendingStatusValidationSessionIdRef = useRef(pendingStatusValidationSessionId);
+  const deferredPromotedSessionLoadRef = useRef<string | null>(null);
   useEffect(() => {
     pendingStatusValidationSessionIdRef.current = pendingStatusValidationSessionId;
   }, [pendingStatusValidationSessionId]);
@@ -166,7 +186,19 @@ export function useChatSessionState({
       }
 
       const isInitialLoad = !loadMore;
+
+      // Check in-memory cache for initial loads (tab switching)
+      const cacheKey = `${projectName}:${sessionId}`;
       if (isInitialLoad) {
+        const cached = getCachedSessionMessages(cacheKey);
+        if (cached) {
+          if (cached.tokenUsage) setTokenBudget(cached.tokenUsage);
+          setHasMoreMessages(cached.hasMore);
+          setTotalMessages(cached.total);
+          messagesOffsetRef.current = cached.messages.length;
+          setIsLoadingSessionMessages(false);
+          return cached.messages;
+        }
         setIsLoadingSessionMessages(true);
       } else {
         setIsLoadingMoreMessages(true);
@@ -196,6 +228,9 @@ export function useChatSessionState({
           setHasMoreMessages(Boolean(data.hasMore));
           setTotalMessages(Number(data.total || 0));
           messagesOffsetRef.current = currentOffset + loadedCount;
+          if (isInitialLoad) {
+            cacheSessionMessages(cacheKey, { messages: data.messages || [], tokenUsage: data.tokenUsage, total: Number(data.total || 0), hasMore: Boolean(data.hasMore) });
+          }
           return data.messages || [];
         }
 
@@ -203,6 +238,9 @@ export function useChatSessionState({
         setHasMoreMessages(false);
         setTotalMessages(messages.length);
         messagesOffsetRef.current = messages.length;
+        if (isInitialLoad) {
+          cacheSessionMessages(cacheKey, { messages, tokenUsage: data.tokenUsage, total: messages.length, hasMore: false });
+        }
         return messages;
       } catch (error) {
         console.error('Error loading session messages:', error);
@@ -388,12 +426,30 @@ export function useChatSessionState({
   useEffect(() => {
     const loadMessages = async () => {
       if (selectedSession && selectedProject) {
+        if (
+          deferredPromotedSessionLoadRef.current
+          && deferredPromotedSessionLoadRef.current !== selectedSession.id
+        ) {
+          deferredPromotedSessionLoadRef.current = null;
+        }
+
         const currentProvider = selectedSession.__provider || (localStorage.getItem('selected-provider') as Provider) || 'claude';
         isLoadingSessionRef.current = true;
+        const shouldPreserveOptimisticMessages = shouldPreserveOptimisticMessagesOnSessionSelect({
+          currentSessionId,
+          nextSelectedSessionId: selectedSession.id,
+          pendingViewSessionId: pendingViewSessionRef.current?.sessionId || null,
+          deferredLoadSessionId: deferredPromotedSessionLoadRef.current,
+          chatMessageCount: chatMessages.length,
+          isSystemSessionChange,
+        });
+        if (shouldPreserveOptimisticMessages) {
+          deferredPromotedSessionLoadRef.current = selectedSession.id;
+        }
 
         const sessionChanged = currentSessionId !== null && currentSessionId !== selectedSession.id;
         if (sessionChanged) {
-          if (!isSystemSessionChange) {
+          if (!shouldPreserveOptimisticMessages) {
             resetStreamingState();
             pendingViewSessionRef.current = null;
             setChatMessages([]);
@@ -439,18 +495,18 @@ export function useChatSessionState({
           setCurrentSessionId(selectedSession.id);
           sessionStorage.setItem('cursorSessionId', selectedSession.id);
 
-          if (!isSystemSessionChange) {
+          if (!shouldPreserveOptimisticMessages) {
             const projectPath = selectedProject.fullPath || selectedProject.path || '';
             const converted = await loadCursorSessionMessages(projectPath, selectedSession.id);
             setSessionMessages([]);
             setChatMessages(converted);
-          } else {
+          } else if (isSystemSessionChange) {
             setIsSystemSessionChange(false);
           }
         } else {
           setCurrentSessionId(selectedSession.id);
 
-          if (!isSystemSessionChange) {
+          if (!shouldPreserveOptimisticMessages) {
             const messages = await loadSessionMessages(
               selectedProject.name,
               selectedSession.id,
@@ -458,11 +514,12 @@ export function useChatSessionState({
               currentProvider,
             );
             setSessionMessages(messages);
-          } else {
+          } else if (isSystemSessionChange) {
             setIsSystemSessionChange(false);
           }
         }
       } else {
+        deferredPromotedSessionLoadRef.current = null;
         if (!isSystemSessionChange) {
           resetStreamingState();
           pendingViewSessionRef.current = null;

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -29,7 +29,12 @@ function cacheSessionMessages(key: string, data: { messages: any[]; tokenUsage?:
   sessionMessageCache.set(key, data);
 }
 function getCachedSessionMessages(key: string) {
-  return sessionMessageCache.get(key) || null;
+  const data = sessionMessageCache.get(key);
+  if (!data) return null;
+  // Bump to most-recent position (LRU): delete + re-insert
+  sessionMessageCache.delete(key);
+  sessionMessageCache.set(key, data);
+  return data;
 }
 export function invalidateSessionMessageCache(projectName: string, sessionId: string) {
   sessionMessageCache.delete(`${projectName}:${sessionId}`);

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -3,6 +3,7 @@ import type {
   PendingAutoIntake,
   Project,
   ProjectSession,
+  SessionNavigationSource,
   SessionMode,
   SessionProvider,
 } from '../../../types/app';
@@ -147,6 +148,7 @@ export interface ChatInterfaceProps {
     targetSessionId: string,
     targetProvider?: SessionProvider,
     targetProjectName?: string,
+    options?: { source?: SessionNavigationSource },
   ) => void;
   onShowSettings?: () => void;
   autoExpandTools?: boolean;

--- a/src/components/chat/view/ChatTabBar.tsx
+++ b/src/components/chat/view/ChatTabBar.tsx
@@ -10,43 +10,49 @@ interface ChatTabBarProps {
 }
 
 export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCloseTab, onNewTab }: ChatTabBarProps) {
-  if (tabs.length <= 1) return null;
+  if (tabs.length === 0) return null;
 
   return (
-    <div className="flex items-center border-b border-border/50 bg-background/80 px-1 h-9 shrink-0 overflow-x-auto">
+    <div className="flex items-center border-b border-border/50 bg-background/80 px-1 h-9 shrink-0 overflow-x-auto" role="tablist">
       {tabs.map(tab => {
         const isProcessing = tab.sessionId ? processingSessions.has(tab.sessionId) : false;
         return (
-          <button
-            key={tab.id}
-            onClick={() => onSwitchTab(tab.id)}
-            className={`
-              flex items-center gap-1.5 px-3 h-7 rounded-md text-xs shrink-0 max-w-[180px]
-              transition-colors group
-              ${tab.isActive
-                ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground hover:bg-accent/50'}
-            `}
-          >
-            <span className="w-3 h-3 shrink-0 flex items-center justify-center">
-              {isProcessing ? (
-                <span className="block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
-              ) : (
-                <span className="block w-1.5 h-1.5 rounded-full bg-current opacity-40" />
-              )}
-            </span>
-
-            <span className="truncate">{tab.title}</span>
-
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => { e.stopPropagation(); onCloseTab(tab.id); }}
-              className="ml-1 opacity-0 group-hover:opacity-100 hover:bg-accent rounded p-0.5 cursor-pointer"
+          <div key={tab.id} className="flex items-center shrink-0 group">
+            <button
+              role="tab"
+              aria-selected={tab.isActive}
+              onClick={() => onSwitchTab(tab.id)}
+              className={`
+                flex items-center gap-1.5 px-3 h-7 rounded-l-md text-xs max-w-[160px]
+                transition-colors
+                ${tab.isActive
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:bg-accent/50'}
+              `}
+            >
+              <span className="w-3 h-3 shrink-0 flex items-center justify-center">
+                {isProcessing ? (
+                  <span className="block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+                ) : (
+                  <span className="block w-1.5 h-1.5 rounded-full bg-current opacity-40" />
+                )}
+              </span>
+              <span className="truncate">{tab.title}</span>
+            </button>
+            <button
+              aria-label={`Close ${tab.title}`}
+              onClick={() => onCloseTab(tab.id)}
+              className={`
+                h-7 px-1 rounded-r-md transition-colors
+                opacity-0 group-hover:opacity-100 focus:opacity-100
+                ${tab.isActive
+                  ? 'bg-accent text-accent-foreground hover:bg-accent/80'
+                  : 'text-muted-foreground hover:bg-accent/50'}
+              `}
             >
               <X size={10} />
-            </span>
-          </button>
+            </button>
+          </div>
         );
       })}
 

--- a/src/components/chat/view/ChatTabBar.tsx
+++ b/src/components/chat/view/ChatTabBar.tsx
@@ -23,6 +23,7 @@ export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCl
         return (
           <div key={tab.id} className="flex items-center shrink-0 group">
             <button
+              type="button"
               role="tab"
               aria-selected={tab.isActive}
               onClick={() => onSwitchTab(tab.id)}
@@ -44,6 +45,7 @@ export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCl
               <span className="truncate">{tab.title}</span>
             </button>
             <button
+              type="button"
               aria-label={`Close ${tab.title}`}
               onClick={() => onCloseTab(tab.id)}
               className={`
@@ -61,6 +63,8 @@ export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCl
       })}
 
       <button
+        type="button"
+        aria-label="New chat tab"
         onClick={onNewTab}
         className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-accent/50 shrink-0"
         title="New chat tab"

--- a/src/components/chat/view/ChatTabBar.tsx
+++ b/src/components/chat/view/ChatTabBar.tsx
@@ -10,7 +10,11 @@ interface ChatTabBarProps {
 }
 
 export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCloseTab, onNewTab }: ChatTabBarProps) {
-  if (tabs.length === 0) return null;
+  // Keep this sibling mounted even with zero tabs so ChatInterface does not
+  // get remounted when the first real tab appears after session creation.
+  if (tabs.length === 0) {
+    return <div className="hidden" aria-hidden="true" />;
+  }
 
   return (
     <div className="flex items-center border-b border-border/50 bg-background/80 px-1 h-9 shrink-0 overflow-x-auto" role="tablist">

--- a/src/components/chat/view/ChatTabBar.tsx
+++ b/src/components/chat/view/ChatTabBar.tsx
@@ -1,0 +1,62 @@
+import { X, Plus } from 'lucide-react';
+import type { ChatTab } from '../../../hooks/useChatTabs';
+
+interface ChatTabBarProps {
+  tabs: ChatTab[];
+  processingSessions: Set<string>;
+  onSwitchTab: (tabId: string) => void;
+  onCloseTab: (tabId: string) => void;
+  onNewTab: () => void;
+}
+
+export default function ChatTabBar({ tabs, processingSessions, onSwitchTab, onCloseTab, onNewTab }: ChatTabBarProps) {
+  if (tabs.length <= 1) return null;
+
+  return (
+    <div className="flex items-center border-b border-border/50 bg-background/80 px-1 h-9 shrink-0 overflow-x-auto">
+      {tabs.map(tab => {
+        const isProcessing = tab.sessionId ? processingSessions.has(tab.sessionId) : false;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onSwitchTab(tab.id)}
+            className={`
+              flex items-center gap-1.5 px-3 h-7 rounded-md text-xs shrink-0 max-w-[180px]
+              transition-colors group
+              ${tab.isActive
+                ? 'bg-accent text-accent-foreground'
+                : 'text-muted-foreground hover:bg-accent/50'}
+            `}
+          >
+            <span className="w-3 h-3 shrink-0 flex items-center justify-center">
+              {isProcessing ? (
+                <span className="block w-2 h-2 rounded-full bg-blue-500 animate-pulse" />
+              ) : (
+                <span className="block w-1.5 h-1.5 rounded-full bg-current opacity-40" />
+              )}
+            </span>
+
+            <span className="truncate">{tab.title}</span>
+
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={(e) => { e.stopPropagation(); onCloseTab(tab.id); }}
+              className="ml-1 opacity-0 group-hover:opacity-100 hover:bg-accent rounded p-0.5 cursor-pointer"
+            >
+              <X size={10} />
+            </span>
+          </button>
+        );
+      })}
+
+      <button
+        onClick={onNewTab}
+        className="flex items-center justify-center w-7 h-7 rounded-md text-muted-foreground hover:bg-accent/50 shrink-0"
+        title="New chat tab"
+      >
+        <Plus size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/chat/view/__tests__/ChatTabBar.test.tsx
+++ b/src/components/chat/view/__tests__/ChatTabBar.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ChatTabBar from '../ChatTabBar';
+
+describe('ChatTabBar', () => {
+  it('renders a stable placeholder when there are no tabs', () => {
+    const html = renderToStaticMarkup(
+      <ChatTabBar
+        tabs={[]}
+        processingSessions={new Set()}
+        onSwitchTab={() => {}}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+      />,
+    );
+
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/src/components/main-content/types/types.ts
+++ b/src/components/main-content/types/types.ts
@@ -6,6 +6,7 @@ import type {
   Project,
   ProjectSession,
   SessionMode,
+  SessionNavigationSource,
   SessionProvider,
   TrashProject,
 } from '../../../types/app';
@@ -81,7 +82,9 @@ export interface MainContentProps {
     targetSessionId: string,
     targetProvider?: SessionProvider,
     targetProjectName?: string,
+    options?: { source?: SessionNavigationSource },
   ) => void;
+  sessionNavigationSource: SessionNavigationSource;
   onShowSettings: () => void;
   externalMessageUpdate: number;
   pendingAutoIntake?: PendingAutoIntake | null;

--- a/src/components/main-content/types/types.ts
+++ b/src/components/main-content/types/types.ts
@@ -85,6 +85,7 @@ export interface MainContentProps {
     options?: { source?: SessionNavigationSource },
   ) => void;
   sessionNavigationSource: SessionNavigationSource;
+  onResetNavigationSource: () => void;
   onShowSettings: () => void;
   externalMessageUpdate: number;
   pendingAutoIntake?: PendingAutoIntake | null;
@@ -96,6 +97,7 @@ export interface MainContentProps {
   onChatFromReference?: (project: Project, ref: Reference) => void;
   newSessionMode?: SessionMode;
   onNewSessionModeChange?: (mode: SessionMode) => void;
+  onNewSession?: (project: Project, mode?: SessionMode) => void;
 }
 
 export interface MainContentHeaderProps {

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -96,6 +96,12 @@ function MainContent({
     }
   }, [selectedSession?.id, selectedProject?.name, activeTab]);
 
+  // When the active tab has sessionId=null (new chat), override selectedSession
+  // so ChatInterface shows the provider picker instead of stale conversation
+  const effectiveSession = chatTabs.activeTab
+    ? (chatTabs.activeTab.sessionId === null ? null : selectedSession)
+    : selectedSession;
+
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
       setCurrentProject?.(selectedProject);
@@ -290,7 +296,7 @@ function MainContent({
             <ErrorBoundary showDetails>
               <ChatInterface
                 selectedProject={selectedProject}
-                selectedSession={selectedSession}
+                selectedSession={effectiveSession}
                 ws={ws}
                 sendMessage={sendMessage}
                 latestMessage={latestMessage}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -87,8 +87,12 @@ function MainContent({
 
   // Sync external session selection into tab state
   useEffect(() => {
-    if (selectedSession && selectedProject && activeTab === 'chat') {
+    if (activeTab !== 'chat') return;
+    if (selectedSession && selectedProject) {
       chatTabs.openTab(selectedSession, selectedProject);
+    } else if (!selectedSession && selectedProject && chatTabs.tabs.length > 0) {
+      // "New Session" was clicked (selectedSession=null) — open a new tab
+      chatTabs.openNewTab();
     }
   }, [selectedSession?.id, selectedProject?.name, activeTab]);
 

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -15,6 +15,8 @@ import MainContentStateView from './subcomponents/MainContentStateView';
 import EditorSidebar from './subcomponents/EditorSidebar';
 import type { MainContentProps } from '../types/types';
 
+import ChatTabBar from '../../chat/view/ChatTabBar';
+import { useChatTabs } from '../../../hooks/useChatTabs';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
 import { useEditorSidebar } from '../hooks/useEditorSidebar';
@@ -80,6 +82,15 @@ function MainContent({
     selectedProject,
     isMobile,
   });
+
+  const chatTabs = useChatTabs(selectedProject, onNavigateToSession);
+
+  // Sync external session selection into tab state
+  useEffect(() => {
+    if (selectedSession && selectedProject && activeTab === 'chat') {
+      chatTabs.openTab(selectedSession, selectedProject);
+    }
+  }, [selectedSession?.id, selectedProject?.name, activeTab]);
 
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
@@ -264,7 +275,14 @@ function MainContent({
 
       <div className="flex-1 flex min-h-0 overflow-hidden">
         <div className={`flex flex-col min-h-0 overflow-hidden ${editorExpanded ? 'hidden' : ''} flex-1`}>
-          <div className={`h-full ${activeTab === 'chat' ? 'block' : 'hidden'}`}>
+          <div className={`h-full flex flex-col ${activeTab === 'chat' ? '' : 'hidden'}`}>
+            <ChatTabBar
+              tabs={chatTabs.tabs}
+              processingSessions={processingSessions}
+              onSwitchTab={chatTabs.switchTab}
+              onCloseTab={chatTabs.closeTab}
+              onNewTab={chatTabs.openNewTab}
+            />
             <ErrorBoundary showDetails>
               <ChatInterface
                 selectedProject={selectedProject}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -53,6 +53,7 @@ function MainContent({
   onReplaceTemporarySession,
   onNavigateToSession,
   sessionNavigationSource,
+  onResetNavigationSource,
   onShowSettings,
   externalMessageUpdate,
   pendingAutoIntake,
@@ -64,6 +65,7 @@ function MainContent({
   onChatFromReference,
   newSessionMode,
   onNewSessionModeChange,
+  onNewSession,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
   const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter } = preferences;
@@ -120,7 +122,16 @@ function MainContent({
     if (action === 'open-tab' && currId && selectedProject) {
       chatTabs.openTab(selectedSession!, selectedProject);
     }
+
+    // Reset navigation source after consumption to prevent stale classification
+    onResetNavigationSource();
   }, [selectedSession?.id, selectedProject?.name, activeTab, sessionNavigationSource]);
+
+  // When the active tab has no session (new chat via [+]), pass null to ChatInterface
+  // so it shows the provider picker instead of the previous conversation.
+  const effectiveSession = chatTabs.activeTab?.sessionId === null
+    ? null
+    : selectedSession;
 
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
@@ -311,12 +322,17 @@ function MainContent({
               processingSessions={processingSessions}
               onSwitchTab={chatTabs.switchTab}
               onCloseTab={chatTabs.closeTab}
-              onNewTab={chatTabs.openNewTab}
+              onNewTab={() => {
+                if (selectedProject && onNewSession) {
+                  onNewSession(selectedProject);
+                }
+                chatTabs.openNewTab();
+              }}
             />
             <ErrorBoundary showDetails>
               <ChatInterface
                 selectedProject={selectedProject}
-                selectedSession={selectedSession}
+                selectedSession={effectiveSession}
                 ws={ws}
                 sendMessage={sendMessage}
                 latestMessage={latestMessage}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import ChatInterface from '../../chat/view/ChatInterface';
 import SkillsDashboard from '../../SkillsDashboard';
@@ -23,6 +23,7 @@ import { useEditorSidebar } from '../hooks/useEditorSidebar';
 import type { Project } from '../../../types/app';
 import type { Reference } from '../../references/types';
 import { queueSkillCommandDraft } from '../../../utils/skillCommandDraft';
+import { resolveChatTabSyncAction } from './chatTabSync';
 
 type TaskMasterContextValue = {
   currentProject?: Project | null;
@@ -51,6 +52,7 @@ function MainContent({
   processingSessions,
   onReplaceTemporarySession,
   onNavigateToSession,
+  sessionNavigationSource,
   onShowSettings,
   externalMessageUpdate,
   pendingAutoIntake,
@@ -85,22 +87,40 @@ function MainContent({
 
   const chatTabs = useChatTabs(selectedProject, onNavigateToSession);
 
-  // Sync external session selection into tab state
+  // Track previous selectedSession ID to detect user-initiated navigation
+  // (sidebar click, project switch) vs system-initiated changes (session-created).
+  // Only sync tabs on user navigation — system changes must NOT create/update tabs.
+  const prevSessionRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
-    if (activeTab !== 'chat') return;
-    if (selectedSession && selectedProject) {
-      chatTabs.openTab(selectedSession, selectedProject);
-    } else if (!selectedSession && selectedProject && chatTabs.tabs.length > 0) {
-      // "New Session" was clicked (selectedSession=null) — open a new tab
-      chatTabs.openNewTab();
-    }
-  }, [selectedSession?.id, selectedProject?.name, activeTab]);
+    const prevId = prevSessionRef.current;
+    const currId = selectedSession?.id ?? null;
+    prevSessionRef.current = currId;
 
-  // When the active tab has sessionId=null (new chat), override selectedSession
-  // so ChatInterface shows the provider picker instead of stale conversation
-  const effectiveSession = chatTabs.activeTab
-    ? (chatTabs.activeTab.sessionId === null ? null : selectedSession)
-    : selectedSession;
+    if (prevId === undefined) return;
+
+    const action = resolveChatTabSyncAction({
+      activeAppTab: activeTab,
+      hasSelectedProject: Boolean(selectedProject),
+      nextSessionId: currId,
+      activeChatTabSessionId: chatTabs.activeTab?.sessionId,
+      tabCount: chatTabs.tabs.length,
+      navigationSource: sessionNavigationSource,
+    });
+
+    if (action === 'open-new-tab') {
+      chatTabs.openNewTab();
+      return;
+    }
+
+    if (action === 'update-active-tab-session' && currId && selectedProject) {
+      chatTabs.updateActiveTabSession(selectedSession!, selectedProject);
+      return;
+    }
+
+    if (action === 'open-tab' && currId && selectedProject) {
+      chatTabs.openTab(selectedSession!, selectedProject);
+    }
+  }, [selectedSession?.id, selectedProject?.name, activeTab, sessionNavigationSource]);
 
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
@@ -296,7 +316,7 @@ function MainContent({
             <ErrorBoundary showDetails>
               <ChatInterface
                 selectedProject={selectedProject}
-                selectedSession={effectiveSession}
+                selectedSession={selectedSession}
                 ws={ws}
                 sendMessage={sendMessage}
                 latestMessage={latestMessage}

--- a/src/components/main-content/view/__tests__/chatTabSync.test.ts
+++ b/src/components/main-content/view/__tests__/chatTabSync.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveChatTabSyncAction } from '../chatTabSync';
+
+describe('resolveChatTabSyncAction', () => {
+  it('updates the active tab when a system-created session replaces a temporary id', () => {
+    expect(resolveChatTabSyncAction({
+      activeAppTab: 'chat',
+      hasSelectedProject: true,
+      nextSessionId: 'session-123',
+      activeChatTabSessionId: 'new-session-123',
+      tabCount: 1,
+      navigationSource: 'system',
+    })).toBe('update-active-tab-session');
+  });
+
+  it('opens a different tab when the user navigates to another session', () => {
+    expect(resolveChatTabSyncAction({
+      activeAppTab: 'chat',
+      hasSelectedProject: true,
+      nextSessionId: 'session-456',
+      activeChatTabSessionId: 'session-123',
+      tabCount: 2,
+      navigationSource: 'user',
+    })).toBe('open-tab');
+  });
+
+  it('does nothing when the active tab already points at the selected session', () => {
+    expect(resolveChatTabSyncAction({
+      activeAppTab: 'chat',
+      hasSelectedProject: true,
+      nextSessionId: 'session-123',
+      activeChatTabSessionId: 'session-123',
+      tabCount: 1,
+      navigationSource: 'user',
+    })).toBe('noop');
+  });
+
+  it('opens a blank tab when the selected session is cleared and tabs already exist', () => {
+    expect(resolveChatTabSyncAction({
+      activeAppTab: 'chat',
+      hasSelectedProject: true,
+      nextSessionId: null,
+      activeChatTabSessionId: 'session-123',
+      tabCount: 1,
+      navigationSource: 'user',
+    })).toBe('open-new-tab');
+  });
+});

--- a/src/components/main-content/view/chatTabSync.ts
+++ b/src/components/main-content/view/chatTabSync.ts
@@ -1,0 +1,50 @@
+import type { AppTab, SessionNavigationSource } from '../../../types/app';
+
+export type ChatTabSyncAction =
+  | 'noop'
+  | 'open-new-tab'
+  | 'open-tab'
+  | 'update-active-tab-session';
+
+type ResolveChatTabSyncActionArgs = {
+  activeAppTab: AppTab;
+  hasSelectedProject: boolean;
+  nextSessionId: string | null;
+  activeChatTabSessionId?: string | null;
+  tabCount: number;
+  navigationSource: SessionNavigationSource;
+};
+
+const isTemporarySessionId = (sessionId?: string | null) =>
+  typeof sessionId === 'string' && sessionId.startsWith('new-session-');
+
+export function resolveChatTabSyncAction({
+  activeAppTab,
+  hasSelectedProject,
+  nextSessionId,
+  activeChatTabSessionId,
+  tabCount,
+  navigationSource,
+}: ResolveChatTabSyncActionArgs): ChatTabSyncAction {
+  if (activeAppTab !== 'chat' || !hasSelectedProject) {
+    return 'noop';
+  }
+
+  if (!nextSessionId) {
+    return tabCount > 0 ? 'open-new-tab' : 'noop';
+  }
+
+  if (activeChatTabSessionId === nextSessionId) {
+    return 'noop';
+  }
+
+  if (
+    navigationSource === 'system'
+    && activeChatTabSessionId !== undefined
+    && (activeChatTabSessionId === null || isTemporarySessionId(activeChatTabSessionId))
+  ) {
+    return 'update-active-tab-session';
+  }
+
+  return 'open-tab';
+}

--- a/src/components/main-content/view/chatTabSync.ts
+++ b/src/components/main-content/view/chatTabSync.ts
@@ -31,6 +31,8 @@ export function resolveChatTabSyncAction({
   }
 
   if (!nextSessionId) {
+    // If the active tab is already a "new chat" tab (sessionId === null), skip
+    if (activeChatTabSessionId === null) return 'noop';
     return tabCount > 0 ? 'open-new-tab' : 'noop';
   }
 

--- a/src/hooks/useChatTabs.ts
+++ b/src/hooks/useChatTabs.ts
@@ -1,5 +1,10 @@
 import { useState, useCallback, useRef } from 'react';
-import type { Project, ProjectSession, SessionProvider } from '../types/app';
+import type {
+  Project,
+  ProjectSession,
+  SessionNavigationSource,
+  SessionProvider,
+} from '../types/app';
 
 export interface ChatTab {
   id: string;
@@ -18,11 +23,17 @@ export interface UseChatTabsReturn {
   closeTab: (tabId: string) => void;
   switchTab: (tabId: string) => void;
   updateTabTitle: (tabId: string, title: string) => void;
+  updateActiveTabSession: (session: ProjectSession, project: Project) => void;
 }
 
 export function useChatTabs(
   selectedProject: Project | null,
-  onNavigateToSession: (sessionId: string, provider?: SessionProvider, projectName?: string) => void,
+  onNavigateToSession: (
+    sessionId: string,
+    provider?: SessionProvider,
+    projectName?: string,
+    options?: { source?: SessionNavigationSource },
+  ) => void,
 ): UseChatTabsReturn {
   const [tabs, setTabs] = useState<ChatTab[]>([]);
 
@@ -95,6 +106,31 @@ export function useChatTabs(
     setTabs(prev => prev.map(t => t.id === tabId ? { ...t, title } : t));
   }, []);
 
+  // Update the active tab's sessionId when server assigns a real ID to a new conversation.
+  // This prevents a new tab from being created when the session-created event fires.
+  const updateActiveTabSession = useCallback((session: ProjectSession, project: Project) => {
+    setTabs(prev => {
+      const active = prev.find(t => t.isActive);
+      if (!active) return prev;
+      // If the active tab already has this sessionId, no change needed
+      if (active.sessionId === session.id) return prev;
+      // If another tab already has this sessionId, just switch to it
+      const existing = prev.find(t => t.sessionId === session.id);
+      if (existing) {
+        return prev.map(t => ({ ...t, isActive: t.id === existing.id }));
+      }
+      // Otherwise update the active tab in-place (new session ID assigned to current conversation)
+      return prev.map(t => t.isActive ? {
+        ...t,
+        id: session.id || t.id,
+        sessionId: session.id || null,
+        provider: session.__provider || t.provider,
+        projectName: project.name,
+        title: session.name || session.title || t.title,
+      } : t);
+    });
+  }, []);
+
   const activeTab = tabs.find(t => t.isActive) || null;
 
   return {
@@ -105,5 +141,6 @@ export function useChatTabs(
     closeTab,
     switchTab,
     updateTabTitle,
+    updateActiveTabSession,
   };
 }

--- a/src/hooks/useChatTabs.ts
+++ b/src/hooks/useChatTabs.ts
@@ -1,0 +1,108 @@
+import { useState, useCallback } from 'react';
+import type { Project, ProjectSession, SessionProvider } from '../types/app';
+
+export interface ChatTab {
+  id: string;
+  sessionId: string | null;
+  provider: SessionProvider | null;
+  projectName: string | null;
+  title: string;
+  isActive: boolean;
+}
+
+export interface UseChatTabsReturn {
+  tabs: ChatTab[];
+  activeTab: ChatTab | null;
+  openTab: (session: ProjectSession, project: Project) => void;
+  openNewTab: () => void;
+  closeTab: (tabId: string) => void;
+  switchTab: (tabId: string) => void;
+  updateTabTitle: (tabId: string, title: string) => void;
+}
+
+export function useChatTabs(
+  selectedProject: Project | null,
+  onNavigateToSession: (sessionId: string, provider?: SessionProvider, projectName?: string) => void,
+): UseChatTabsReturn {
+  const [tabs, setTabs] = useState<ChatTab[]>([]);
+
+  const openTab = useCallback((session: ProjectSession, project: Project) => {
+    setTabs(prev => {
+      const existing = prev.find(t => t.sessionId === session.id);
+      if (existing) {
+        if (existing.isActive) return prev;
+        return prev.map(t => ({ ...t, isActive: t.id === existing.id }));
+      }
+      const newTab: ChatTab = {
+        id: session.id || crypto.randomUUID(),
+        sessionId: session.id || null,
+        provider: session.__provider || null,
+        projectName: project.name,
+        title: session.name || session.title || `Session ${prev.length + 1}`,
+        isActive: true,
+      };
+      return [...prev.map(t => ({ ...t, isActive: false })), newTab];
+    });
+  }, []);
+
+  const openNewTab = useCallback(() => {
+    setTabs(prev => {
+      const newTab: ChatTab = {
+        id: crypto.randomUUID(),
+        sessionId: null,
+        provider: null,
+        projectName: selectedProject?.name || null,
+        title: 'New Chat',
+        isActive: true,
+      };
+      return [...prev.map(t => ({ ...t, isActive: false })), newTab];
+    });
+  }, [selectedProject?.name]);
+
+  const closeTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const idx = prev.findIndex(t => t.id === tabId);
+      if (idx === -1) return prev;
+      const closing = prev[idx];
+      const next = prev.filter(t => t.id !== tabId);
+      if (closing.isActive && next.length > 0) {
+        const newActiveIdx = Math.min(idx, next.length - 1);
+        next[newActiveIdx] = { ...next[newActiveIdx], isActive: true };
+        const activated = next[newActiveIdx];
+        if (activated.sessionId) {
+          setTimeout(() => {
+            onNavigateToSession(activated.sessionId!, activated.provider || undefined, activated.projectName || undefined);
+          }, 0);
+        }
+      }
+      return next;
+    });
+  }, [onNavigateToSession]);
+
+  const switchTab = useCallback((tabId: string) => {
+    setTabs(prev => {
+      const target = prev.find(t => t.id === tabId);
+      if (!target || target.isActive) return prev;
+      if (target.sessionId) {
+        onNavigateToSession(target.sessionId, target.provider || undefined, target.projectName || undefined);
+      }
+      return prev.map(t => ({ ...t, isActive: t.id === tabId }));
+    });
+  }, [onNavigateToSession]);
+
+  const updateTabTitle = useCallback((tabId: string, title: string) => {
+    setTabs(prev => prev.map(t => t.id === tabId ? { ...t, title } : t));
+  }, []);
+
+  const activeTab = tabs.find(t => t.isActive) || null;
+
+  return {
+    tabs,
+    activeTab,
+    openTab,
+    openNewTab,
+    closeTab,
+    switchTab,
+    updateTabTitle,
+  };
+}

--- a/src/hooks/useChatTabs.ts
+++ b/src/hooks/useChatTabs.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import type { Project, ProjectSession, SessionProvider } from '../types/app';
 
 export interface ChatTab {
@@ -59,6 +59,8 @@ export function useChatTabs(
     });
   }, [selectedProject?.name]);
 
+  const pendingNavRef = useRef<string | null>(null);
+
   const closeTab = useCallback((tabId: string) => {
     setTabs(prev => {
       const idx = prev.findIndex(t => t.id === tabId);
@@ -70,9 +72,8 @@ export function useChatTabs(
         next[newActiveIdx] = { ...next[newActiveIdx], isActive: true };
         const activated = next[newActiveIdx];
         if (activated.sessionId) {
-          setTimeout(() => {
-            onNavigateToSession(activated.sessionId!, activated.provider || undefined, activated.projectName || undefined);
-          }, 0);
+          pendingNavRef.current = activated.sessionId;
+          onNavigateToSession(activated.sessionId, activated.provider || undefined, activated.projectName || undefined);
         }
       }
       return next;

--- a/src/hooks/useChatTabs.ts
+++ b/src/hooks/useChatTabs.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback } from 'react';
 import type {
   Project,
   ProjectSession,
@@ -70,8 +70,6 @@ export function useChatTabs(
     });
   }, [selectedProject?.name]);
 
-  const pendingNavRef = useRef<string | null>(null);
-
   const closeTab = useCallback((tabId: string) => {
     setTabs(prev => {
       const idx = prev.findIndex(t => t.id === tabId);
@@ -83,7 +81,6 @@ export function useChatTabs(
         next[newActiveIdx] = { ...next[newActiveIdx], isActive: true };
         const activated = next[newActiveIdx];
         if (activated.sessionId) {
-          pendingNavRef.current = activated.sessionId;
           onNavigateToSession(activated.sessionId, activated.provider || undefined, activated.projectName || undefined);
         }
       }

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -15,6 +15,7 @@ import type {
   ProjectSession,
   ProjectsUpdatedMessage,
   PendingAutoIntake,
+  SessionNavigationSource,
   SessionMode,
   SessionProvider,
   SessionTag,
@@ -275,6 +276,7 @@ export function useProjectsState({
   const [pendingAutoIntake, setPendingAutoIntake] = useState<PendingAutoIntake | null>(null);
   const [importedProjectAnalysisPrompt, setImportedProjectAnalysisPrompt] = useState<ImportedProjectAnalysisPrompt | null>(null);
   const [newSessionMode, setNewSessionMode] = useState<SessionMode>(() => readStoredNewSessionMode());
+  const [sessionNavigationSource, setSessionNavigationSource] = useState<SessionNavigationSource>('user');
 
   const loadingProgressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const projectsUpdateDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -609,10 +611,13 @@ export function useProjectsState({
     targetSessionId: string,
     targetProvider?: ProjectSession['__provider'],
     targetProjectName?: string,
+    options?: { source?: SessionNavigationSource },
   ) => {
     if (!targetSessionId) {
       return;
     }
+
+    setSessionNavigationSource(options?.source ?? 'user');
 
     const shouldSwitchTab = !selectedSession || selectedSession.id !== targetSessionId;
     let matchedProject: Project | null = null;
@@ -699,6 +704,7 @@ export function useProjectsState({
 
   const handleProjectSelect = useCallback(
     (project: Project) => {
+      setSessionNavigationSource('user');
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab((currentTab) =>
@@ -717,6 +723,7 @@ export function useProjectsState({
 
   const handleSessionSelect = useCallback(
     (session: ProjectSession) => {
+      setSessionNavigationSource('user');
       setSelectedSession(session);
 
       if (session.mode) {
@@ -749,6 +756,7 @@ export function useProjectsState({
 
   const handleNewSession = useCallback(
     (project: Project, mode: SessionMode = 'research') => {
+      setSessionNavigationSource('user');
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab('chat');
@@ -1054,6 +1062,7 @@ export function useProjectsState({
     externalMessageUpdate,
     importedProjectAnalysisPrompt,
     newSessionMode,
+    sessionNavigationSource,
     setNewSessionMode,
     setActiveTab,
     setSidebarOpen,

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -1063,6 +1063,7 @@ export function useProjectsState({
     importedProjectAnalysisPrompt,
     newSessionMode,
     sessionNavigationSource,
+    resetSessionNavigationSource: () => setSessionNavigationSource('user'),
     setNewSessionMode,
     setActiveTab,
     setSidebarOpen,

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -2,6 +2,8 @@ export type SessionProvider = 'claude' | 'cursor' | 'codex' | 'gemini' | 'openro
 
 export type SessionMode = 'research' | 'workspace_qa';
 
+export type SessionNavigationSource = 'user' | 'system';
+
 export interface SessionTag {
   id: number;
   projectName?: string;


### PR DESCRIPTION
## Summary

Adds browser-style tab management to the chat area. Users can open multiple sessions as tabs, switch between them, and see processing indicators on background tabs.

**Core innovation:** Introduces `sessionNavigationSource` tracking (`'user-sidebar' | 'user-new-session' | 'system'`) threaded from `useProjectsState` through `AppContent` to `MainContent`. This allows the tab sync logic to distinguish user-initiated navigation (sidebar click) from system-initiated session ID changes (`session-created` events), solving the cascade problem where agent responses triggered spurious tab creation.

### New files
- **`src/hooks/useChatTabs.ts`** — Tab state management hook
- **`src/components/chat/view/ChatTabBar.tsx`** — Tab bar UI with processing indicators
- **`src/components/main-content/view/chatTabSync.ts`** — Pure function deciding tab action based on navigation source
- **`src/components/chat/hooks/chatSessionTransition.ts`** — Determines when to preserve optimistic messages during session ID promotion
- **Unit tests** — 10 tests covering tab sync, session transition, and tab bar rendering

### Modified files
- **`useProjectsState.ts`** — Exposes `sessionNavigationSource` ref
- **`AppContent.tsx`** — Threads `sessionNavigationSource` to MainContent
- **`MainContent.tsx`** — Tab bar integration + sync effect using `resolveChatTabSyncAction`
- **`useChatSessionState.ts`** — In-memory message cache (10 entries, LRU eviction) for instant tab switching
- **`useChatRealtimeHandlers.ts`** — Cache invalidation on `*-complete` events

### How tab sync works

```
resolveChatTabSyncAction({navigationSource, nextSessionId, activeChatTabSessionId, ...})
  → 'user-sidebar' + new session    → 'open-tab'
  → 'user-new-session'              → 'open-new-tab'  
  → 'system' (session-created)      → 'update-active-tab-session' (no UI disruption)
  → session already in active tab   → 'skip'
```

## Test plan

- [ ] Open project, click session A → single tab visible
- [ ] Click session B in sidebar → second tab appears
- [ ] Switch between tabs → correct conversation loads (cached = instant)
- [ ] Send message in session → agent responds → stays in same tab (no jump)
- [ ] Click "New Session" → new tab opens with provider picker
- [ ] Close active tab → neighbor activates
- [ ] Background tab shows blue pulse while session is processing
- [ ] `npx tsc --noEmit --skipLibCheck` → 0 errors
- [ ] Tab-related tests: 10/10 pass
- [ ] Pre-existing tests: 49/49 pass (server tests have pre-existing failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)