### PR TITLE
Feat/compute warning skill

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -27,6 +27,7 @@ import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 import { createRequestId, waitForToolApproval, resolveToolApproval as resolvePermApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
 import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
+import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
 
 const activeSessions = new Map();
 const pendingClaudeSessionIndexReconciles = new Map();
@@ -145,12 +146,13 @@ function mapCliOptionsToSDK(options = {}) {
   sdkOptions.model = options.model || CLAUDE_MODELS.DEFAULT;
   console.log(`Using model: ${sdkOptions.model}`);
 
-  // Map system prompt configuration with optional user memory injection
+  // Map system prompt configuration with optional user memory + compute guard injection
   const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
+  const appendBlock = (memoryBlock + COMPUTE_GUARD_BLOCK).trim();
   sdkOptions.systemPrompt = {
     type: 'preset',
     preset: 'claude_code',  // Required to use CLAUDE.md
-    ...(memoryBlock ? { append: memoryBlock } : {}),
+    ...(appendBlock ? { append: appendBlock } : {}),
   };
 
   // Map setting sources for CLAUDE.md loading

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -148,7 +148,7 @@ function mapCliOptionsToSDK(options = {}) {
 
   // Map system prompt configuration with optional user memory + compute guard injection
   const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-  const appendBlock = (memoryBlock + COMPUTE_GUARD_BLOCK).trim();
+  const appendBlock = [memoryBlock, COMPUTE_GUARD_BLOCK].filter(Boolean).join('\n\n').trim();
   sdkOptions.systemPrompt = {
     type: 'preset',
     preset: 'claude_code',  // Required to use CLAUDE.md

--- a/server/gemini-api.js
+++ b/server/gemini-api.js
@@ -14,6 +14,7 @@ import { buildGeminiThinkingConfig } from '../shared/geminiThinkingSupport.js';
 import { spawnGemini } from './gemini-cli.js';
 import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
 import { GEMINI_MODELS } from '../shared/modelConstants.js';
+import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1532,7 +1533,7 @@ export async function queryGeminiApi(command, options = {}, ws) {
       projectName: workingDirectory ? encodeProjectPath(workingDirectory) : undefined,
     });
 
-    const systemText = customSystemPrompt || await buildSystemPrompt(workingDirectory);
+    const systemText = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + COMPUTE_GUARD_BLOCK;
     const systemInstruction = { parts: [{ text: systemText }] };
     const contents = [];
 

--- a/server/gemini-api.js
+++ b/server/gemini-api.js
@@ -1533,7 +1533,7 @@ export async function queryGeminiApi(command, options = {}, ws) {
       projectName: workingDirectory ? encodeProjectPath(workingDirectory) : undefined,
     });
 
-    const systemText = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + COMPUTE_GUARD_BLOCK;
+    const systemText = [(customSystemPrompt || await buildSystemPrompt(workingDirectory)), COMPUTE_GUARD_BLOCK].filter(Boolean).join('\n\n').trim();
     const systemInstruction = { parts: [{ text: systemText }] };
     const contents = [];
 

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -13,6 +13,7 @@ import { splitLegacyGeminiThoughtContent } from '../shared/geminiThoughtParser.j
 import { classifyError } from '../shared/errorClassifier.js';
 import { buildGeminiThinkingConfig } from '../shared/geminiThinkingSupport.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
 import { expandSkillCommand } from './utils/skillExpander.js';
 
 // Use cross-spawn on Windows for better command execution
@@ -621,8 +622,9 @@ export async function spawnGemini(command, options = {}, ws) {
       // Memory is prepended to the user prompt because Gemini CLI uses --prompt flag
       // and does not expose a separate system instruction API.
       const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-      const effectivePrompt = memoryBlock
-        ? `${memoryBlock}\n\n${attachmentResult.modifiedCommand}`
+      const guardedMemory = (memoryBlock + COMPUTE_GUARD_BLOCK).trim();
+      const effectivePrompt = guardedMemory
+        ? `${guardedMemory}\n\n${attachmentResult.modifiedCommand}`
         : `${attachmentResult.modifiedCommand}`;
       args.push('--prompt', effectivePrompt);
 

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -622,7 +622,7 @@ export async function spawnGemini(command, options = {}, ws) {
       // Memory is prepended to the user prompt because Gemini CLI uses --prompt flag
       // and does not expose a separate system instruction API.
       const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-      const guardedMemory = (memoryBlock + COMPUTE_GUARD_BLOCK).trim();
+      const guardedMemory = [memoryBlock, COMPUTE_GUARD_BLOCK].filter(Boolean).join('\n\n').trim();
       const effectivePrompt = guardedMemory
         ? `${guardedMemory}\n\n${attachmentResult.modifiedCommand}`
         : `${attachmentResult.modifiedCommand}`;

--- a/server/local-gpu.js
+++ b/server/local-gpu.js
@@ -20,6 +20,7 @@ import { classifyError } from '../shared/errorClassifier.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
 import { createRequestId, waitForToolApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -765,7 +766,7 @@ export async function queryLocalGPU(command, options = {}, ws) {
     });
 
     const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock;
+    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock + COMPUTE_GUARD_BLOCK;
     const messages = [{ role: 'system', content: systemContent }];
 
     if (sessionId) {

--- a/server/local-gpu.js
+++ b/server/local-gpu.js
@@ -766,7 +766,7 @@ export async function queryLocalGPU(command, options = {}, ws) {
     });
 
     const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock + COMPUTE_GUARD_BLOCK;
+    const systemContent = [(customSystemPrompt || await buildSystemPrompt(workingDirectory)), memoryBlock, COMPUTE_GUARD_BLOCK].filter(Boolean).join('\n\n').trim();
     const messages = [{ role: 'system', content: systemContent }];
 
     if (sessionId) {

--- a/server/mcp-compute.js
+++ b/server/mcp-compute.js
@@ -108,6 +108,22 @@ const TOOLS = [
       properties: {},
     },
   },
+  {
+    name: 'compute_check_available',
+    description:
+      'Check whether compute resources (GPU) are available for running experiments. Returns COMPUTE_OK=true/false with details. Use this BEFORE running any experiment to avoid hallucinating results when no GPU is available. If COMPUTE_OK=false, STOP and inform the user — do NOT proceed with experiments.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        environment: {
+          type: 'string',
+          enum: ['local', 'remote', 'auto'],
+          description: 'Which environment to check. "auto" checks remote first (if configured), then local. Default: auto.',
+          default: 'auto',
+        },
+      },
+    },
+  },
 ];
 
 // ─── Tool handlers ───
@@ -185,6 +201,124 @@ async function handleTool(name, args) {
         (j) => `${j.jobId}\t${j.name}\t${j.partition}\t${j.state}\t${j.elapsed}\t${j.timeLimit}`,
       );
       return [header, ...rows].join('\n');
