### PR TITLE
feat(chat): add copy, resend, and edit actions

### DIFF
--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -22,7 +22,9 @@ import type { GeminiThinkingModeId } from '../../../../shared/geminiThinkingSupp
 import { getSupportedGeminiThinkingModes } from '../../../../shared/geminiThinkingSupport';
 
 import { grantToolPermission } from '../utils/chatPermissions';
+import { applyEditedMessageToHistory, createChatMessageId } from '../utils/chatMessages';
 import { clearSessionTimerStart, getProviderSettingsKey, persistSessionTimerStart, safeLocalStorage } from '../utils/chatStorage';
+import { hasUnsavedComposerDraft, normalizeProgrammaticDraft, resolveLineHeightPx } from '../utils/composerUtils';
 import { consumeWorkspaceQaDraft, WORKSPACE_QA_DRAFT_EVENT } from '../../../utils/workspaceQa';
 import { consumeReferenceChatDraft, REFERENCE_CHAT_DRAFT_EVENT } from '../../../utils/referenceChatDraft';
 import { consumeSkillCommandDraft, SKILL_COMMAND_DRAFT_EVENT } from '../../../utils/skillCommandDraft';
@@ -116,6 +118,7 @@ interface UploadedProjectFile {
 interface ProgrammaticMessageDraft {
   content?: string;
   attachedPrompt?: AttachedPrompt | null;
+  editingMessageId?: string | null;
 }
 
 const createFakeSubmitEvent = () => {
@@ -333,11 +336,15 @@ export function useChatComposerState({
   const handleSubmitRef = useRef<
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
+  // Programmatic draft loads and async submit callbacks must read the latest composer state
+  // without waiting for a rerender, so the mutable refs intentionally mirror state here.
   const inputValueRef = useRef(input);
   const attachedFilesRef = useRef<File[]>([]);
   const attachedPromptRef = useRef<AttachedPrompt | null>(null);
   const pendingStageTagKeysRef = useRef<string[]>([]);
   const abortTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const textareaLayoutTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingEditedMessageIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     return () => {
@@ -345,11 +352,16 @@ export function useChatComposerState({
         clearTimeout(abortTimeoutRef.current);
         abortTimeoutRef.current = null;
       }
+      if (textareaLayoutTimeoutRef.current) {
+        clearTimeout(textareaLayoutTimeoutRef.current);
+        textareaLayoutTimeoutRef.current = null;
+      }
     };
   }, []);
 
   useEffect(() => {
     setPendingStageTagKeys([]);
+    pendingEditedMessageIdRef.current = null;
   }, [selectedProject?.name, selectedSession?.id]);
 
   useEffect(() => {
@@ -739,13 +751,29 @@ export function useChatComposerState({
   });
 
   const applyProgrammaticDraft = useCallback((draft: ProgrammaticMessageDraft) => {
-    const nextContent = draft.content || '';
-    const nextAttachedPrompt = draft.attachedPrompt ?? null;
+    if (
+      hasUnsavedComposerDraft(
+        inputValueRef.current,
+        attachedFilesRef.current,
+        attachedPromptRef.current,
+      )
+    ) {
+      const confirmed = window.confirm(
+        t('messageActions.confirmReplaceDraft', {
+          defaultValue: 'Replace your current unsent draft with this message?',
+        }),
+      );
+      if (!confirmed) {
+        return false;
+      }
+    }
 
-    setInput(nextContent);
-    inputValueRef.current = nextContent;
-    setAttachedPrompt(nextAttachedPrompt);
-    attachedPromptRef.current = nextAttachedPrompt;
+    const normalizedDraft = normalizeProgrammaticDraft(draft);
+
+    setInput(normalizedDraft.content);
+    inputValueRef.current = normalizedDraft.content;
+    setAttachedPrompt(normalizedDraft.attachedPrompt);
+    attachedPromptRef.current = normalizedDraft.attachedPrompt;
 
     setAttachedFiles([]);
     attachedFilesRef.current = [];
@@ -753,11 +781,16 @@ export function useChatComposerState({
     setFileErrors(new Map());
     setPendingStageTagKeys([]);
     pendingStageTagKeysRef.current = [];
+    pendingEditedMessageIdRef.current = draft.editingMessageId ?? null;
     resetCommandMenuState();
-  }, [resetCommandMenuState]);
+    return true;
+  }, [resetCommandMenuState, t]);
 
   const submitProgrammaticMessage = useCallback((draft: ProgrammaticMessageDraft) => {
-    applyProgrammaticDraft(draft);
+    const didApplyDraft = applyProgrammaticDraft(draft);
+    if (!didApplyDraft) {
+      return false;
+    }
 
     const attemptSubmit = (attempt = 0) => {
       if (handleSubmitRef.current) {
@@ -778,6 +811,7 @@ export function useChatComposerState({
     setTimeout(() => {
       attemptSubmit();
     }, 0);
+    return true;
   }, [applyProgrammaticDraft]);
 
   const submitProgrammaticInput = useCallback((content: string, options?: { attachedPrompt?: AttachedPrompt | null }) => {
@@ -811,12 +845,17 @@ export function useChatComposerState({
   }, []);
 
   const syncTextareaLayout = useCallback((nextValue: string, focus: boolean) => {
-    setTimeout(() => {
-      if (!textareaRef.current) {
+    if (textareaLayoutTimeoutRef.current) {
+      clearTimeout(textareaLayoutTimeoutRef.current);
+    }
+
+    textareaLayoutTimeoutRef.current = setTimeout(() => {
+      textareaLayoutTimeoutRef.current = null;
+      const textarea = textareaRef.current;
+      if (!textarea) {
         return;
       }
 
-      const textarea = textareaRef.current;
       if (focus) {
         textarea.focus();
       }
@@ -827,14 +866,21 @@ export function useChatComposerState({
       textarea.setSelectionRange(cursor, cursor);
       syncInputOverlayScroll(textarea);
 
-      const lineHeight = parseInt(window.getComputedStyle(textarea).lineHeight);
+      const computedStyle = window.getComputedStyle(textarea);
+      const lineHeight = resolveLineHeightPx(computedStyle.lineHeight, computedStyle.fontSize);
       setIsTextareaExpanded(textarea.scrollHeight > lineHeight * 2);
     }, 0);
   }, [syncInputOverlayScroll]);
 
   const loadMessageIntoComposer = useCallback((draft: ProgrammaticMessageDraft) => {
-    applyProgrammaticDraft(draft);
-    syncTextareaLayout(draft.content || '', true);
+    const didApplyDraft = applyProgrammaticDraft(draft);
+    if (!didApplyDraft) {
+      return false;
+    }
+
+    const normalizedDraft = normalizeProgrammaticDraft(draft);
+    syncTextareaLayout(normalizedDraft.content, true);
+    return true;
   }, [applyProgrammaticDraft, syncTextareaLayout]);
 
   const handleAttachmentFiles = useCallback((files: File[]) => {
@@ -1051,6 +1097,7 @@ export function useChatComposerState({
           inputValueRef.current = '';
           setAttachedPrompt(null);
           attachedPromptRef.current = null;
+          pendingEditedMessageIdRef.current = null;
           setAttachedFiles([]);
           attachedFilesRef.current = [];
           setUploadingFiles(new Map());
@@ -1200,17 +1247,22 @@ export function useChatComposerState({
         }
       }
 
+      const editedMessageId = pendingEditedMessageIdRef.current;
+      const userMessageId = createChatMessageId();
       const userMessage: ChatMessage = {
+        messageId: userMessageId,
         type: 'user',
         content: normalizedInput,
         submittedContent: messageContent,
         images: uploadedImages.length > 0 ? uploadedImages : undefined,
         attachments: messageAttachments.length > 0 ? messageAttachments : undefined,
         timestamp: new Date(),
+        ...(editedMessageId ? { editedFromMessageId: editedMessageId } : {}),
         ...(currentAttachedPrompt ? { attachedPrompt: currentAttachedPrompt } : {}),
       };
 
-      setChatMessages((previous) => [...previous, userMessage]);
+      setChatMessages((previous) => applyEditedMessageToHistory(previous, userMessage, editedMessageId));
+      pendingEditedMessageIdRef.current = null;
       if (abortTimeoutRef.current) {
         clearTimeout(abortTimeoutRef.current);
         abortTimeoutRef.current = null;
@@ -1459,6 +1511,7 @@ export function useChatComposerState({
       setThinkingMode('none');
       setAttachedPrompt(null);
       attachedPromptRef.current = null;
+      pendingEditedMessageIdRef.current = null;
 
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
@@ -1532,20 +1585,7 @@ export function useChatComposerState({
     const applyDraft = (draft: string) => {
       setInput(draft);
       inputValueRef.current = draft;
-
-      setTimeout(() => {
-        if (!textareaRef.current) {
-          return;
-        }
-
-        textareaRef.current.focus();
-        textareaRef.current.style.height = 'auto';
-        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-        const cursor = draft.length;
-        textareaRef.current.setSelectionRange(cursor, cursor);
-        const lineHeight = parseInt(window.getComputedStyle(textareaRef.current).lineHeight);
-        setIsTextareaExpanded(textareaRef.current.scrollHeight > lineHeight * 2);
-      }, 0);
+      syncTextareaLayout(draft, true);
     };
 
     const applyQueuedDraft = () => {
@@ -1618,7 +1658,8 @@ export function useChatComposerState({
     // Re-run when input changes so restored drafts get the same autosize behavior as typed text.
     textareaRef.current.style.height = 'auto';
     textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-    const lineHeight = parseInt(window.getComputedStyle(textareaRef.current).lineHeight);
+    const computedStyle = window.getComputedStyle(textareaRef.current);
+    const lineHeight = resolveLineHeightPx(computedStyle.lineHeight, computedStyle.fontSize);
     const expanded = textareaRef.current.scrollHeight > lineHeight * 2;
     setIsTextareaExpanded(expanded);
   }, [input]);
@@ -1709,7 +1750,8 @@ export function useChatComposerState({
       setCursorPosition(target.selectionStart);
       syncInputOverlayScroll(target);
 
-      const lineHeight = parseInt(window.getComputedStyle(target).lineHeight);
+      const computedStyle = window.getComputedStyle(target);
+      const lineHeight = resolveLineHeightPx(computedStyle.lineHeight, computedStyle.fontSize);
       setIsTextareaExpanded(target.scrollHeight > lineHeight * 2);
     },
     [setCursorPosition, syncInputOverlayScroll],
@@ -1726,6 +1768,7 @@ export function useChatComposerState({
     setFileErrors(new Map());
     setAttachedPrompt(null);
     attachedPromptRef.current = null;
+    pendingEditedMessageIdRef.current = null;
     resetCommandMenuState();
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
@@ -1807,21 +1850,11 @@ export function useChatComposerState({
     setInput((previousInput) => {
       const newInput = previousInput.trim() ? `${previousInput} ${text}` : text;
       inputValueRef.current = newInput;
-
-      setTimeout(() => {
-        if (!textareaRef.current) {
-          return;
-        }
-
-        textareaRef.current.style.height = 'auto';
-        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-        const lineHeight = parseInt(window.getComputedStyle(textareaRef.current).lineHeight);
-        setIsTextareaExpanded(textareaRef.current.scrollHeight > lineHeight * 2);
-      }, 0);
+      syncTextareaLayout(newInput, false);
 
       return newInput;
     });
-  }, []);
+  }, [syncTextareaLayout]);
 
   const handleGrantToolPermission = useCallback(
     (suggestion: { entry: string; toolName: string }) => {

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -113,6 +113,11 @@ interface UploadedProjectFile {
   size?: number;
 }
 
+interface ProgrammaticMessageDraft {
+  content?: string;
+  attachedPrompt?: AttachedPrompt | null;
+}
+
 const createFakeSubmitEvent = () => {
   return { preventDefault: () => undefined } as unknown as FormEvent<HTMLFormElement>;
 };
@@ -329,6 +334,9 @@ export function useChatComposerState({
     ((event: FormEvent<HTMLFormElement> | MouseEvent | TouchEvent | KeyboardEvent<HTMLTextAreaElement>) => Promise<void>) | null
   >(null);
   const inputValueRef = useRef(input);
+  const attachedFilesRef = useRef<File[]>([]);
+  const attachedPromptRef = useRef<AttachedPrompt | null>(null);
+  const pendingStageTagKeysRef = useRef<string[]>([]);
   const abortTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -343,6 +351,18 @@ export function useChatComposerState({
   useEffect(() => {
     setPendingStageTagKeys([]);
   }, [selectedProject?.name, selectedSession?.id]);
+
+  useEffect(() => {
+    attachedFilesRef.current = attachedFiles;
+  }, [attachedFiles]);
+
+  useEffect(() => {
+    attachedPromptRef.current = attachedPrompt;
+  }, [attachedPrompt]);
+
+  useEffect(() => {
+    pendingStageTagKeysRef.current = pendingStageTagKeys;
+  }, [pendingStageTagKeys]);
 
   useEffect(() => {
     safeLocalStorage.setItem('codex-reasoning-effort', codexReasoningEffort);
@@ -505,32 +525,6 @@ export function useChatComposerState({
       }
     }, 0);
   }, [setChatMessages]);
-
-  const submitProgrammaticInput = useCallback((content: string) => {
-    const nextContent = content || '';
-    setInput(nextContent);
-    inputValueRef.current = nextContent;
-
-    const attemptSubmit = (attempt = 0) => {
-      if (handleSubmitRef.current) {
-        handleSubmitRef.current(createFakeSubmitEvent());
-        return;
-      }
-
-      if (attempt >= PROGRAMMATIC_SUBMIT_MAX_RETRIES) {
-        console.warn('[Chat] Programmatic submit skipped because handleSubmit was not ready');
-        return;
-      }
-
-      setTimeout(() => {
-        attemptSubmit(attempt + 1);
-      }, PROGRAMMATIC_SUBMIT_RETRY_DELAY_MS);
-    };
-
-    setTimeout(() => {
-      attemptSubmit();
-    }, 0);
-  }, []);
 
   const executeCommand = useCallback(
     async (command: SlashCommand, rawInput?: string) => {
@@ -744,6 +738,55 @@ export function useChatComposerState({
     onExecuteCommand: executeCommand,
   });
 
+  const applyProgrammaticDraft = useCallback((draft: ProgrammaticMessageDraft) => {
+    const nextContent = draft.content || '';
+    const nextAttachedPrompt = draft.attachedPrompt ?? null;
+
+    setInput(nextContent);
+    inputValueRef.current = nextContent;
+    setAttachedPrompt(nextAttachedPrompt);
+    attachedPromptRef.current = nextAttachedPrompt;
+
+    setAttachedFiles([]);
+    attachedFilesRef.current = [];
+    setUploadingFiles(new Map());
+    setFileErrors(new Map());
+    setPendingStageTagKeys([]);
+    pendingStageTagKeysRef.current = [];
+    resetCommandMenuState();
+  }, [resetCommandMenuState]);
+
+  const submitProgrammaticMessage = useCallback((draft: ProgrammaticMessageDraft) => {
+    applyProgrammaticDraft(draft);
+
+    const attemptSubmit = (attempt = 0) => {
+      if (handleSubmitRef.current) {
+        handleSubmitRef.current(createFakeSubmitEvent());
+        return;
+      }
+
+      if (attempt >= PROGRAMMATIC_SUBMIT_MAX_RETRIES) {
+        console.warn('[Chat] Programmatic submit skipped because handleSubmit was not ready');
+        return;
+      }
+
+      setTimeout(() => {
+        attemptSubmit(attempt + 1);
+      }, PROGRAMMATIC_SUBMIT_RETRY_DELAY_MS);
+    };
+
+    setTimeout(() => {
+      attemptSubmit();
+    }, 0);
+  }, [applyProgrammaticDraft]);
+
+  const submitProgrammaticInput = useCallback((content: string, options?: { attachedPrompt?: AttachedPrompt | null }) => {
+    submitProgrammaticMessage({
+      content,
+      attachedPrompt: options?.attachedPrompt ?? null,
+    });
+  }, [submitProgrammaticMessage]);
+
   const {
     showFileDropdown,
     filteredFiles,
@@ -766,6 +809,33 @@ export function useChatComposerState({
     inputHighlightRef.current.scrollTop = target.scrollTop;
     inputHighlightRef.current.scrollLeft = target.scrollLeft;
   }, []);
+
+  const syncTextareaLayout = useCallback((nextValue: string, focus: boolean) => {
+    setTimeout(() => {
+      if (!textareaRef.current) {
+        return;
+      }
+
+      const textarea = textareaRef.current;
+      if (focus) {
+        textarea.focus();
+      }
+
+      textarea.style.height = 'auto';
+      textarea.style.height = `${textarea.scrollHeight}px`;
+      const cursor = nextValue.length;
+      textarea.setSelectionRange(cursor, cursor);
+      syncInputOverlayScroll(textarea);
+
+      const lineHeight = parseInt(window.getComputedStyle(textarea).lineHeight);
+      setIsTextareaExpanded(textarea.scrollHeight > lineHeight * 2);
+    }, 0);
+  }, [syncInputOverlayScroll]);
+
+  const loadMessageIntoComposer = useCallback((draft: ProgrammaticMessageDraft) => {
+    applyProgrammaticDraft(draft);
+    syncTextareaLayout(draft.content || '', true);
+  }, [applyProgrammaticDraft, syncTextareaLayout]);
 
   const handleAttachmentFiles = useCallback((files: File[]) => {
     const validFiles: File[] = [];
@@ -958,10 +1028,11 @@ export function useChatComposerState({
     ) => {
       event.preventDefault();
       const currentInput = inputValueRef.current;
-      if (!selectedProject) {
-        return;
-      }
-      if (!currentInput.trim() && attachedFiles.length === 0 && !attachedPrompt) {
+      const currentAttachedFiles = attachedFilesRef.current;
+      const currentAttachedPrompt = attachedPromptRef.current;
+      const currentStageTagKeys = pendingStageTagKeysRef.current;
+
+      if ((!currentInput.trim() && currentAttachedFiles.length === 0 && !currentAttachedPrompt) || isLoading || !selectedProject) {
         return;
       }
 
@@ -979,9 +1050,13 @@ export function useChatComposerState({
           setInput('');
           inputValueRef.current = '';
           setAttachedPrompt(null);
+          attachedPromptRef.current = null;
           setAttachedFiles([]);
+          attachedFilesRef.current = [];
           setUploadingFiles(new Map());
           setFileErrors(new Map());
+          setPendingStageTagKeys([]);
+          pendingStageTagKeysRef.current = [];
           resetCommandMenuState();
           setIsTextareaExpanded(false);
           if (textareaRef.current) {
@@ -1003,11 +1078,11 @@ export function useChatComposerState({
       let messageContent = normalizedInput;
 
       // Prepend attached prompt text if present
-      if (attachedPrompt) {
+      if (currentAttachedPrompt) {
         if (currentInput.trim()) {
-          messageContent = `${attachedPrompt.promptText}\n\n${normalizedInput}`;
+          messageContent = `${currentAttachedPrompt.promptText}\n\n${normalizedInput}`;
         } else {
-          messageContent = attachedPrompt.promptText;
+          messageContent = currentAttachedPrompt.promptText;
         }
       }
 
@@ -1044,11 +1119,11 @@ export function useChatComposerState({
         | undefined;
       let messageAttachments: ChatAttachment[] = [];
 
-      if (attachedFiles.length > 0) {
+      if (currentAttachedFiles.length > 0) {
         let uploadedFiles: UploadedProjectFile[] = [];
 
         try {
-          uploadedFiles = await uploadFilesToProject(attachedFiles);
+          uploadedFiles = await uploadFilesToProject(currentAttachedFiles);
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Unknown error';
           console.error('File upload failed:', error);
@@ -1063,7 +1138,7 @@ export function useChatComposerState({
           return;
         }
 
-        messageAttachments = attachedFiles.map((file, index) => {
+        messageAttachments = currentAttachedFiles.map((file, index) => {
           const uploadedFile = uploadedFiles[index];
           const uploadedPath = uploadedFile?.path && typeof uploadedFile.path === 'string' ? uploadedFile.path : undefined;
 
@@ -1092,7 +1167,7 @@ export function useChatComposerState({
               uploadedFile: UploadedProjectFile,
               index: number,
             ) => {
-              const sourceFile = attachedFiles[index];
+              const sourceFile = currentAttachedFiles[index];
               const uploadedPath =
                 uploadedFile?.path && typeof uploadedFile.path === 'string' ? uploadedFile.path : null;
 
@@ -1115,7 +1190,7 @@ export function useChatComposerState({
           );
         }
 
-        const imageFiles = attachedFiles.filter((file) => isImageAttachment(file));
+        const imageFiles = currentAttachedFiles.filter((file) => isImageAttachment(file));
         if (imageFiles.length > 0) {
           try {
             uploadedImages = await uploadPreviewImages(imageFiles);
@@ -1128,10 +1203,11 @@ export function useChatComposerState({
       const userMessage: ChatMessage = {
         type: 'user',
         content: normalizedInput,
+        submittedContent: messageContent,
         images: uploadedImages.length > 0 ? uploadedImages : undefined,
         attachments: messageAttachments.length > 0 ? messageAttachments : undefined,
         timestamp: new Date(),
-        ...(attachedPrompt ? { attachedPrompt } : {}),
+        ...(currentAttachedPrompt ? { attachedPrompt: currentAttachedPrompt } : {}),
       };
 
       setChatMessages((previous) => [...previous, userMessage]);
@@ -1239,7 +1315,7 @@ export function useChatComposerState({
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1261,7 +1337,7 @@ export function useChatComposerState({
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1283,7 +1359,7 @@ export function useChatComposerState({
             images: uploadedImages,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1303,7 +1379,7 @@ export function useChatComposerState({
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1344,7 +1420,7 @@ export function useChatComposerState({
             toolsSettings,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1364,7 +1440,7 @@ export function useChatComposerState({
             images: uploadedImages.length > 0 ? uploadedImages : undefined,
             telemetryEnabled,
             sessionMode: isNewSession ? newSessionMode : selectedSession?.mode,
-            stageTagKeys: pendingStageTagKeys,
+            stageTagKeys: currentStageTagKeys,
             stageTagSource: 'task_context',
           },
         });
@@ -1373,13 +1449,16 @@ export function useChatComposerState({
       setInput('');
       inputValueRef.current = '';
       setPendingStageTagKeys([]);
+      pendingStageTagKeysRef.current = [];
       resetCommandMenuState();
       setAttachedFiles([]);
+      attachedFilesRef.current = [];
       setUploadingFiles(new Map());
       setFileErrors(new Map());
       setIsTextareaExpanded(false);
       setThinkingMode('none');
       setAttachedPrompt(null);
+      attachedPromptRef.current = null;
 
       if (textareaRef.current) {
         textareaRef.current.style.height = 'auto';
@@ -1416,7 +1495,6 @@ export function useChatComposerState({
       setClaudeStatus,
       setIsLoading,
       setIsUserScrolledUp,
-      pendingStageTagKeys,
       slashCommands,
       thinkingMode,
       t,
@@ -1641,9 +1719,13 @@ export function useChatComposerState({
     setInput('');
     inputValueRef.current = '';
     setPendingStageTagKeys([]);
+    pendingStageTagKeysRef.current = [];
     setAttachedFiles([]);
+    attachedFilesRef.current = [];
     setUploadingFiles(new Map());
     setFileErrors(new Map());
+    setAttachedPrompt(null);
+    attachedPromptRef.current = null;
     resetCommandMenuState();
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
@@ -1865,5 +1947,7 @@ export function useChatComposerState({
     submitProgrammaticInput,
     btwOverlay,
     closeBtwOverlay,
+    submitProgrammaticMessage,
+    loadMessageIntoComposer,
   };
 }

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -6,6 +6,7 @@ import { RESUMING_STATUS_TEXT } from '../types/types';
 import type { ChatMessage, Provider, TokenBudget } from '../types/types';
 import type { Project, ProjectSession } from '../../../types/app';
 import { clearSessionTimerStart, readSessionTimerStart, safeLocalStorage } from '../utils/chatStorage';
+import { hydrateStoredChatMessages } from '../utils/chatMessages';
 import {
   convertCursorSessionMessages,
   convertSessionMessages,
@@ -103,7 +104,7 @@ export function useChatSessionState({
       const saved = safeLocalStorage.getItem(`chat_messages_${selectedProject.name}`);
       if (saved) {
         try {
-          return JSON.parse(saved) as ChatMessage[];
+          return hydrateStoredChatMessages(JSON.parse(saved) as ChatMessage[]);
         } catch {
           console.error('Failed to parse saved chat messages, resetting');
           safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
@@ -118,15 +119,7 @@ export function useChatSessionState({
   const setChatMessages = useCallback((updater: React.SetStateAction<ChatMessage[]>) => {
     _setChatMessages((prev) => {
       const next = typeof updater === 'function' ? updater(prev) : updater;
-      let hasChanges = false;
-      const final = next.map((msg) => {
-        if (!msg.id && !msg.messageId && !msg.toolId && !msg.toolCallId && !msg.blobId && !msg.rowid && !msg.sequence) {
-          hasChanges = true;
-          return { ...msg, messageId: (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15) };
-        }
-        return msg;
-      });
-      return hasChanges ? final : next;
+      return hydrateStoredChatMessages(next);
     });
   }, []);
 

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -54,6 +54,7 @@ export interface AttachedPrompt {
 export interface ChatMessage {
   type: string;
   content?: string;
+  submittedContent?: string;
   timestamp: string | number | Date;
   images?: ChatImage[];
   attachments?: ChatAttachment[];

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -53,6 +53,8 @@ export interface AttachedPrompt {
 
 export interface ChatMessage {
   type: string;
+  id?: string | number;
+  messageId?: string;
   content?: string;
   submittedContent?: string;
   timestamp: string | number | Date;
@@ -75,6 +77,9 @@ export interface ChatMessage {
     currentToolIndex: number;
     isComplete: boolean;
   };
+  editedFromMessageId?: string;
+  isSuperseded?: boolean;
+  supersededByMessageId?: string;
   attachedPrompt?: AttachedPrompt;
   errorType?: 'usage_limit' | 'overloaded' | 'network' | 'auth' | 'unknown';
   isRetryable?: boolean;

--- a/src/components/chat/utils/__tests__/chatMessages.test.ts
+++ b/src/components/chat/utils/__tests__/chatMessages.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AttachedPrompt, ChatMessage } from '../../types/types';
+import {
+  applyEditedMessageToHistory,
+  buildReplayMessageDraft,
+  findLatestEditableUserMessage,
+  hydrateStoredChatMessages,
+} from '../chatMessages';
+
+const attachedPrompt: AttachedPrompt = {
+  scenarioId: 'draft-review',
+  scenarioIcon: 'P',
+  scenarioTitle: 'Review a draft',
+  promptText: 'Please review the attached draft before responding.',
+};
+
+describe('buildReplayMessageDraft', () => {
+  it('round-trips submittedContent without duplicating attached prompt metadata', () => {
+    const message: ChatMessage = {
+      type: 'user',
+      content: 'Summarize this draft.',
+      submittedContent: `${attachedPrompt.promptText}\n\nSummarize this draft.`,
+      attachedPrompt,
+      timestamp: 0,
+    };
+
+    expect(buildReplayMessageDraft(message)).toEqual({
+      content: `${attachedPrompt.promptText}\n\nSummarize this draft.`,
+      attachedPrompt: null,
+    });
+  });
+});
+
+describe('hydrateStoredChatMessages', () => {
+  it('backfills submittedContent and message ids for older stored user messages', () => {
+    const hydrated = hydrateStoredChatMessages([
+      {
+        type: 'user',
+        content: 'Continue from the saved draft.',
+        attachedPrompt,
+        attachments: [
+          {
+            name: 'draft.md',
+            kind: 'file',
+            path: '.dr-claw/chat-attachments/draft.md',
+          },
+        ],
+        timestamp: 0,
+      },
+      {
+        type: 'assistant',
+        content: 'Ready when you are.',
+        timestamp: 1,
+      },
+    ] as ChatMessage[]);
+
+    expect(hydrated[0].submittedContent).toBe(
+      'Please review the attached draft before responding.\n\nContinue from the saved draft.\n\n[Files available at the following paths]\n1. .dr-claw/chat-attachments/draft.md',
+    );
+    expect(hydrated[0].messageId).toBeTruthy();
+    expect(hydrated[1].messageId).toBeTruthy();
+  });
+});
+
+describe('applyEditedMessageToHistory', () => {
+  it('marks the original user message as superseded and appends the edited version', () => {
+    const originalMessage: ChatMessage = {
+      type: 'user',
+      messageId: 'message-original',
+      content: 'Initial question',
+      submittedContent: 'Initial question',
+      timestamp: 0,
+    };
+    const editedMessage: ChatMessage = {
+      type: 'user',
+      messageId: 'message-edited',
+      content: 'Updated question',
+      submittedContent: 'Updated question',
+      editedFromMessageId: 'message-original',
+      timestamp: 1,
+    };
+
+    const updatedMessages = applyEditedMessageToHistory(
+      [originalMessage],
+      editedMessage,
+      'message-original',
+    );
+
+    expect(updatedMessages).toHaveLength(2);
+    expect(updatedMessages[0]).toMatchObject({
+      messageId: 'message-original',
+      isSuperseded: true,
+      supersededByMessageId: 'message-edited',
+    });
+    expect(updatedMessages[1]).toEqual(editedMessage);
+  });
+});
+
+describe('findLatestEditableUserMessage', () => {
+  it('returns the latest non-superseded user message for shell history handoff', () => {
+    const latestEditable = findLatestEditableUserMessage(
+      [
+        {
+          type: 'user',
+          messageId: 'message-1',
+          content: 'Original question',
+          submittedContent: 'Original question',
+          timestamp: 0,
+          isSuperseded: true,
+        },
+        {
+          type: 'assistant',
+          content: 'Answer',
+          timestamp: 1,
+        },
+        {
+          type: 'user',
+          messageId: 'message-2',
+          content: 'Edited question',
+          submittedContent: 'Edited question',
+          timestamp: 2,
+        },
+      ] as ChatMessage[],
+      true,
+    );
+
+    expect(latestEditable?.messageId).toBe('message-2');
+  });
+
+  it('returns null when there is no selected session to continue in shell', () => {
+    const latestEditable = findLatestEditableUserMessage(
+      [
+        {
+          type: 'user',
+          messageId: 'message-1',
+          content: 'Question',
+          submittedContent: 'Question',
+          timestamp: 0,
+        },
+      ] as ChatMessage[],
+      false,
+    );
+
+    expect(latestEditable).toBeNull();
+  });
+});

--- a/src/components/chat/utils/__tests__/composerUtils.test.ts
+++ b/src/components/chat/utils/__tests__/composerUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AttachedPrompt } from '../../types/types';
+import {
+  hasUnsavedComposerDraft,
+  normalizeProgrammaticDraft,
+  resolveLineHeightPx,
+} from '../composerUtils';
+
+const attachedPrompt: AttachedPrompt = {
+  scenarioId: 'draft-review',
+  scenarioIcon: 'P',
+  scenarioTitle: 'Review a draft',
+  promptText: 'Please review the attached draft before responding.',
+};
+
+describe('normalizeProgrammaticDraft', () => {
+  it('preserves attachedPrompt when loading a draft into the composer', () => {
+    expect(
+      normalizeProgrammaticDraft({
+        content: 'Please revise paragraph two.',
+        attachedPrompt,
+      }),
+    ).toEqual({
+      content: 'Please revise paragraph two.',
+      attachedPrompt,
+    });
+  });
+});
+
+describe('hasUnsavedComposerDraft', () => {
+  it('detects non-empty input, attachments, or prompt state before replacing a draft', () => {
+    expect(hasUnsavedComposerDraft('', 0, null)).toBe(false);
+    expect(hasUnsavedComposerDraft('Follow-up question', 0, null)).toBe(true);
+    expect(hasUnsavedComposerDraft('', 1, null)).toBe(true);
+    expect(hasUnsavedComposerDraft('', 0, attachedPrompt)).toBe(true);
+  });
+});
+
+describe('resolveLineHeightPx', () => {
+  it('handles unitless and percentage line-height values', () => {
+    expect(resolveLineHeightPx('1.5', '16px')).toBe(24);
+    expect(resolveLineHeightPx('150%', '16px')).toBe(24);
+  });
+});

--- a/src/components/chat/utils/chatMessages.ts
+++ b/src/components/chat/utils/chatMessages.ts
@@ -1,0 +1,210 @@
+import type { AttachedPrompt, ChatMessage } from '../types/types';
+
+export interface MessageDraft {
+  content: string;
+  attachedPrompt: AttachedPrompt | null;
+}
+
+const toOptionalString = (value: unknown): string | null => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const normalized = String(value).trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const createChatMessageId = (): string => {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).substring(2, 15);
+};
+
+export const getChatMessageId = (message: Pick<ChatMessage, 'messageId' | 'id'>): string | null => {
+  return toOptionalString(message.messageId) ?? toOptionalString(message.id);
+};
+
+export const getMessageReplayContent = (
+  message: Pick<ChatMessage, 'content' | 'submittedContent'>,
+): string => {
+  if (typeof message.submittedContent === 'string') {
+    return message.submittedContent;
+  }
+
+  return typeof message.content === 'string' ? message.content : '';
+};
+
+export const buildReplayMessageDraft = (
+  message: Pick<ChatMessage, 'content' | 'submittedContent' | 'attachedPrompt'>,
+): MessageDraft | null => {
+  const hasSubmittedContent =
+    typeof message.submittedContent === 'string' && message.submittedContent.trim().length > 0;
+  const content: string = hasSubmittedContent
+    ? message.submittedContent!
+    : typeof message.content === 'string'
+    ? message.content
+    : '';
+
+  if (!content.trim() && !message.attachedPrompt) {
+    return null;
+  }
+
+  return {
+    content,
+    attachedPrompt: hasSubmittedContent ? null : message.attachedPrompt ?? null,
+  };
+};
+
+export const buildEditableMessageDraft = (
+  message: Pick<ChatMessage, 'content' | 'submittedContent' | 'attachedPrompt'>,
+): MessageDraft | null => {
+  const content: string =
+    typeof message.content === 'string'
+      ? message.content
+      : getMessageReplayContent(message);
+
+  if (!content.trim() && !message.attachedPrompt) {
+    return null;
+  }
+
+  return {
+    content,
+    attachedPrompt: message.attachedPrompt ?? null,
+  };
+};
+
+export const isShellEditableUserMessage = (
+  message: Pick<ChatMessage, 'type' | 'isSkillContent' | 'isSuperseded' | 'content' | 'submittedContent' | 'attachedPrompt'>,
+): boolean => {
+  if (message.type !== 'user' || message.isSkillContent || message.isSuperseded) {
+    return false;
+  }
+
+  return buildEditableMessageDraft(message) !== null;
+};
+
+export const findLatestEditableUserMessage = (
+  messages: ChatMessage[],
+  hasSelectedSession: boolean,
+): ChatMessage | null => {
+  if (!hasSelectedSession) {
+    return null;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (isShellEditableUserMessage(messages[index])) {
+      return messages[index];
+    }
+  }
+
+  return null;
+};
+
+const buildAttachmentReplayNote = (
+  message: Pick<ChatMessage, 'attachments'>,
+): string => {
+  const attachmentPaths = Array.isArray(message.attachments)
+    ? message.attachments
+        .map((attachment) =>
+          typeof attachment.path === 'string' && attachment.path.trim().length > 0
+            ? attachment.path
+            : null,
+        )
+        .filter((path): path is string => Boolean(path))
+    : [];
+
+  if (attachmentPaths.length === 0) {
+    return '';
+  }
+
+  return `[Files available at the following paths]\n${attachmentPaths
+    .map((path, index) => `${index + 1}. ${path}`)
+    .join('\n')}`;
+};
+
+const backfillSubmittedContent = (message: ChatMessage): string | null => {
+  if (typeof message.submittedContent === 'string') {
+    return message.submittedContent;
+  }
+
+  if (message.type !== 'user') {
+    return null;
+  }
+
+  const promptPrefix =
+    message.attachedPrompt && typeof message.attachedPrompt.promptText === 'string'
+      ? message.attachedPrompt.promptText
+      : '';
+  const visibleContent = typeof message.content === 'string' ? message.content : '';
+  const attachmentNote = buildAttachmentReplayNote(message);
+  const prefixedContent = promptPrefix
+    ? visibleContent.trim()
+      ? `${promptPrefix}\n\n${visibleContent}`
+      : promptPrefix
+    : visibleContent;
+
+  if (prefixedContent && attachmentNote) {
+    return `${prefixedContent}\n\n${attachmentNote}`;
+  }
+
+  return prefixedContent || attachmentNote || null;
+};
+
+export const hydrateStoredChatMessages = (messages: ChatMessage[]): ChatMessage[] => {
+  let hasChanges = false;
+
+  const hydratedMessages = messages.map((message) => {
+    let nextMessage = message;
+
+    const backfilledSubmittedContent = backfillSubmittedContent(message);
+    if (backfilledSubmittedContent !== null && backfilledSubmittedContent !== message.submittedContent) {
+      nextMessage = {
+        ...nextMessage,
+        submittedContent: backfilledSubmittedContent,
+      };
+      hasChanges = true;
+    }
+
+    if (!getChatMessageId(nextMessage)) {
+      nextMessage = {
+        ...nextMessage,
+        messageId: createChatMessageId(),
+      };
+      hasChanges = true;
+    }
+
+    return nextMessage;
+  });
+
+  return hasChanges ? hydratedMessages : messages;
+};
+
+export const applyEditedMessageToHistory = (
+  messages: ChatMessage[],
+  nextMessage: ChatMessage,
+  editedMessageId: string | null,
+): ChatMessage[] => {
+  if (!editedMessageId) {
+    return [...messages, nextMessage];
+  }
+
+  const replacementMessageId = getChatMessageId(nextMessage);
+  let foundEditedSource = false;
+
+  const updatedMessages = messages.map((message) => {
+    if (getChatMessageId(message) !== editedMessageId) {
+      return message;
+    }
+
+    foundEditedSource = true;
+    return {
+      ...message,
+      isSuperseded: true,
+      supersededByMessageId: replacementMessageId ?? undefined,
+    };
+  });
+
+  return foundEditedSource ? [...updatedMessages, nextMessage] : [...messages, nextMessage];
+};

--- a/src/components/chat/utils/composerUtils.ts
+++ b/src/components/chat/utils/composerUtils.ts
@@ -1,0 +1,62 @@
+import type { AttachedPrompt } from '../types/types';
+
+export interface ProgrammaticDraftSnapshot {
+  content: string;
+  attachedPrompt: AttachedPrompt | null;
+}
+
+export const normalizeProgrammaticDraft = (draft: {
+  content?: string;
+  attachedPrompt?: AttachedPrompt | null;
+}): ProgrammaticDraftSnapshot => ({
+  content: draft.content || '',
+  attachedPrompt: draft.attachedPrompt ?? null,
+});
+
+export const hasUnsavedComposerDraft = (
+  input: string,
+  attachedFilesOrCount: number | { length: number },
+  attachedPrompt: AttachedPrompt | null,
+): boolean => {
+  const attachedFilesCount =
+    typeof attachedFilesOrCount === 'number'
+      ? attachedFilesOrCount
+      : attachedFilesOrCount.length;
+
+  return input.trim().length > 0 || attachedFilesCount > 0 || Boolean(attachedPrompt);
+};
+
+export const resolveLineHeightPx = (
+  lineHeightValue: string | null | undefined,
+  fontSizeValue: string | null | undefined,
+): number => {
+  const fontSize = Number.parseFloat(fontSizeValue || '');
+  const fallback = Number.isFinite(fontSize) && fontSize > 0 ? fontSize * 1.2 : 19.2;
+
+  if (!lineHeightValue || lineHeightValue === 'normal') {
+    return fallback;
+  }
+
+  const numericValue = Number.parseFloat(lineHeightValue);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return fallback;
+  }
+
+  if (lineHeightValue.endsWith('px')) {
+    return numericValue;
+  }
+
+  if (lineHeightValue.endsWith('%')) {
+    return Number.isFinite(fontSize) && fontSize > 0
+      ? (numericValue / 100) * fontSize
+      : fallback;
+  }
+
+  if (/^[\d.]+$/.test(lineHeightValue.trim())) {
+    return Number.isFinite(fontSize) && fontSize > 0
+      ? numericValue * fontSize
+      : fallback;
+  }
+
+  return numericValue;
+};

--- a/src/components/chat/utils/messageTransforms.ts
+++ b/src/components/chat/utils/messageTransforms.ts
@@ -229,9 +229,11 @@ export const convertCursorSessionMessages = (blobs: CursorBlob[], projectPath: s
 
             if (part?.type === 'tool-call' || part?.type === 'tool_use') {
               if (textParts.length > 0 || reasoningText) {
+                const textContent = textParts.join('\n');
                 converted.push({
                   type: role,
-                  content: textParts.join('\n'),
+                  content: textContent,
+                  ...(role === 'user' ? { submittedContent: textContent } : {}),
                   reasoning: reasoningText ?? undefined,
                   timestamp: new Date(Date.now() + blobIdx * 1000),
                   blobId: blob.id,
@@ -360,6 +362,7 @@ export const convertCursorSessionMessages = (blobs: CursorBlob[], projectPath: s
       const message: ChatMessage = {
         type: role,
         content: text,
+        ...(role === 'user' ? { submittedContent: text } : {}),
         timestamp: new Date(Date.now() + blobIdx * 1000),
         blobId: blob.id,
         sequence: blob.sequence,
@@ -495,6 +498,7 @@ export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
         converted.push({
           type: 'user',
           content: unescapeWithMathProtection(visibleText),
+          submittedContent: unescapeWithMathProtection(rawText),
           timestamp: message.timestamp || new Date().toISOString(),
           isSkillContent: true,
         });
@@ -509,6 +513,7 @@ export const convertSessionMessages = (rawMessages: any[]): ChatMessage[] => {
         converted.push({
           type: 'user',
           content: unescapeWithMathProtection(visibleText),
+          submittedContent: unescapeWithMathProtection(rawText),
           timestamp: message.timestamp || new Date().toISOString(),
         });
       }

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -26,6 +26,7 @@ import type { PendingAutoIntake } from '../../../types/app';
 import type { EditingFile, DiffInfo } from '../../main-content/types/types';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, LOCAL_MODELS, NANO_CLAUDE_CODE_MODELS, OPENROUTER_MODELS } from '../../../../shared/modelConstants';
 import { getProviderDisplayName } from '../utils/chatFormatting';
+import { buildEditableMessageDraft, buildReplayMessageDraft, getChatMessageId, getMessageReplayContent } from '../utils/chatMessages';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 
@@ -369,14 +370,13 @@ function ChatInterface({
       if (msgs[i].type === 'user') { lastUserMessage = msgs[i]; break; }
     }
     if (!lastUserMessage) return;
-    submitProgrammaticMessage({
-      content: lastUserMessage.content || '',
-      attachedPrompt: lastUserMessage.attachedPrompt ?? null,
-    });
+    const replayDraft = buildReplayMessageDraft(lastUserMessage);
+    if (!replayDraft) return;
+    submitProgrammaticMessage(replayDraft);
   }, [submitProgrammaticMessage]);
 
   const handleCopyMessage = useCallback(async (message: ChatMessage) => {
-    const text = String(message.submittedContent || message.content || '').trim();
+    const text = getMessageReplayContent(message).trim();
     if (!text || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
       return false;
     }
@@ -391,27 +391,27 @@ function ChatInterface({
   }, []);
 
   const handleResendMessage = useCallback((message: ChatMessage) => {
-    const content = typeof message.content === 'string' ? message.content : '';
-    if (!content.trim() && !message.attachedPrompt) {
+    const replayDraft = buildReplayMessageDraft(message);
+    if (!replayDraft) {
       return;
     }
 
-    submitProgrammaticMessage({
-      content,
-      attachedPrompt: message.attachedPrompt ?? null,
-    });
+    submitProgrammaticMessage(replayDraft);
   }, [submitProgrammaticMessage]);
 
   const handleEditMessage = useCallback((message: ChatMessage) => {
-    const content =
-      typeof message.content === 'string'
-        ? message.content
-        : String(message.submittedContent || '');
-    scrollToBottomAndReset();
-    loadMessageIntoComposer({
-      content,
-      attachedPrompt: message.attachedPrompt ?? null,
+    const editableDraft = buildEditableMessageDraft(message);
+    if (!editableDraft) {
+      return;
+    }
+
+    const didLoad = loadMessageIntoComposer({
+      ...editableDraft,
+      editingMessageId: getChatMessageId(message),
     });
+    if (didLoad) {
+      scrollToBottomAndReset();
+    }
   }, [loadMessageIntoComposer, scrollToBottomAndReset]);
 
   const autoIntakeTriggeredRef = useRef(false);
@@ -894,6 +894,7 @@ function ChatInterface({
           onCopyMessage={handleCopyMessage}
           onResendMessage={handleResendMessage}
           onEditMessage={handleEditMessage}
+          onSuggestShellEdit={handleOpenShellEditPrompt}
         />
 
         <ChatComposer
@@ -1030,6 +1031,33 @@ function ChatInterface({
           onStartTask={handleStartTaskInChat}
         />
       </div>
+
+      {isShellEditPromptOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+          <div
+            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={handleCloseShellEditPrompt}
+          />
+          <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-background shadow-2xl">
+            <div className="px-5 py-4">
+              <h3 className="text-base font-semibold text-foreground">
+                {t('shell.historyEdit.promptTitle')}
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {t('shell.historyEdit.promptDescription')}
+              </p>
+            </div>
+            <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-4">
+              <Button variant="outline" onClick={handleCloseShellEditPrompt}>
+                {t('shell.historyEdit.cancel')}
+              </Button>
+              <Button onClick={handleConfirmOpenShell}>
+                {t('shell.historyEdit.confirm')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <QuickSettingsPanel />
       <BtwOverlay state={btwOverlay} onClose={closeBtwOverlay} />

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -13,6 +13,7 @@ import GuidedPromptStarter from './subcomponents/GuidedPromptStarter';
 import { RESUMING_STATUS_TEXT } from '../types/types';
 import type { ChatInterfaceProps } from '../types/types';
 import type { ProviderAvailability } from '../types/types';
+import type { ChatMessage } from '../types/types';
 import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
@@ -297,6 +298,8 @@ function ChatInterface({
     submitProgrammaticInput,
     btwOverlay,
     closeBtwOverlay,
+    submitProgrammaticMessage,
+    loadMessageIntoComposer,
   } = useChatComposerState({
     selectedProject,
     selectedSession,
@@ -361,13 +364,55 @@ function ChatInterface({
 
   const handleRetry = useCallback(() => {
     const msgs = chatMessagesForBtwRef.current;
-    let lastUserMessage: (typeof msgs)[number] | undefined;
+    let lastUserMessage: ChatMessage | undefined;
     for (let i = msgs.length - 1; i >= 0; i--) {
       if (msgs[i].type === 'user') { lastUserMessage = msgs[i]; break; }
     }
-    if (!lastUserMessage?.content) return;
-    submitProgrammaticInput(lastUserMessage.content);
-  }, [submitProgrammaticInput]);
+    if (!lastUserMessage) return;
+    submitProgrammaticMessage({
+      content: lastUserMessage.content || '',
+      attachedPrompt: lastUserMessage.attachedPrompt ?? null,
+    });
+  }, [submitProgrammaticMessage]);
+
+  const handleCopyMessage = useCallback(async (message: ChatMessage) => {
+    const text = String(message.submittedContent || message.content || '').trim();
+    if (!text || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+      return false;
+    }
+
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.error('Failed to copy message text:', error);
+      return false;
+    }
+  }, []);
+
+  const handleResendMessage = useCallback((message: ChatMessage) => {
+    const content = typeof message.content === 'string' ? message.content : '';
+    if (!content.trim() && !message.attachedPrompt) {
+      return;
+    }
+
+    submitProgrammaticMessage({
+      content,
+      attachedPrompt: message.attachedPrompt ?? null,
+    });
+  }, [submitProgrammaticMessage]);
+
+  const handleEditMessage = useCallback((message: ChatMessage) => {
+    const content =
+      typeof message.content === 'string'
+        ? message.content
+        : String(message.submittedContent || '');
+    scrollToBottomAndReset();
+    loadMessageIntoComposer({
+      content,
+      attachedPrompt: message.attachedPrompt ?? null,
+    });
+  }, [loadMessageIntoComposer, scrollToBottomAndReset]);
 
   const autoIntakeTriggeredRef = useRef(false);
   const lastAutoIntakeTriggerIdRef = useRef<string | null>(null);
@@ -838,7 +883,6 @@ function ChatInterface({
           onFileOpen={handleFileOpen}
           onShowSettings={onShowSettings}
           onGrantToolPermission={handleGrantToolPermission}
-          onSuggestShellEdit={handleOpenShellEditPrompt}
           autoExpandTools={autoExpandTools}
           showRawParameters={showRawParameters}
           showThinking={showThinking}
@@ -847,6 +891,9 @@ function ChatInterface({
           statusText={statusTextOverride || claudeStatus?.text}
           newSessionMode={newSessionMode}
           onRetry={handleRetry}
+          onCopyMessage={handleCopyMessage}
+          onResendMessage={handleResendMessage}
+          onEditMessage={handleEditMessage}
         />
 
         <ChatComposer
@@ -983,33 +1030,6 @@ function ChatInterface({
           onStartTask={handleStartTaskInChat}
         />
       </div>
-
-      {isShellEditPromptOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
-          <div
-            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-            onClick={handleCloseShellEditPrompt}
-          />
-          <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-background shadow-2xl">
-            <div className="px-5 py-4">
-              <h3 className="text-base font-semibold text-foreground">
-                {t('shell.historyEdit.promptTitle')}
-              </h3>
-              <p className="mt-2 text-sm leading-6 text-muted-foreground">
-                {t('shell.historyEdit.promptDescription')}
-              </p>
-            </div>
-            <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-4">
-              <Button variant="outline" onClick={handleCloseShellEditPrompt}>
-                {t('shell.historyEdit.cancel')}
-              </Button>
-              <Button onClick={handleConfirmOpenShell}>
-                {t('shell.historyEdit.confirm')}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
 
       <QuickSettingsPanel />
       <BtwOverlay state={btwOverlay} onClose={closeBtwOverlay} />

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -13,6 +13,7 @@ import AssistantThinkingIndicator from './AssistantThinkingIndicator';
 import { getIntrinsicMessageKey } from '../../utils/messageKeys';
 import { groupMessagesIntoTurns } from '../../utils/groupAgentTurns';
 import { getProviderDisplayName } from '../../utils/chatFormatting';
+import { findLatestEditableUserMessage } from '../../utils/chatMessages';
 
 interface ChatMessagesPaneProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
@@ -51,6 +52,7 @@ interface ChatMessagesPaneProps {
   onCopyMessage?: (message: ChatMessage) => Promise<boolean> | boolean;
   onResendMessage?: (message: ChatMessage) => void;
   onEditMessage?: (message: ChatMessage) => void;
+  onSuggestShellEdit?: () => void;
 }
 
 export default function ChatMessagesPane({
@@ -90,6 +92,7 @@ export default function ChatMessagesPane({
   onCopyMessage,
   onResendMessage,
   onEditMessage,
+  onSuggestShellEdit,
 }: ChatMessagesPaneProps) {
   const { t } = useTranslation('chat');
   const messageKeyMapRef = useRef<WeakMap<ChatMessage, string>>(new WeakMap());
@@ -123,6 +126,10 @@ export default function ChatMessagesPane({
   const groupedItems = useMemo(
     () => groupMessagesIntoTurns(visibleMessages, isLoading),
     [visibleMessages, isLoading]
+  );
+  const latestEditableUserMessage = useMemo(
+    () => findLatestEditableUserMessage(chatMessages, Boolean(selectedSession)),
+    [chatMessages, selectedSession],
   );
   return (
     <div
@@ -267,6 +274,8 @@ export default function ChatMessagesPane({
                   onCopyMessage={onCopyMessage}
                   onResendMessage={onResendMessage}
                   onEditMessage={onEditMessage}
+                  canSuggestShellEdit={item.message === latestEditableUserMessage}
+                  onSuggestShellEdit={item.message === latestEditableUserMessage ? onSuggestShellEdit : undefined}
                   disableUserActions={isLoading}
                 />
               );

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -39,7 +39,6 @@ interface ChatMessagesPaneProps {
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
   onGrantToolPermission: (suggestion: { entry: string; toolName: string }) => { success: boolean };
-  onSuggestShellEdit?: () => void;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
@@ -49,6 +48,9 @@ interface ChatMessagesPaneProps {
   intakeGreeting?: string | null;
   newSessionMode?: SessionMode;
   onRetry?: () => void;
+  onCopyMessage?: (message: ChatMessage) => Promise<boolean> | boolean;
+  onResendMessage?: (message: ChatMessage) => void;
+  onEditMessage?: (message: ChatMessage) => void;
 }
 
 export default function ChatMessagesPane({
@@ -76,7 +78,6 @@ export default function ChatMessagesPane({
   onFileOpen,
   onShowSettings,
   onGrantToolPermission,
-  onSuggestShellEdit,
   autoExpandTools,
   showRawParameters,
   showThinking,
@@ -86,6 +87,9 @@ export default function ChatMessagesPane({
   intakeGreeting,
   newSessionMode = 'research',
   onRetry,
+  onCopyMessage,
+  onResendMessage,
+  onEditMessage,
 }: ChatMessagesPaneProps) {
   const { t } = useTranslation('chat');
   const messageKeyMapRef = useRef<WeakMap<ChatMessage, string>>(new WeakMap());
@@ -120,26 +124,6 @@ export default function ChatMessagesPane({
     () => groupMessagesIntoTurns(visibleMessages, isLoading),
     [visibleMessages, isLoading]
   );
-  const latestEditableUserMessage = useMemo(() => {
-    if (!selectedSession) {
-      return null;
-    }
-
-    for (let index = chatMessages.length - 1; index >= 0; index -= 1) {
-      const message = chatMessages[index];
-      if (
-        message.type === 'user' &&
-        !message.isSkillContent &&
-        typeof message.content === 'string' &&
-        message.content.trim()
-      ) {
-        return message;
-      }
-    }
-
-    return null;
-  }, [chatMessages, selectedSession]);
-
   return (
     <div
       ref={scrollContainerRef}
@@ -274,14 +258,16 @@ export default function ChatMessagesPane({
                   onFileOpen={onFileOpen}
                   onShowSettings={onShowSettings}
                   onGrantToolPermission={onGrantToolPermission}
-                  canSuggestShellEdit={item.message === latestEditableUserMessage}
-                  onSuggestShellEdit={item.message === latestEditableUserMessage ? onSuggestShellEdit : undefined}
                   autoExpandTools={autoExpandTools}
                   showRawParameters={showRawParameters}
                   showThinking={showThinking}
                   selectedProject={selectedProject}
                   provider={provider}
                   onRetry={onRetry}
+                  onCopyMessage={onCopyMessage}
+                  onResendMessage={onResendMessage}
+                  onEditMessage={onEditMessage}
+                  disableUserActions={isLoading}
                 />
               );
             }

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { FileImage, FileText, User, RefreshCw } from 'lucide-react';
+import { Check, Copy, FileImage, FileText, Pencil, RefreshCw, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import SessionProviderLogo from '../../../SessionProviderLogo';
 import type {
@@ -28,8 +28,6 @@ interface MessageComponentProps {
   onFileOpen?: (filePath: string, diffInfo?: unknown) => void;
   onShowSettings?: () => void;
   onGrantToolPermission?: (suggestion: PermissionSuggestion) => PermissionGrantResult | null | undefined;
-  canSuggestShellEdit?: boolean;
-  onSuggestShellEdit?: () => void;
   autoExpandTools?: boolean;
   showRawParameters?: boolean;
   showThinking?: boolean;
@@ -37,6 +35,10 @@ interface MessageComponentProps {
   selectedProject?: Project | null;
   provider: Provider | string;
   onRetry?: () => void;
+  onCopyMessage?: (message: ChatMessage) => Promise<boolean> | boolean;
+  onResendMessage?: (message: ChatMessage) => void;
+  onEditMessage?: (message: ChatMessage) => void;
+  disableUserActions?: boolean;
 }
 
 type InteractiveOption = {
@@ -66,7 +68,7 @@ function extractSkillContentTitle(content: string, fallback: string): string {
   return fallback;
 }
 
-const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, canSuggestShellEdit, onSuggestShellEdit, autoExpandTools, showRawParameters, showThinking, hideThinkingFold, selectedProject, provider, onRetry }: MessageComponentProps) => {
+const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, autoExpandTools, showRawParameters, showThinking, hideThinkingFold, selectedProject, provider, onRetry, onCopyMessage, onResendMessage, onEditMessage, disableUserActions }: MessageComponentProps) => {
   const { t } = useTranslation('chat');
   const isGrouped = prevMessage && prevMessage.type === message.type &&
                    ((prevMessage.type === 'assistant') ||
@@ -77,11 +79,26 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
   const [isExpanded, setIsExpanded] = React.useState(false);
   const permissionSuggestion = getPermissionSuggestion(message, provider);
   const [permissionGrantState, setPermissionGrantState] = React.useState<PermissionGrantState>('idle');
+  const [didCopy, setDidCopy] = React.useState(false);
 
 
   React.useEffect(() => {
     setPermissionGrantState('idle');
   }, [permissionSuggestion?.entry, message.toolId]);
+
+  React.useEffect(() => {
+    if (!didCopy) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setDidCopy(false);
+    }, 1500);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [didCopy]);
 
   React.useEffect(() => {
     const node = messageRef.current;
@@ -118,6 +135,13 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
   }
 
   const visibleAttachments = Array.isArray(message.attachments) ? message.attachments : [];
+  const hasReplayableAttachments = visibleAttachments.length > 0 || (Array.isArray(message.images) && message.images.length > 0);
+  const hasVisibleUserText = typeof message.content === 'string' && message.content.trim().length > 0;
+  const hasAttachedPrompt = Boolean(message.attachedPrompt);
+  const canCopyMessage = Boolean(onCopyMessage && (hasVisibleUserText || (typeof message.submittedContent === 'string' && message.submittedContent.trim().length > 0)));
+  const canResendMessage = Boolean(onResendMessage && !hasReplayableAttachments && (hasVisibleUserText || hasAttachedPrompt));
+  const canEditMessage = Boolean(onEditMessage && !hasReplayableAttachments && (hasVisibleUserText || hasAttachedPrompt));
+  const actionButtonClass = 'inline-flex items-center gap-1 rounded-full border border-blue-200/80 bg-white/90 px-2.5 py-1 text-[11px] font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800/60 dark:bg-slate-900/80 dark:text-blue-300 dark:hover:bg-blue-950/40';
 
   return (
     <div
@@ -168,18 +192,6 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               </div>
             )}
           </div>
-          {canSuggestShellEdit && onSuggestShellEdit && (
-            <div className="mb-1.5 mr-1">
-              <button
-                type="button"
-                onClick={onSuggestShellEdit}
-                className="text-[11px] font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
-                title={t('shell.historyEdit.action')}
-              >
-                {t('shell.historyEdit.action')}
-              </button>
-            </div>
-          )}
           <div className="bg-blue-600 text-white rounded-2xl rounded-tr-none px-4 py-2.5 shadow-sm max-w-[90%] sm:max-w-[85%]">
             {message.attachedPrompt && (
               <div className={message.content?.trim() ? 'mb-1.5' : ''}>
@@ -251,6 +263,53 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               </div>
             )}
           </div>
+          {(canCopyMessage || canResendMessage || canEditMessage) && (
+            <div className="mt-2 mr-1 flex flex-wrap items-center justify-end gap-1.5">
+              {canCopyMessage && (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const copied = await onCopyMessage?.(message);
+                    if (copied) {
+                      setDidCopy(true);
+                    }
+                  }}
+                  className={actionButtonClass}
+                  title={didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}
+                  aria-label={didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}
+                >
+                  {didCopy ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                  <span>{didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}</span>
+                </button>
+              )}
+              {canResendMessage && (
+                <button
+                  type="button"
+                  onClick={() => onResendMessage?.(message)}
+                  disabled={disableUserActions}
+                  className={actionButtonClass}
+                  title={t('messageActions.resend', { defaultValue: 'Resend' })}
+                  aria-label={t('messageActions.resend', { defaultValue: 'Resend' })}
+                >
+                  <RefreshCw className="h-3.5 w-3.5" />
+                  <span>{t('messageActions.resend', { defaultValue: 'Resend' })}</span>
+                </button>
+              )}
+              {canEditMessage && (
+                <button
+                  type="button"
+                  onClick={() => onEditMessage?.(message)}
+                  disabled={disableUserActions}
+                  className={actionButtonClass}
+                  title={t('messageActions.edit', { defaultValue: 'Edit' })}
+                  aria-label={t('messageActions.edit', { defaultValue: 'Edit' })}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  <span>{t('messageActions.edit', { defaultValue: 'Edit' })}</span>
+                </button>
+              )}
+            </div>
+          )}
           {!isGrouped && (
             <div className="text-[10px] text-gray-400 mt-1 mr-1">
               {formattedTime}

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -10,6 +10,7 @@ import type {
 } from '../../types/types';
 import { Markdown } from './Markdown';
 import { formatUsageLimitText, getProviderDisplayName } from '../../utils/chatFormatting';
+import { getMessageReplayContent } from '../../utils/chatMessages';
 import { getPermissionSuggestion } from '../../utils/chatPermissions';
 import type { Project } from '../../../../types/app';
 import { ToolRenderer, shouldHideToolResult } from '../../tools';
@@ -38,6 +39,8 @@ interface MessageComponentProps {
   onCopyMessage?: (message: ChatMessage) => Promise<boolean> | boolean;
   onResendMessage?: (message: ChatMessage) => void;
   onEditMessage?: (message: ChatMessage) => void;
+  canSuggestShellEdit?: boolean;
+  onSuggestShellEdit?: () => void;
   disableUserActions?: boolean;
 }
 
@@ -68,7 +71,7 @@ function extractSkillContentTitle(content: string, fallback: string): string {
   return fallback;
 }
 
-const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, autoExpandTools, showRawParameters, showThinking, hideThinkingFold, selectedProject, provider, onRetry, onCopyMessage, onResendMessage, onEditMessage, disableUserActions }: MessageComponentProps) => {
+const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFileOpen, onShowSettings, onGrantToolPermission, autoExpandTools, showRawParameters, showThinking, hideThinkingFold, selectedProject, provider, onRetry, onCopyMessage, onResendMessage, onEditMessage, canSuggestShellEdit, onSuggestShellEdit, disableUserActions }: MessageComponentProps) => {
   const { t } = useTranslation('chat');
   const isGrouped = prevMessage && prevMessage.type === message.type &&
                    ((prevMessage.type === 'assistant') ||
@@ -136,11 +139,19 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
 
   const visibleAttachments = Array.isArray(message.attachments) ? message.attachments : [];
   const hasReplayableAttachments = visibleAttachments.length > 0 || (Array.isArray(message.images) && message.images.length > 0);
+  const replayContent = getMessageReplayContent(message);
   const hasVisibleUserText = typeof message.content === 'string' && message.content.trim().length > 0;
   const hasAttachedPrompt = Boolean(message.attachedPrompt);
-  const canCopyMessage = Boolean(onCopyMessage && (hasVisibleUserText || (typeof message.submittedContent === 'string' && message.submittedContent.trim().length > 0)));
-  const canResendMessage = Boolean(onResendMessage && !hasReplayableAttachments && (hasVisibleUserText || hasAttachedPrompt));
-  const canEditMessage = Boolean(onEditMessage && !hasReplayableAttachments && (hasVisibleUserText || hasAttachedPrompt));
+  const hasReplayableUserContent = replayContent.trim().length > 0 || hasAttachedPrompt;
+  const isSupersededUserMessage = Boolean(message.isSuperseded);
+  const canCopyMessage = Boolean(onCopyMessage && replayContent.trim().length > 0);
+  const showResendMessage = Boolean(onResendMessage && !isSupersededUserMessage && hasReplayableUserContent);
+  const showEditMessage = Boolean(onEditMessage && !isSupersededUserMessage && (hasVisibleUserText || hasAttachedPrompt || replayContent.trim().length > 0));
+  const replayAttachmentTooltip = hasReplayableAttachments
+    ? t('messageActions.attachmentsUnsupported', {
+        defaultValue: 'Resend and edit are unavailable for messages with attachments right now.',
+      })
+    : null;
   const actionButtonClass = 'inline-flex items-center gap-1 rounded-full border border-blue-200/80 bg-white/90 px-2.5 py-1 text-[11px] font-medium text-blue-700 transition-colors hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800/60 dark:bg-slate-900/80 dark:text-blue-300 dark:hover:bg-blue-950/40';
 
   return (
@@ -192,7 +203,34 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               </div>
             )}
           </div>
+          {canSuggestShellEdit && onSuggestShellEdit && (
+            <div className="mb-1.5 mr-1">
+              <button
+                type="button"
+                onClick={onSuggestShellEdit}
+                className="text-[11px] font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors"
+                title={t('shell.historyEdit.action')}
+                aria-label={t('shell.historyEdit.action')}
+              >
+                {t('shell.historyEdit.action')}
+              </button>
+            </div>
+          )}
           <div className="bg-blue-600 text-white rounded-2xl rounded-tr-none px-4 py-2.5 shadow-sm max-w-[90%] sm:max-w-[85%]">
+            {(message.editedFromMessageId || message.isSuperseded) && (
+              <div className="mb-1.5 flex flex-wrap gap-1.5">
+                {message.editedFromMessageId && (
+                  <span className="inline-flex items-center rounded-full bg-blue-500/20 px-2.5 py-1 text-[11px] font-medium text-blue-100">
+                    {t('messageActions.editedVersion', { defaultValue: 'Edited message' })}
+                  </span>
+                )}
+                {message.isSuperseded && (
+                  <span className="inline-flex items-center rounded-full bg-slate-900/20 px-2.5 py-1 text-[11px] font-medium text-blue-100">
+                    {t('messageActions.superseded', { defaultValue: 'Superseded by later edit' })}
+                  </span>
+                )}
+              </div>
+            )}
             {message.attachedPrompt && (
               <div className={message.content?.trim() ? 'mb-1.5' : ''}>
                 <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-blue-500/20 text-blue-100 text-xs font-medium">
@@ -263,49 +301,55 @@ const MessageComponent = memo(({ message, index, prevMessage, createDiff, onFile
               </div>
             )}
           </div>
-          {(canCopyMessage || canResendMessage || canEditMessage) && (
+          {(canCopyMessage || showResendMessage || showEditMessage) && (
             <div className="mt-2 mr-1 flex flex-wrap items-center justify-end gap-1.5">
               {canCopyMessage && (
                 <button
                   type="button"
                   onClick={async () => {
+                    if (didCopy) {
+                      setDidCopy(false);
+                    }
                     const copied = await onCopyMessage?.(message);
                     if (copied) {
                       setDidCopy(true);
                     }
                   }}
                   className={actionButtonClass}
-                  title={didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}
-                  aria-label={didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}
+                  title={didCopy ? t('codeBlock.copied') : t('messageActions.copy')}
+                  aria-label={didCopy ? t('codeBlock.copied') : t('messageActions.copy')}
                 >
                   {didCopy ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  <span>{didCopy ? t('codeBlock.copied') : t('messageActions.copy', { defaultValue: 'Copy' })}</span>
+                  <span>{didCopy ? t('codeBlock.copied') : t('messageActions.copy')}</span>
+                  <span className="sr-only" aria-live="polite">
+                    {didCopy ? t('codeBlock.copied') : ''}
+                  </span>
                 </button>
               )}
-              {canResendMessage && (
+              {showResendMessage && (
                 <button
                   type="button"
                   onClick={() => onResendMessage?.(message)}
-                  disabled={disableUserActions}
+                  disabled={disableUserActions || Boolean(replayAttachmentTooltip)}
                   className={actionButtonClass}
-                  title={t('messageActions.resend', { defaultValue: 'Resend' })}
-                  aria-label={t('messageActions.resend', { defaultValue: 'Resend' })}
+                  title={replayAttachmentTooltip || t('messageActions.resend')}
+                  aria-label={t('messageActions.resend')}
                 >
                   <RefreshCw className="h-3.5 w-3.5" />
-                  <span>{t('messageActions.resend', { defaultValue: 'Resend' })}</span>
+                  <span>{t('messageActions.resend')}</span>
                 </button>
               )}
-              {canEditMessage && (
+              {showEditMessage && (
                 <button
                   type="button"
                   onClick={() => onEditMessage?.(message)}
-                  disabled={disableUserActions}
+                  disabled={disableUserActions || Boolean(replayAttachmentTooltip)}
                   className={actionButtonClass}
-                  title={t('messageActions.edit', { defaultValue: 'Edit' })}
-                  aria-label={t('messageActions.edit', { defaultValue: 'Edit' })}
+                  title={replayAttachmentTooltip || t('messageActions.edit')}
+                  aria-label={t('messageActions.edit')}
                 >
                   <Pencil className="h-3.5 w-3.5" />
-                  <span>{t('messageActions.edit', { defaultValue: 'Edit' })}</span>
+                  <span>{t('messageActions.edit')}</span>
                 </button>
               )}
             </div>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -24,7 +24,11 @@
   "messageActions": {
     "copy": "Copy",
     "resend": "Resend",
-    "edit": "Edit"
+    "edit": "Edit",
+    "editedVersion": "Edited message",
+    "superseded": "Superseded by later edit",
+    "attachmentsUnsupported": "Resend and edit are unavailable for messages with attachments right now.",
+    "confirmReplaceDraft": "Replace your current unsent draft with this message?"
   },
   "tools": {
     "settings": "Tool Settings",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -21,6 +21,11 @@
     "retry": "Retry",
     "usageLimitHint": "You can retry when your usage limit resets"
   },
+  "messageActions": {
+    "copy": "Copy",
+    "resend": "Resend",
+    "edit": "Edit"
+  },
   "tools": {
     "settings": "Tool Settings",
     "error": "Tool Error",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -24,7 +24,11 @@
   "messageActions": {
     "copy": "복사",
     "resend": "다시 보내기",
-    "edit": "수정"
+    "edit": "수정",
+    "editedVersion": "수정된 메시지",
+    "superseded": "나중 수정본으로 대체됨",
+    "attachmentsUnsupported": "첨부 파일이 있는 메시지는 지금 다시 보내기나 수정이 지원되지 않습니다.",
+    "confirmReplaceDraft": "현재 작성 중인 초안을 이 메시지로 바꾸시겠습니까?"
   },
   "tools": {
     "settings": "도구 설정",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -21,6 +21,11 @@
     "retry": "재시도",
     "usageLimitHint": "사용량 제한이 재설정되면 재시도할 수 있습니다"
   },
+  "messageActions": {
+    "copy": "복사",
+    "resend": "다시 보내기",
+    "edit": "수정"
+  },
   "tools": {
     "settings": "도구 설정",
     "error": "도구 오류",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -24,7 +24,11 @@
   "messageActions": {
     "copy": "复制",
     "resend": "重发",
-    "edit": "修改"
+    "edit": "修改",
+    "editedVersion": "已修改消息",
+    "superseded": "已被后续修改替代",
+    "attachmentsUnsupported": "当前带附件的消息暂不支持重发或修改。",
+    "confirmReplaceDraft": "要用这条消息替换你当前未发送的草稿吗？"
   },
   "tools": {
     "settings": "工具设置",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -21,6 +21,11 @@
     "retry": "重试",
     "usageLimitHint": "使用限制重置后可以重试"
   },
+  "messageActions": {
+    "copy": "复制",
+    "resend": "重发",
+    "edit": "修改"
+  },
   "tools": {
     "settings": "工具设置",
     "error": "工具错误",


### PR DESCRIPTION
## Summary

  - Copy the original submitted message text
  - Resend a previous user message
  - Load a previous user message back into the composer for editing

  ## What Changed

  - Added `Copy`, `Resend`, and `Edit` actions to user messages
  - Preserved the original submitted content so copy/retry behavior remains accurate when attached prompts are involved
  - Added programmatic draft loading/submission helpers in the chat composer state
  - Disabled resend/edit for messages with replayable file/image attachments
  - Added i18n strings for the new message actions

  ## Validation

  - `npm run typecheck`
  - Rebased onto the latest upstream `main`

  ## Notes

  - This PR only contains the chat message action changes
  - The separate runtime fix for `cross-spawn` is intentionally not included here