+    }
+
+    case 'compute_check_available': {
+      const env = args.environment || 'auto';
+      const lines = [];
+      let available = false;
+
+      const checkRemote = async () => {
+        const node = await getActiveNode();
+        if (!node) return null;
+        try {
+          const gpuOut = await ComputeNode.run({
+            nodeId: node.id,
+            command: 'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits 2>/dev/null || echo "NO_GPU"',
+            skipSync: true,
+          });
+          if (gpuOut.includes('NO_GPU')) {
+            return { available: false, reason: `Remote node "${node.name}" has no GPU` };
+          }
+          let freeCount = 0;
+          const gpuLines = [];
+          for (const line of gpuOut.split('\n')) {
+            const parts = line.split(',').map(s => s.trim());
+            if (parts.length >= 4) {
+              const used = parseFloat(parts[2]) || 0;
+              const total = parseFloat(parts[3]) || 0;
+              const isFree = used < 500;
+              if (isFree) freeCount++;
+              gpuLines.push(`  GPU ${parts[0]}: ${parts[1]} — ${used}/${total} MiB${isFree ? ' (FREE)' : ' (BUSY)'}`);
+            }
+          }
+          return {
+            available: freeCount > 0,
+            reason: freeCount > 0
+              ? `Remote node "${node.name}": ${freeCount} free GPU(s)`
+              : `Remote node "${node.name}": all GPUs occupied`,
+            details: gpuLines.join('\n'),
+          };
+        } catch (err) {
+          return { available: false, reason: `Remote node "${node.name}" unreachable: ${err.message}` };
+        }
+      };
+
+      const checkLocal = async () => {
+        const { exec } = await import('child_process');
+        const { promisify } = await import('util');
+        const execAsync = promisify(exec);
+        const run = async (cmd) => { try { return (await execAsync(cmd, { timeout: 15000 })).stdout.trim(); } catch { return ''; } };
+
+        const gpuOut = await run('nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits');
+        if (gpuOut) {
+          let freeCount = 0;
+          const gpuLines = [];
+          for (const line of gpuOut.split('\n')) {
+            const parts = line.split(',').map(s => s.trim());
+            if (parts.length >= 4) {
+              const used = parseFloat(parts[2]) || 0;
+              const total = parseFloat(parts[3]) || 0;
+              const isFree = used < 500;
+              if (isFree) freeCount++;
+              gpuLines.push(`  GPU ${parts[0]}: ${parts[1]} — ${used}/${total} MiB${isFree ? ' (FREE)' : ' (BUSY)'}`);
+            }
+          }
+          return {
+            available: freeCount > 0,
+            reason: freeCount > 0 ? `Local: ${freeCount} free CUDA GPU(s)` : 'Local: all CUDA GPUs occupied',
+            details: gpuLines.join('\n'),
+          };
+        }
+
+        const mpsOut = await run('python3 -c "import torch; print(hasattr(torch.backends, \'mps\') and torch.backends.mps.is_available())" 2>/dev/null');
+        if (mpsOut === 'True') {
+          return { available: true, reason: 'Local: Apple MPS available', details: '  GPU 0: Apple MPS (Metal)' };
+        }
+
+        return {
+          available: false,
+          reason: 'Local: no GPU detected (no CUDA, no MPS)',
+          details: '  nvidia-smi not found, PyTorch MPS not available',
+        };
+      };
+
+      if (env === 'remote') {
+        const r = await checkRemote();
+        if (!r) {
+          lines.push('COMPUTE_OK=false', 'REASON=No active remote compute node configured.');
+        } else {
+          available = r.available;
+          lines.push(`COMPUTE_OK=${r.available}`, `REASON=${r.reason}`);
+          if (r.details) lines.push(r.details);
+        }
+      } else if (env === 'local') {
+        const r = await checkLocal();
+        available = r.available;
+        lines.push(`COMPUTE_OK=${r.available}`, `REASON=${r.reason}`);
+        if (r.details) lines.push(r.details);
+      } else {
+        const remote = await checkRemote();
+        if (remote?.available) {
+          available = true;
+          lines.push(`COMPUTE_OK=true`, `REASON=${remote.reason} (remote)`, remote.details || '');
+        } else {
+          const local = await checkLocal();
+          available = local.available;
+          lines.push(`COMPUTE_OK=${local.available}`, `REASON=${local.reason} (local)`);
+          if (local.details) lines.push(local.details);
+          if (remote) lines.push(`(Remote also checked: ${remote.reason})`);
+        }
+      }
+
+      if (!available) {
+        lines.push('', 'ACTION REQUIRED: Do NOT proceed with experiment execution.',
+          'Inform the user that compute resources are unavailable.',
+          'Do NOT fabricate or hallucinate experiment results.',
+          'Suggest: gpu: modal (serverless), gpu: vast (on-demand), or configure a remote server.');
+      }
+
+      return lines.filter(Boolean).join('\n');
     }
 
     default:

--- a/server/mcp-compute.js
+++ b/server/mcp-compute.js
@@ -204,118 +204,24 @@ async function handleTool(name, args) {
     }
 
     case 'compute_check_available': {
+      const { checkComputeAvailability } = await import('./utils/computeCheck.js');
       const env = args.environment || 'auto';
-      const lines = [];
-      let available = false;
+      const result = await checkComputeAvailability(env);
 
-      const checkRemote = async () => {
-        const node = await getActiveNode();
-        if (!node) return null;
-        try {
-          const gpuOut = await ComputeNode.run({
-            nodeId: node.id,
-            command: 'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits 2>/dev/null || echo "NO_GPU"',
-            skipSync: true,
-          });
-          if (gpuOut.includes('NO_GPU')) {
-            return { available: false, reason: `Remote node "${node.name}" has no GPU` };
-          }
-          let freeCount = 0;
-          const gpuLines = [];
-          for (const line of gpuOut.split('\n')) {
-            const parts = line.split(',').map(s => s.trim());
-            if (parts.length >= 4) {
-              const used = parseFloat(parts[2]) || 0;
-              const total = parseFloat(parts[3]) || 0;
-              const isFree = used < 500;
-              if (isFree) freeCount++;
-              gpuLines.push(`  GPU ${parts[0]}: ${parts[1]} — ${used}/${total} MiB${isFree ? ' (FREE)' : ' (BUSY)'}`);
-            }
-          }
-          return {
-            available: freeCount > 0,
-            reason: freeCount > 0
-              ? `Remote node "${node.name}": ${freeCount} free GPU(s)`
-              : `Remote node "${node.name}": all GPUs occupied`,
-            details: gpuLines.join('\n'),
-          };
-        } catch (err) {
-          return { available: false, reason: `Remote node "${node.name}" unreachable: ${err.message}` };
-        }
-      };
+      const lines = [
+        `COMPUTE_OK=${result.available}`,
+        `REASON=${result.reason}`,
+      ];
+      if (result.details) lines.push(result.details);
 
-      const checkLocal = async () => {
-        const { exec } = await import('child_process');
-        const { promisify } = await import('util');
-        const execAsync = promisify(exec);
-        const run = async (cmd) => { try { return (await execAsync(cmd, { timeout: 15000 })).stdout.trim(); } catch { return ''; } };
-
-        const gpuOut = await run('nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits');
-        if (gpuOut) {
-          let freeCount = 0;
-          const gpuLines = [];
-          for (const line of gpuOut.split('\n')) {
-            const parts = line.split(',').map(s => s.trim());
-            if (parts.length >= 4) {
-              const used = parseFloat(parts[2]) || 0;
-              const total = parseFloat(parts[3]) || 0;
-              const isFree = used < 500;
-              if (isFree) freeCount++;
-              gpuLines.push(`  GPU ${parts[0]}: ${parts[1]} — ${used}/${total} MiB${isFree ? ' (FREE)' : ' (BUSY)'}`);
-            }
-          }
-          return {
-            available: freeCount > 0,
-            reason: freeCount > 0 ? `Local: ${freeCount} free CUDA GPU(s)` : 'Local: all CUDA GPUs occupied',
-            details: gpuLines.join('\n'),
-          };
-        }
-
-        const mpsOut = await run('python3 -c "import torch; print(hasattr(torch.backends, \'mps\') and torch.backends.mps.is_available())" 2>/dev/null');
-        if (mpsOut === 'True') {
-          return { available: true, reason: 'Local: Apple MPS available', details: '  GPU 0: Apple MPS (Metal)' };
-        }
-
-        return {
-          available: false,
-          reason: 'Local: no GPU detected (no CUDA, no MPS)',
-          details: '  nvidia-smi not found, PyTorch MPS not available',
-        };
-      };
-
-      if (env === 'remote') {
-        const r = await checkRemote();
-        if (!r) {
-          lines.push('COMPUTE_OK=false', 'REASON=No active remote compute node configured.');
-        } else {
-          available = r.available;
-          lines.push(`COMPUTE_OK=${r.available}`, `REASON=${r.reason}`);
-          if (r.details) lines.push(r.details);
-        }
-      } else if (env === 'local') {
-        const r = await checkLocal();
-        available = r.available;
-        lines.push(`COMPUTE_OK=${r.available}`, `REASON=${r.reason}`);
-        if (r.details) lines.push(r.details);
-      } else {
-        const remote = await checkRemote();
-        if (remote?.available) {
-          available = true;
-          lines.push(`COMPUTE_OK=true`, `REASON=${remote.reason} (remote)`, remote.details || '');
-        } else {
-          const local = await checkLocal();
-          available = local.available;
-          lines.push(`COMPUTE_OK=${local.available}`, `REASON=${local.reason} (local)`);
-          if (local.details) lines.push(local.details);
-          if (remote) lines.push(`(Remote also checked: ${remote.reason})`);
-        }
-      }
-
-      if (!available) {
-        lines.push('', 'ACTION REQUIRED: Do NOT proceed with experiment execution.',
+      if (!result.available) {
+        lines.push(
+          '',
+          '**CRITICAL SAFETY RULE**: Do NOT proceed with experiment execution.',
           'Inform the user that compute resources are unavailable.',
           'Do NOT fabricate or hallucinate experiment results.',
-          'Suggest: gpu: modal (serverless), gpu: vast (on-demand), or configure a remote server.');
+          'Suggest: gpu: modal (serverless), gpu: vast (on-demand), or configure a remote server.',
+        );
       }
 
       return lines.filter(Boolean).join('\n');

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -22,6 +22,7 @@ import { classifyError } from '../shared/errorClassifier.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
 import { createRequestId, waitForToolApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
 import { expandSkillCommand } from './utils/skillExpander.js';
 import { safePath } from './utils/safePath.js';
 
@@ -658,7 +659,7 @@ export async function queryOpenRouter(command, options = {}, ws) {
 
     // ── Build conversation ───────────────────���─────────────────────────
     const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock;
+    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock + COMPUTE_GUARD_BLOCK;
     const messages = [{ role: 'system', content: systemContent }];
 
     if (sessionId) {

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -659,7 +659,7 @@ export async function queryOpenRouter(command, options = {}, ws) {
 
     // ── Build conversation ───────────────────���─────────────────────────
     const memoryBlock = options.userId ? buildMemoryBlock(options.userId) : '';
-    const systemContent = (customSystemPrompt || await buildSystemPrompt(workingDirectory)) + memoryBlock + COMPUTE_GUARD_BLOCK;
+    const systemContent = [(customSystemPrompt || await buildSystemPrompt(workingDirectory)), memoryBlock, COMPUTE_GUARD_BLOCK].filter(Boolean).join('\n\n').trim();
     const messages = [{ role: 'system', content: systemContent }];
 
     if (sessionId) {

--- a/server/routes/compute.js
+++ b/server/routes/compute.js
@@ -495,6 +495,125 @@ router.get('/local/monitor', async (_req, res) => {
   }
 });
 
+// GET /api/compute/check-available - Quick compute availability check for aris-compute-guard
+router.get('/check-available', async (_req, res) => {
+  const { exec } = await import('child_process');
+  const os = await import('os');
+  const { promisify } = await import('util');
+  const execAsync = promisify(exec);
+
+  const run = async (cmd) => {
+    try {
+      const { stdout } = await execAsync(cmd, { timeout: 15000 });
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  };
+
+  try {
+    const platform = os.default.platform();
+    const result = {
+      available: false,
+      environment: 'local',
+      reason: '',
+      gpus: [],
+      freeGpuCount: 0,
+      suggestions: [],
+    };
+
+    // Check for NVIDIA GPU via nvidia-smi
+    const gpuRaw = await run(
+      'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits'
+    );
+
+    if (gpuRaw) {
+      for (const line of gpuRaw.split('\n')) {
+        const parts = line.split(',').map(s => s.trim());
+        if (parts.length >= 4) {
+          const memUsed = parseFloat(parts[2]) || 0;
+          const memTotal = parseFloat(parts[3]) || 0;
+          const isFree = memUsed < 500;
+          result.gpus.push({
+            index: parseInt(parts[0]) || 0,
+            name: parts[1] || 'Unknown',
+            memUsedMB: memUsed,
+            memTotalMB: memTotal,
+            free: isFree,
+          });
+          if (isFree) result.freeGpuCount++;
+        }
+      }
+
+      if (result.freeGpuCount > 0) {
+        result.available = true;
+        result.reason = `${result.freeGpuCount} free GPU(s) detected via CUDA`;
+      } else {
+        result.reason = 'All GPUs are occupied (memory.used >= 500 MiB on every GPU)';
+        result.suggestions.push(
+          'Free up GPU memory by stopping other processes (check with nvidia-smi)',
+          'Use gpu: modal in CLAUDE.md for serverless GPU',
+          'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
+        );
+      }
+    } else if (platform === 'darwin') {
+      // macOS — check for MPS
+      const mpsCheck = await run(
+        'python3 -c "import torch; print(hasattr(torch.backends, \'mps\') and torch.backends.mps.is_available())" 2>/dev/null'
+      );
+
+      if (mpsCheck === 'True') {
+        result.available = true;
+        result.reason = 'Apple MPS (Metal Performance Shaders) available';
+        result.gpus.push({ index: 0, name: 'Apple MPS', memUsedMB: 0, memTotalMB: 0, free: true });
+        result.freeGpuCount = 1;
+      } else {
+        result.available = false;
+        result.reason = 'No GPU available — macOS without MPS support or PyTorch not installed';
+        result.suggestions.push(
+          'Install PyTorch with MPS support: pip install torch',
+          'Use gpu: modal in CLAUDE.md for serverless GPU',
+          'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
+        );
+      }
+    } else {
+      result.available = false;
+      result.reason = 'No GPU detected — nvidia-smi not found and not on macOS';
+      result.suggestions.push(
+        'Install NVIDIA drivers and CUDA toolkit',
+        'Use gpu: modal in CLAUDE.md for serverless GPU',
+        'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
+        'Configure a remote GPU server with gpu: remote in CLAUDE.md',
+      );
+    }
+
+    // Also check remote compute node availability
+    let remoteAvailable = false;
+    try {
+      const activeNode = await getActiveNode();
+      if (activeNode) {
+        result.remoteNode = { name: activeNode.name, host: activeNode.host };
+        remoteAvailable = true;
+      }
+    } catch { /* no remote node configured */ }
+
+    if (!result.available && remoteAvailable) {
+      result.suggestions.unshift('An active remote compute node is configured — consider using gpu: remote');
+    }
+
+    res.json({ success: true, ...result, timestamp: Date.now() });
+  } catch (error) {
+    console.error('Error checking compute availability:', error);
+    res.json({
+      success: false,
+      available: false,
+      reason: `Compute check failed: ${error.message}`,
+      suggestions: ['Check system configuration and try again'],
+      timestamp: Date.now(),
+    });
+  }
+});
+
 router.get('/status', async (req, res) => {
   try {
     const node = await getActiveNode();

--- a/server/routes/compute.js
+++ b/server/routes/compute.js
@@ -496,118 +496,29 @@ router.get('/local/monitor', async (_req, res) => {
 });
 
 // GET /api/compute/check-available - Quick compute availability check for aris-compute-guard
-router.get('/check-available', async (_req, res) => {
-  const { exec } = await import('child_process');
-  const os = await import('os');
-  const { promisify } = await import('util');
-  const execAsync = promisify(exec);
-
-  const run = async (cmd) => {
-    try {
-      const { stdout } = await execAsync(cmd, { timeout: 15000 });
-      return stdout.trim();
-    } catch {
-      return '';
-    }
-  };
-
+router.get('/check-available', async (req, res) => {
   try {
-    const platform = os.default.platform();
-    const result = {
-      available: false,
-      environment: 'local',
-      reason: '',
-      gpus: [],
-      freeGpuCount: 0,
-      suggestions: [],
-    };
+    const { checkComputeAvailability } = await import('../utils/computeCheck.js');
+    const environment = req.query.environment || 'auto';
+    const result = await checkComputeAvailability(environment);
 
-    // Check for NVIDIA GPU via nvidia-smi
-    const gpuRaw = await run(
-      'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits'
-    );
-
-    if (gpuRaw) {
-      for (const line of gpuRaw.split('\n')) {
-        const parts = line.split(',').map(s => s.trim());
-        if (parts.length >= 4) {
-          const memUsed = parseFloat(parts[2]) || 0;
-          const memTotal = parseFloat(parts[3]) || 0;
-          const isFree = memUsed < 500;
-          result.gpus.push({
-            index: parseInt(parts[0]) || 0,
-            name: parts[1] || 'Unknown',
-            memUsedMB: memUsed,
-            memTotalMB: memTotal,
-            free: isFree,
-          });
-          if (isFree) result.freeGpuCount++;
-        }
-      }
-
-      if (result.freeGpuCount > 0) {
-        result.available = true;
-        result.reason = `${result.freeGpuCount} free GPU(s) detected via CUDA`;
-      } else {
-        result.reason = 'All GPUs are occupied (memory.used >= 500 MiB on every GPU)';
-        result.suggestions.push(
-          'Free up GPU memory by stopping other processes (check with nvidia-smi)',
-          'Use gpu: modal in CLAUDE.md for serverless GPU',
-          'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
-        );
-      }
-    } else if (platform === 'darwin') {
-      // macOS — check for MPS
-      const mpsCheck = await run(
-        'python3 -c "import torch; print(hasattr(torch.backends, \'mps\') and torch.backends.mps.is_available())" 2>/dev/null'
-      );
-
-      if (mpsCheck === 'True') {
-        result.available = true;
-        result.reason = 'Apple MPS (Metal Performance Shaders) available';
-        result.gpus.push({ index: 0, name: 'Apple MPS', memUsedMB: 0, memTotalMB: 0, free: true });
-        result.freeGpuCount = 1;
-      } else {
-        result.available = false;
-        result.reason = 'No GPU available — macOS without MPS support or PyTorch not installed';
-        result.suggestions.push(
-          'Install PyTorch with MPS support: pip install torch',
-          'Use gpu: modal in CLAUDE.md for serverless GPU',
-          'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
-        );
-      }
-    } else {
-      result.available = false;
-      result.reason = 'No GPU detected — nvidia-smi not found and not on macOS';
-      result.suggestions.push(
-        'Install NVIDIA drivers and CUDA toolkit',
-        'Use gpu: modal in CLAUDE.md for serverless GPU',
-        'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
-        'Configure a remote GPU server with gpu: remote in CLAUDE.md',
-      );
-    }
-
-    // Also check remote compute node availability
-    let remoteAvailable = false;
-    try {
-      const activeNode = await getActiveNode();
-      if (activeNode) {
-        result.remoteNode = { name: activeNode.name, host: activeNode.host };
-        remoteAvailable = true;
-      }
-    } catch { /* no remote node configured */ }
-
-    if (!result.available && remoteAvailable) {
-      result.suggestions.unshift('An active remote compute node is configured — consider using gpu: remote');
-    }
-
-    res.json({ success: true, ...result, timestamp: Date.now() });
+    res.json({
+      success: true,
+      available: result.available,
+      environment,
+      reason: result.reason,
+      gpus: result.gpus || [],
+      freeGpuCount: result.freeCount || 0,
+      suggestions: result.suggestions || [],
+      ...(result.remoteNode ? { remoteNode: result.remoteNode } : {}),
+      timestamp: Date.now(),
+    });
   } catch (error) {
     console.error('Error checking compute availability:', error);
     res.json({
       success: false,
       available: false,
-      reason: `Compute check failed: ${error.message}`,
+      reason: 'Compute check failed — see server logs for details',
       suggestions: ['Check system configuration and try again'],
       timestamp: Date.now(),
     });

--- a/server/templates/AGENTS.md
+++ b/server/templates/AGENTS.md
@@ -89,6 +89,25 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
+## Compute Resource Guard (Experiment Stage)
+
+**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
+
+**How to check:**
+1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
+2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
+3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
+
+**If compute resources are insufficient or unavailable:**
+- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
+- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
+- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
+
+**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
+
+The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+
 ## Rules
 
 - **SANDBOX**: All file reads, writes, and creation MUST stay inside this project directory. Never access files outside it. If external data is needed, copy or symlink it into the project.

--- a/server/templates/AGENTS.md
+++ b/server/templates/AGENTS.md
@@ -89,24 +89,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
-## Compute Resource Guard (Experiment Stage)
-
-**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
-
-**How to check:**
-1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
-2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
-3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
-
-**If compute resources are insufficient or unavailable:**
-- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
-- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
-- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
-- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
-
-**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
-
-The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+{{COMPUTE-GUARD}}
 
 ## Rules
 

--- a/server/templates/CLAUDE.md
+++ b/server/templates/CLAUDE.md
@@ -89,6 +89,25 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
+## Compute Resource Guard (Experiment Stage)
+
+**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
+
+**How to check:**
+1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
+2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
+3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
+
+**If compute resources are insufficient or unavailable:**
+- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
+- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
+- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
+
+**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
+
+The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+
 ## Rules
 
 - **SANDBOX**: All file reads, writes, and creation MUST stay inside this project directory. Never access files outside it. If external data is needed, copy or symlink it into the project.

--- a/server/templates/CLAUDE.md
+++ b/server/templates/CLAUDE.md
@@ -89,24 +89,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
-## Compute Resource Guard (Experiment Stage)
-
-**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
-
-**How to check:**
-1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
-2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
-3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
-
-**If compute resources are insufficient or unavailable:**
-- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
-- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
-- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
-- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
-
-**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
-
-The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+{{COMPUTE-GUARD}}
 
 ## Rules
 

--- a/server/templates/GEMINI.md
+++ b/server/templates/GEMINI.md
@@ -89,6 +89,25 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
+## Compute Resource Guard (Experiment Stage)
+
+**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
+
+**How to check:**
+1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
+2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
+3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
+
+**If compute resources are insufficient or unavailable:**
+- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
+- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
+- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
+
+**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
+
+The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+
 ## Rules
 
 - **SANDBOX**: All file reads, writes, and creation MUST stay inside this project directory. Never access files outside it. If external data is needed, copy or symlink it into the project.

--- a/server/templates/GEMINI.md
+++ b/server/templates/GEMINI.md
@@ -89,24 +89,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
-## Compute Resource Guard (Experiment Stage)
-
-**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
-
-**How to check:**
-1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
-2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
-3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
-
-**If compute resources are insufficient or unavailable:**
-- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
-- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
-- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
-- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
-
-**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
-
-The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+{{COMPUTE-GUARD}}
 
 ## Rules
 

--- a/server/templates/_compute-guard-snippet.md
+++ b/server/templates/_compute-guard-snippet.md
@@ -1,0 +1,18 @@
+## Compute Resource Guard (Experiment Stage)
+
+**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
+
+**How to check:**
+1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
+2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
+3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
+
+**If compute resources are insufficient or unavailable:**
+- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
+- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
+- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
+
+**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
+
+The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.

--- a/server/templates/cursor-project.md
+++ b/server/templates/cursor-project.md
@@ -94,6 +94,25 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
+## Compute Resource Guard (Experiment Stage)
+
+**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
+
+**How to check:**
+1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
+2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
+3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
+
+**If compute resources are insufficient or unavailable:**
+- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
+- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
+- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
+
+**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
+
+The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+
 ## Rules
 
 - **SANDBOX**: All file reads, writes, and creation MUST stay inside this project directory. Never access files outside it. If external data is needed, copy or symlink it into the project.

--- a/server/templates/cursor-project.md
+++ b/server/templates/cursor-project.md
@@ -94,24 +94,7 @@ If no suggested skills appear in the prompt, or the user makes a freeform reques
 - `.pipeline/tasks/tasks.json` — The task list generated from the research brief. Each task has: `id`, `title`, `description`, `status` (pending, in-progress, done, review, deferred, cancelled), `stage`, `priority`, `dependencies`, `taskType`, `inputsNeeded`, `suggestedSkills`, and `nextActionPrompt`. Read this to understand what needs to be done.
 - `.pipeline/config.json` — Pipeline configuration metadata.
 
-## Compute Resource Guard (Experiment Stage)
-
-**Before running ANY experiment, training script, evaluation, or GPU-intensive computation**, you MUST first verify that adequate compute resources are available. This applies whether the user invokes a skill explicitly or asks in natural language (e.g., "run the experiment", "train the model", "evaluate on the test set").
-
-**How to check:**
-1. Run `nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader` for CUDA GPUs, or check MPS via `python3 -c "import torch; print(torch.backends.mps.is_available())"` on Mac.
-2. For remote servers, check SSH connectivity and GPU via `ssh <server> nvidia-smi ...`.
-3. Compare the experiment's resource requirements (GPU count, VRAM, RAM) against what is actually available.
-
-**If compute resources are insufficient or unavailable:**
-- **STOP.** Do NOT run training scripts, evaluation scripts, or any experiment code.
-- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is the single most important rule for the experiment stage. An experiment that was never executed has no results.
-- **Report clearly** to the user: what resources the experiment needs, what is currently available, and concrete alternatives (e.g., `gpu: modal` for serverless GPU, `gpu: vast` for on-demand rental, or configuring a remote GPU server).
-- **Do NOT** continue the experiment pipeline or attempt workarounds like running a GPU experiment on CPU unless the user explicitly agrees.
-
-**If compute resources are available:** Briefly confirm (e.g., "GPU 0: RTX 4090, 22GB free — proceeding") and continue with the experiment.
-
-The `/aris-compute-guard` skill in the skills library provides a detailed procedure for this check. Use it when available, or perform the checks inline as described above.
+{{COMPUTE-GUARD}}
 
 ## Rules
 

--- a/server/templates/index.js
+++ b/server/templates/index.js
@@ -7,29 +7,64 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /**
  * Static template files to copy into new Research Lab projects.
  * Each entry maps a source template to its destination path relative to the project root.
+ * Templates with `insertSnippets` have {{SNIPPET_NAME}} placeholders replaced at write time.
  */
 const TEMPLATES = [
-  { src: 'CLAUDE.md', dest: 'CLAUDE.md' },
-  { src: 'cursor-project.md', dest: path.join('.cursor', 'rules', 'project.md') },
-  { src: 'AGENTS.md', dest: 'AGENTS.md' },
-  { src: 'GEMINI.md', dest: 'GEMINI.md' },
+  { src: 'CLAUDE.md', dest: 'CLAUDE.md', insertSnippets: true },
+  { src: 'cursor-project.md', dest: path.join('.cursor', 'rules', 'project.md'), insertSnippets: true },
+  { src: 'AGENTS.md', dest: 'AGENTS.md', insertSnippets: true },
+  { src: 'GEMINI.md', dest: 'GEMINI.md', insertSnippets: true },
 ];
+
+const snippetCache = new Map();
+
+async function loadSnippet(name) {
+  if (snippetCache.has(name)) return snippetCache.get(name);
+  const content = await fs.readFile(path.join(__dirname, `_${name}-snippet.md`), 'utf-8');
+  snippetCache.set(name, content.trim());
+  return content.trim();
+}
+
+async function resolveSnippets(templateContent) {
+  const pattern = /\{\{([A-Z_]+(?:-[A-Z_]+)*)\}\}/g;
+  const matches = [...templateContent.matchAll(pattern)];
+  if (matches.length === 0) return templateContent;
+
+  let result = templateContent;
+  for (const match of matches) {
+    const snippetName = match[1].toLowerCase();
+    try {
+      const snippet = await loadSnippet(snippetName);
+      result = result.replace(match[0], snippet);
+    } catch {
+      console.warn(`[templates] Snippet {{${match[1]}}} not found, leaving placeholder`);
+    }
+  }
+  return result;
+}
 
 /**
  * Write agent instruction template files into a project directory.
- * Copies static .md templates from this directory.
+ * Copies static .md templates from this directory, resolving {{SNIPPET}} placeholders.
  * Skips any file that already exists so user customizations are preserved.
  * @param {string} projectPath - Absolute path to the project directory.
  */
 export async function writeProjectTemplates(projectPath) {
-  for (const { src, dest } of TEMPLATES) {
+  for (const { src, dest, insertSnippets } of TEMPLATES) {
     const destPath = path.join(projectPath, dest);
     try {
       const exists = await fs.access(destPath).then(() => true).catch(() => false);
       if (exists) continue;
 
       await fs.mkdir(path.dirname(destPath), { recursive: true });
-      await fs.copyFile(path.join(__dirname, src), destPath);
+
+      if (insertSnippets) {
+        const raw = await fs.readFile(path.join(__dirname, src), 'utf-8');
+        const resolved = await resolveSnippets(raw);
+        await fs.writeFile(destPath, resolved, 'utf-8');
+      } else {
+        await fs.copyFile(path.join(__dirname, src), destPath);
+      }
     } catch (err) {
       console.error(`[templates] Failed to write ${dest}:`, err.message);
     }

--- a/server/utils/computeCheck.js
+++ b/server/utils/computeCheck.js
@@ -1,0 +1,287 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import os from 'os';
+import { ComputeNode, getActiveNode } from '../compute-node.js';
+
+const execAsync = promisify(exec);
+
+export const MIN_FREE_GPU_MB = Number.parseInt(process.env.COMPUTE_MIN_FREE_GPU_MB || '', 10) || 500;
+
+const CMD_TIMEOUT_MS = 15_000;
+
+/**
+ * Run a shell command locally, returning stdout or '' on failure.
+ * Captures stderr separately for diagnostic logging.
+ */
+async function runLocal(cmd) {
+  try {
+    const { stdout } = await execAsync(cmd, { timeout: CMD_TIMEOUT_MS });
+    return stdout.trim();
+  } catch (err) {
+    if (err.stderr) {
+      console.warn('[computeCheck] command stderr:', err.stderr.trim());
+    }
+    return '';
+  }
+}
+
+/**
+ * Escape a string so it doesn't break plain-text / markdown-ish output.
+ */
+function escapeGpuName(name) {
+  return (name || 'Unknown').replace(/[`\\]/g, '');
+}
+
+/**
+ * Parse nvidia-smi CSV output (index,name,memory.used,memory.total) into
+ * a structured GPU array. Shared between local and remote checks.
+ * @returns {{ gpus: Array, freeCount: number }}
+ */
+export function parseNvidiaSmiGpuList(csvOutput) {
+  const gpus = [];
+  let freeCount = 0;
+  for (const line of csvOutput.split('\n')) {
+    const parts = line.split(',').map(s => s.trim());
+    if (parts.length >= 4) {
+      const memUsed = parseFloat(parts[2]) || 0;
+      const memTotal = parseFloat(parts[3]) || 0;
+      const isFree = memUsed < MIN_FREE_GPU_MB;
+      if (isFree) freeCount++;
+      gpus.push({
+        index: parseInt(parts[0]) || 0,
+        name: escapeGpuName(parts[1]),
+        memUsedMB: memUsed,
+        memTotalMB: memTotal,
+        free: isFree,
+      });
+    }
+  }
+  return { gpus, freeCount };
+}
+
+/**
+ * Format a GPU list for plain-text MCP tool output.
+ */
+export function formatGpuLines(gpus) {
+  return gpus.map(g =>
+    `  GPU ${g.index}: ${g.name} — ${g.memUsedMB}/${g.memTotalMB} MiB${g.free ? ' (FREE)' : ' (BUSY)'}`,
+  );
+}
+
+const FALLBACK_SUGGESTIONS = [
+  'Use gpu: modal in CLAUDE.md for serverless GPU',
+  'Use gpu: vast in CLAUDE.md to rent on-demand GPU',
+  'Configure a remote GPU server with gpu: remote in CLAUDE.md',
+];
+
+/**
+ * Check local compute availability (CUDA GPUs + macOS MPS).
+ * @returns {{ available: boolean, reason: string, gpus: Array, freeCount: number, suggestions: string[], details?: string }}
+ */
+export async function checkLocalCompute() {
+  const gpuRaw = await runLocal(
+    'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits',
+  );
+
+  if (gpuRaw) {
+    const { gpus, freeCount } = parseNvidiaSmiGpuList(gpuRaw);
+    if (freeCount > 0) {
+      return {
+        available: true,
+        reason: `${freeCount} free GPU(s) detected via CUDA`,
+        gpus,
+        freeCount,
+        suggestions: [],
+        details: formatGpuLines(gpus).join('\n'),
+      };
+    }
+    return {
+      available: false,
+      reason: `All GPUs are occupied (memory.used >= ${MIN_FREE_GPU_MB} MiB on every GPU)`,
+      gpus,
+      freeCount: 0,
+      suggestions: [
+        'Free up GPU memory by stopping other processes (check with nvidia-smi)',
+        ...FALLBACK_SUGGESTIONS,
+      ],
+      details: formatGpuLines(gpus).join('\n'),
+    };
+  }
+
+  const platform = os.platform();
+  if (platform === 'darwin') {
+    const mpsOut = await runLocal(
+      'python3 -c "import torch; print(hasattr(torch.backends, \'mps\') and torch.backends.mps.is_available())"',
+    );
+
+    if (mpsOut === 'True') {
+      const gpu = { index: 0, name: 'Apple MPS', memUsedMB: 0, memTotalMB: 0, free: true };
+      return {
+        available: true,
+        reason: 'Apple MPS (Metal Performance Shaders) available',
+        gpus: [gpu],
+        freeCount: 1,
+        suggestions: [],
+        details: '  GPU 0: Apple MPS (Metal)',
+      };
+    }
+    return {
+      available: false,
+      reason: 'No GPU available — macOS without MPS support or PyTorch not installed',
+      gpus: [],
+      freeCount: 0,
+      suggestions: [
+        'Install PyTorch with MPS support: pip install torch',
+        ...FALLBACK_SUGGESTIONS,
+      ],
+    };
+  }
+
+  return {
+    available: false,
+    reason: 'No GPU detected — nvidia-smi not found and not on macOS',
+    gpus: [],
+    freeCount: 0,
+    suggestions: ['Install NVIDIA drivers and CUDA toolkit', ...FALLBACK_SUGGESTIONS],
+  };
+}
+
+/**
+ * Check remote compute node availability (via SSH + nvidia-smi).
+ * @returns {null} if no active node is configured.
+ * @returns {{ available: boolean, reason: string, details?: string, nodeName: string }}
+ */
+export async function checkRemoteCompute() {
+  const node = await getActiveNode();
+  if (!node) return null;
+
+  const nodeName = escapeGpuName(node.name);
+  try {
+    const gpuOut = await ComputeNode.run({
+      nodeId: node.id,
+      command:
+        'nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader,nounits 2>/dev/null || echo "NO_GPU"',
+      skipSync: true,
+    });
+
+    if (gpuOut.includes('NO_GPU')) {
+      return { available: false, reason: `Remote node "${nodeName}" has no GPU`, nodeName };
+    }
+
+    const { gpus, freeCount } = parseNvidiaSmiGpuList(gpuOut);
+    const details = formatGpuLines(gpus).join('\n');
+    return {
+      available: freeCount > 0,
+      reason: freeCount > 0
+        ? `Remote node "${nodeName}": ${freeCount} free GPU(s)`
+        : `Remote node "${nodeName}": all GPUs occupied`,
+      details,
+      nodeName,
+    };
+  } catch (err) {
+    console.error(`[computeCheck] Remote node "${nodeName}" SSH error:`, err.message);
+    return {
+      available: false,
+      reason: `Remote node "${nodeName}" unreachable — check SSH connectivity and try again`,
+      nodeName,
+    };
+  }
+}
+
+/**
+ * Check Vast.ai instance availability by reading vast-instances.json or CLI.
+ * @param {string} [cwd] - project directory to look for vast-instances.json
+ * @returns {{ available: boolean, reason: string }}
+ */
+export async function checkVastCompute(cwd) {
+  try {
+    if (cwd) {
+      const { promises: fs } = await import('fs');
+      const path = await import('path');
+      const instPath = path.default.join(cwd, 'vast-instances.json');
+      const raw = await fs.readFile(instPath, 'utf-8');
+      const instances = JSON.parse(raw);
+      const running = Array.isArray(instances)
+        ? instances.filter(i => i.status === 'running' || i.actual_status === 'running')
+        : [];
+      if (running.length > 0) {
+        return { available: true, reason: `Vast.ai: ${running.length} running instance(s) found` };
+      }
+    }
+  } catch { /* file not found or parse error — fall through */ }
+
+  const cliOut = await runLocal('vastai show instances --raw 2>/dev/null');
+  if (cliOut) {
+    try {
+      const instances = JSON.parse(cliOut);
+      const running = Array.isArray(instances)
+        ? instances.filter(i => i.actual_status === 'running')
+        : [];
+      if (running.length > 0) {
+        return { available: true, reason: `Vast.ai: ${running.length} running instance(s)` };
+      }
+      return { available: false, reason: 'Vast.ai: no running instances (provision one first)' };
+    } catch { /* parse error */ }
+  }
+
+  return { available: false, reason: 'Vast.ai: CLI not installed or no running instances' };
+}
+
+/**
+ * Check Modal serverless compute availability.
+ * @returns {{ available: boolean, reason: string }}
+ */
+export async function checkModalCompute() {
+  const out = await runLocal('modal token verify 2>&1');
+  if (out && !out.toLowerCase().includes('error') && !out.toLowerCase().includes('not found')) {
+    return { available: true, reason: 'Modal: authenticated and ready (serverless — always available)' };
+  }
+  return { available: false, reason: 'Modal: CLI not installed or not authenticated' };
+}
+
+/**
+ * Full compute availability check dispatching to the right environment.
+ * @param {'local'|'remote'|'vast'|'modal'|'auto'} environment
+ * @param {{ cwd?: string }} [opts]
+ * @returns {{ available: boolean, reason: string, gpus?: Array, freeCount?: number, suggestions?: string[], details?: string, remoteNode?: object }}
+ */
+export async function checkComputeAvailability(environment = 'auto', opts = {}) {
+  if (environment === 'local') return checkLocalCompute();
+
+  if (environment === 'remote') {
+    const r = await checkRemoteCompute();
+    if (!r) return { available: false, reason: 'No active remote compute node configured', suggestions: FALLBACK_SUGGESTIONS, gpus: [], freeCount: 0 };
+    return { ...r, gpus: [], freeCount: 0, suggestions: r.available ? [] : FALLBACK_SUGGESTIONS };
+  }
+
+  if (environment === 'vast') {
+    const r = await checkVastCompute(opts.cwd);
+    return { ...r, gpus: [], freeCount: 0, suggestions: r.available ? [] : FALLBACK_SUGGESTIONS };
+  }
+
+  if (environment === 'modal') {
+    const r = await checkModalCompute();
+    return { ...r, gpus: [], freeCount: 0, suggestions: r.available ? [] : FALLBACK_SUGGESTIONS };
+  }
+
+  // auto: remote → local, note remote availability as a suggestion if local fails
+  const remote = await checkRemoteCompute();
+  if (remote?.available) {
+    return {
+      available: true,
+      reason: `${remote.reason} (remote)`,
+      gpus: [],
+      freeCount: 0,
+      suggestions: [],
+      details: remote.details,
+      remoteNode: { name: remote.nodeName },
+    };
+  }
+
+  const local = await checkLocalCompute();
+  if (!local.available && remote) {
+    local.suggestions.unshift(`An active remote compute node is configured — consider using gpu: remote`);
+    local.remoteNode = { name: remote.nodeName };
+  }
+  return local;
+}

--- a/server/utils/computeGuardPrompt.js
+++ b/server/utils/computeGuardPrompt.js
@@ -1,0 +1,20 @@
+/**
+ * Compute Guard prompt block injected into system prompts for all providers.
+ * Ensures the AI agent checks compute resource availability before running
+ * experiments, preventing hallucinated results when no GPU is available.
+ */
+export const COMPUTE_GUARD_BLOCK = `
+
+# Compute Resource Guard
+
+BEFORE running ANY experiment, training script, evaluation, or GPU-intensive task — whether invoked via a skill or asked in natural language — you MUST first check that adequate compute resources are available.
+
+Quick check: run \`nvidia-smi --query-gpu=index,name,memory.used,memory.total --format=csv,noheader\` (Linux/CUDA) or \`python3 -c "import torch; print(torch.backends.mps.is_available())"\` (Mac). For remote servers, check via SSH.
+
+If compute is UNAVAILABLE or INSUFFICIENT for the requested experiment:
+- STOP. Do NOT run the experiment.
+- Do NOT fabricate, imagine, or hallucinate experiment results. An experiment that never ran has no results.
+- Report to the user: what is needed vs. what is available, and suggest alternatives (gpu: modal for serverless, gpu: vast for on-demand, or a remote server).
+
+If compute IS available: briefly confirm and proceed.
+`;

--- a/server/utils/computeGuardPrompt.js
+++ b/server/utils/computeGuardPrompt.js
@@ -5,7 +5,7 @@
  */
 export const COMPUTE_GUARD_BLOCK = `
 
-# Compute Resource Guard
+**CRITICAL SAFETY RULE — Compute Resource Guard**
 
 BEFORE running ANY experiment, training script, evaluation, or GPU-intensive task — whether invoked via a skill or asked in natural language — you MUST first check that adequate compute resources are available.
 

--- a/skills/aris-compute-guard/SKILL.md
+++ b/skills/aris-compute-guard/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: aris-compute-guard
+description: "Mandatory pre-flight compute resource check before running experiments. Detects whether local/remote GPU or compute resources are actually available. If resources are unavailable, STOPS the experiment pipeline immediately and reports to the user — preventing the model from hallucinating fake experiment results. Use when: about to run experiments, deploy training, or any GPU-intensive task."
+argument-hint: [environment-type]
+allowed-tools: Bash(nvidia-smi*), Bash(python*), Bash(ssh*), Bash(echo*), Bash(which*), Bash(command*), Read, Grep, Glob
+license: MIT
+metadata:
+  author: wanshuiyin/ARIS
+  version: "1.0.0"
+---
+
+# Compute Resource Guard
+
+**MANDATORY** pre-flight check before any experiment execution. This skill determines whether the required compute resources are actually available. If they are not, you MUST stop immediately and inform the user — do NOT proceed to run experiments, and do NOT imagine or fabricate experiment results.
+
+## Context: $ARGUMENTS
+
+## CRITICAL RULE
+
+**If this check determines compute resources are unavailable, you MUST:**
+1. **STOP** all experiment execution immediately
+2. **DO NOT** attempt to run any training scripts, evaluation scripts, or experiment code
+3. **DO NOT** fabricate, imagine, or hallucinate any experiment results
+4. **REPORT** clearly to the user what resources are missing and what they need to do
+5. **MARK** the experiment task as blocked (not failed, not done)
+
+## Workflow
+
+### Step 1: Detect Target Environment
+
+Read the project's `CLAUDE.md` to determine the experiment environment:
+
+- **Local GPU** (`gpu: local`): Check local CUDA/MPS
+- **Remote server** (`gpu: remote`): Check SSH connectivity + remote GPU
+- **Vast.ai** (`gpu: vast`): Check for running instances
+- **Modal** (`gpu: modal`): Check Modal CLI + auth (Modal is serverless — always "available" if configured)
+
+If no `CLAUDE.md` exists or no `gpu:` setting is found, assume **local** environment.
+
+### Step 2: Check Compute Availability
+
+#### For Local GPU (Linux with CUDA):
+
+```bash
+# Check if nvidia-smi exists
+which nvidia-smi 2>/dev/null
+# If exists, check GPU status
+nvidia-smi --query-gpu=index,name,memory.used,memory.total,utilization.gpu --format=csv,noheader 2>/dev/null
+```
+
+**Available** = `nvidia-smi` succeeds AND at least one GPU has `memory.used < 500 MiB` (free).
+**Unavailable** = `nvidia-smi` not found, returns error, or ALL GPUs have `memory.used >= memory.total * 0.9`.
+
+#### For Local GPU (Mac with MPS):
+
+```bash
+python3 -c "
+import torch
+mps_available = hasattr(torch.backends, 'mps') and torch.backends.mps.is_available()
+print(f'MPS_AVAILABLE={mps_available}')
+if mps_available:
+    print('COMPUTE_OK=true')
+else:
+    print('COMPUTE_OK=false')
+" 2>/dev/null
+```
+
+**Available** = MPS is available (Apple Silicon with PyTorch MPS support).
+**Unavailable** = No MPS, no CUDA, pure CPU only — warn user that experiments will be extremely slow or may not work.
+
+#### For Local CPU-only (no GPU):
+
+```bash
+# Check if any GPU framework is available
+python3 -c "
+import torch
+cuda = torch.cuda.is_available()
+mps = hasattr(torch.backends, 'mps') and torch.backends.mps.is_available()
+print(f'CUDA={cuda}, MPS={mps}')
+if not cuda and not mps:
+    print('COMPUTE_OK=false')
+    print('REASON=No GPU available (no CUDA, no MPS). CPU-only execution is not suitable for ML training experiments.')
+else:
+    print('COMPUTE_OK=true')
+" 2>&1
+```
+
+If `python3` or `torch` is not installed:
+```bash
+# Fallback: check for nvidia-smi directly
+nvidia-smi 2>/dev/null || echo "COMPUTE_OK=false"
+echo "REASON=Neither nvidia-smi nor PyTorch found. Cannot verify GPU availability."
+```
+
+#### For Remote Server (SSH):
+
+```bash
+# Check SSH connectivity (timeout 10s)
+ssh -o ConnectTimeout=10 -o BatchMode=yes <server> "echo CONNECTED" 2>/dev/null
+# If connected, check GPU
+ssh -o ConnectTimeout=10 <server> "nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader" 2>/dev/null
+```
+
+**Available** = SSH connects AND GPU has free memory.
+**Unavailable** = SSH fails (server down, auth issue, network) OR no free GPU.
+
+#### For Vast.ai:
+
+```bash
+# Check for running instances
+cat vast-instances.json 2>/dev/null
+# Or query Vast.ai API
+vastai show instances 2>/dev/null
+```
+
+**Available** = A running instance exists with SSH access.
+**Unavailable** = No running instances (need to provision one first).
+
+#### For Modal (serverless):
+
+```bash
+# Check Modal CLI is installed and authenticated
+modal token verify 2>/dev/null || echo "MODAL_NOT_CONFIGURED"
+```
+
+**Available** = Modal CLI installed and authenticated.
+**Unavailable** = Modal not installed or not authenticated.
+
+### Step 3: Decision Gate
+
+| Check Result | Action |
+|---|---|
+| **COMPUTE_OK = true** | Proceed with experiment. Print brief resource summary and continue. |
+| **COMPUTE_OK = false** | **STOP IMMEDIATELY.** Do NOT run any experiments. Go to Step 4. |
+
+### Step 4: Stop and Report (when compute unavailable)
+
+When compute resources are NOT available, respond with a clear, structured message:
+
+```
+⚠️ COMPUTE RESOURCES UNAVAILABLE — Experiment Stopped
+
+I checked the compute resources and they are NOT available for running experiments.
+
+**Environment:** [local / remote / vast.ai / modal]
+**Issue:** [specific reason — e.g., "No GPU detected", "SSH connection failed", "All GPUs fully occupied"]
+
+**What you need to do:**
+- [Actionable step 1 — e.g., "Ensure your machine has a CUDA-compatible GPU"]
+- [Actionable step 2 — e.g., "Free up GPU memory by stopping other processes"]
+- [Actionable step 3 — e.g., "Configure a remote server in CLAUDE.md"]
+
+**Alternative options:**
+- Set `gpu: modal` in CLAUDE.md to use Modal serverless GPU (no local GPU needed)
+- Set `gpu: vast` in CLAUDE.md to rent an on-demand GPU from Vast.ai
+- Configure a remote GPU server with `gpu: remote` in CLAUDE.md
+
+I will NOT proceed with running experiments or generating results, as doing so without actual compute resources would produce fabricated output. Please resolve the compute issue and try again.
+```
+
+**After this message, STOP. Do not continue with any experiment workflow steps.**
+
+### Step 5: Proceed Summary (when compute available)
+
+When compute IS available, print a brief summary and return control:
+
+```
+✅ Compute resources verified:
+- Environment: [local / remote / vast.ai / modal]
+- GPU: [GPU name, count, free memory]
+- Status: Ready for experiments
+
+Proceeding with experiment execution.
+```
+
+## Integration
+
+This skill is called automatically by:
+- `/aris-run-experiment` (Step 0, before environment detection)
+- `/aris-experiment-bridge` (Phase 0, before parsing experiment plan)
+
+It can also be called standalone:
+```
+/aris-compute-guard
+/aris-compute-guard local
+/aris-compute-guard remote
+```
+
+## Rules
+
+- NEVER skip this check. It exists to prevent wasted time and hallucinated results.
+- If the check itself fails (e.g., `python3` not found), treat it as **unavailable** and report.
+- For `gpu: modal`, the check is lenient — Modal handles GPU allocation automatically. Only fail if Modal CLI is not installed/authenticated.
+- For CPU-only environments, warn but allow if the experiment is explicitly CPU-compatible (e.g., small-scale testing, data preprocessing).
+- This check should complete in under 30 seconds. If SSH times out, report as unavailable.

--- a/skills/aris-experiment-bridge/SKILL.md
+++ b/skills/aris-experiment-bridge/SKILL.md
@@ -49,6 +49,38 @@ If none exist, ask the user what experiments to implement.
 
 ## Workflow
 
+### Phase 0: Compute Resource Guard (MANDATORY)
+
+**Before parsing the experiment plan or writing any code**, verify that compute resources are available by running `/aris-compute-guard`.
+
+If `/aris-compute-guard` is not available as a sub-skill, perform the check inline:
+
+1. Read `CLAUDE.md` to determine the target environment (`gpu: local`, `remote`, `vast`, or `modal`)
+2. Check GPU availability:
+   - **Local (Linux):** `nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader` — free if `memory.used < 500 MiB`
+   - **Local (Mac):** `python3 -c "import torch; print(torch.backends.mps.is_available())"`
+   - **Remote:** `ssh <server> nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader`
+   - **Modal:** `modal token verify` — always available if authenticated
+
+**If compute is NOT available → STOP the entire bridge workflow.**
+
+```
+⚠️ COMPUTE RESOURCES UNAVAILABLE — Experiment Bridge Halted
+
+Cannot proceed with implementing and deploying experiments because compute
+resources are not available.
+
+[reason and suggestions]
+
+I will NOT proceed with code implementation or experiment deployment, as there
+is no compute target to run the experiments on. Please resolve the compute
+issue and re-run /aris-experiment-bridge.
+```
+
+**Do NOT implement experiment code if you cannot deploy it.** Writing code without a deployment target wastes time and may lead to hallucinated results during the collection phase.
+
+**If compute IS available → proceed to Phase 1.**
+
 ### Phase 1: Parse the Experiment Plan
 
 Read `EXPERIMENT_PLAN.md` and extract:

--- a/skills/aris-run-experiment/SKILL.md
+++ b/skills/aris-run-experiment/SKILL.md
@@ -15,6 +15,24 @@ Deploy and run ML experiment: $ARGUMENTS
 
 ## Workflow
 
+### Step 0: Compute Resource Guard (MANDATORY)
+
+**Before doing ANYTHING else**, run `/aris-compute-guard` to verify that compute resources are actually available.
+
+If `/aris-compute-guard` is not available as a sub-skill, perform the check inline:
+
+1. **Local GPU (Linux):** Run `nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader`. A GPU is free if `memory.used < 500 MiB`.
+2. **Local GPU (Mac):** Run `python3 -c "import torch; print(torch.backends.mps.is_available())"`.
+3. **Remote server:** Run `ssh <server> nvidia-smi --query-gpu=index,memory.used,memory.total --format=csv,noheader`.
+4. **Modal:** Check `modal token verify` — Modal is serverless and always available if configured.
+
+**If compute resources are NOT available:**
+- **STOP IMMEDIATELY.** Do NOT proceed to any further steps.
+- Report to the user: which resources are missing, what they need to fix, and alternative options (Modal serverless, Vast.ai, remote server).
+- **Do NOT fabricate, imagine, or hallucinate experiment results.** This is critical — running experiments without actual compute resources produces no real results.
+
+**If compute resources ARE available:** Print a brief confirmation and proceed to Step 1.
+
 ### Step 1: Detect Environment
 
 Read the project's `CLAUDE.md` to determine the experiment environment:

--- a/skills/skill-tag-mapping.json
+++ b/skills/skill-tag-mapping.json
@@ -626,6 +626,11 @@
       "en": "Stage: Analysis",
       "ko": "단계: 분석"
     },
+    "aris-compute-guard": {
+      "zh": "阶段: 实验开发",
+      "en": "Stage: Experiment Dev",
+      "ko": "단계: 실험 개발"
+    },
     "aris-run-experiment": {
       "zh": "阶段: 实验开发",
       "en": "Stage: Experiment Dev",
@@ -1374,6 +1379,11 @@
       "ko": "영역: cs"
     },
     "aris-analyze-results": {
+      "zh": "领域: cs",
+      "en": "Domain: cs",
+      "ko": "영역: cs"
+    },
+    "aris-compute-guard": {
       "zh": "领域: cs",
       "en": "Domain: cs",
       "ko": "영역: cs"

--- a/skills/skills-catalog-v2.json
+++ b/skills/skills-catalog-v2.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "2026-03-24T17:51:17.721Z",
   "schema": "skills-taxonomy-v2",
-  "totalSkills": 170,
+  "totalSkills": 171,
   "skills": [
     {
       "name": "academic-researcher",
@@ -5235,6 +5235,51 @@
         "aris-novelty-check",
         "aris-research-review",
         "aris-research-refine"
+      ]
+    },
+    {
+      "name": "aris-compute-guard",
+      "primaryIntent": "experiment",
+      "intents": [
+        "experiment",
+        "infrastructure-check"
+      ],
+      "capabilities": [
+        "compute-validation",
+        "infrastructure-ops"
+      ],
+      "domains": [
+        "cs-ai"
+      ],
+      "keywords": [
+        "aris",
+        "compute",
+        "guard",
+        "gpu",
+        "check",
+        "availability",
+        "stop",
+        "resource",
+        "nvidia-smi",
+        "mps",
+        "cuda",
+        "pre-flight"
+      ],
+      "source": "imported",
+      "status": "verified",
+      "summary": "Mandatory pre-flight compute resource check before running experiments. Detects GPU/compute availability and STOPS the pipeline if resources are unavailable, preventing hallucinated results.",
+      "legacy": {
+        "dirPath": "aris-compute-guard",
+        "skillFile": "skills/aris-compute-guard/SKILL.md",
+        "topLevelGroup": "ARIS",
+        "collection": "ARIS Research Pipeline"
+      },
+      "owner": "wanshuiyin/ARIS",
+      "relatedSkills": [
+        "aris-run-experiment",
+        "aris-experiment-bridge",
+        "aris-monitor-experiment",
+        "aris-system-profile"
       ]
     },
     {

--- a/skills/stage-skill-map.json
+++ b/skills/stage-skill-map.json
@@ -72,6 +72,7 @@
   },
   "experiment": {
     "base": [
+      "aris-compute-guard",
       "inno-code-survey",
       "dataset-discovery",
       "inno-experiment-dev",


### PR DESCRIPTION
- Add a new aris-compute-guard skill that performs a mandatory pre-flight check of GPU/compute resources (CUDA, MPS, remote SSH, Vast.ai, Modal) before any experiment execution
- Inject a compute guard block into the system prompt of all AI providers (Claude, OpenRouter, Gemini CLI/API, Local GPU) so the agent always checks resources before running experiments — even for natural-language requests
- Add GET /api/compute/check-available REST endpoint and compute_check_available MCP tool for programmatic compute availability checks
- Gate aris-run-experiment (Step 0) and aris-experiment-bridge (Phase 0) with the mandatory compute guard, and update all project templates and skill registries