### PR TITLE
fix(ui): batch fix four UI bugs — AskUserQuestion, scroll arrow, workspace wizard, file preview

### DIFF
--- a/src/components/ProjectCreationWizard.jsx
+++ b/src/components/ProjectCreationWizard.jsx
@@ -11,7 +11,7 @@ const ProjectCreationWizard = ({ onClose, onProjectCreated }) => {
   const { t } = useTranslation();
   // Wizard state
   const [step, setStep] = useState(1); // 1: Choose type, 2: Configure, 3: Confirm
-  const [workspaceType, setWorkspaceType] = useState('existing'); // 'existing' or 'new' - default to 'existing'
+  const [workspaceType, setWorkspaceType] = useState('new'); // 'existing' or 'new' - default to 'new'
 
   // Form state
   const [workspacePath, setWorkspacePath] = useState('');

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -340,7 +340,10 @@ export function useChatRealtimeHandlers({
                 const resultStr = typeof part.content === 'string' ? part.content : JSON.stringify(part.content);
                 const parsedAnswers = parseAskUserAnswers(resultStr);
                 if (parsedAnswers) {
-                  result.toolInput = mergeAnswersIntoToolInput(String(message.toolInput || '{}'), parsedAnswers);
+                  const inputStr = typeof message.toolInput === 'string'
+                    ? message.toolInput
+                    : JSON.stringify(message.toolInput || {});
+                  result.toolInput = mergeAnswersIntoToolInput(inputStr, parsedAnswers);
                 }
               }
               if (message.isSubagentContainer && message.subagentState) {

--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -656,6 +656,9 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       title: (input: any) => {
         const count = input.questions?.length || 0;
         const hasAnswers = input.answers && Object.keys(input.answers).length > 0;
+        if (count === 0) {
+          return hasAnswers ? 'Questions — answered' : 'Questions';
+        }
         if (count === 1) {
           const header = input.questions[0]?.header || 'Question';
           return hasAnswers ? `${header} — answered` : header;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -26,8 +26,6 @@ import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, LOCAL_MODELS
 import { getProviderDisplayName } from '../utils/chatFormatting';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
-import { X } from 'lucide-react';
-
 
 const DEFAULT_PROVIDER_AVAILABILITY: Record<Provider, ProviderAvailability> = {
   claude: { cliAvailable: true, cliCommand: 'claude', installHint: null },
@@ -988,19 +986,12 @@ function ChatInterface({
             className="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl"
             onClick={(event) => event.stopPropagation()}
           >
-            <button
-              type="button"
-              onClick={handleClosePreview}
-              className="absolute right-3 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-              title={t('sessionContext.preview.closePreview')}
-            >
-              <X className="h-5 w-5" />
-            </button>
             <div className="min-h-0 flex-1 overflow-y-auto">
               <ChatContextFilePreview
                 projectName={selectedProject.name}
                 file={previewFile}
                 onOpenInEditor={handleOpenPreviewInEditor}
+                onClose={handleClosePreview}
               />
             </div>
           </div>

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -364,38 +364,39 @@ export default function ChatComposer({
   ];
 
   return (
-    <div className={`p-2 sm:p-4 md:p-4 flex-shrink-0 ${centered ? 'pb-2 sm:pb-3' : 'pb-2 sm:pb-4 md:pb-6'} ${mobileFloatingClass}`}>
-      <div className={`${centered ? 'max-w-3xl' : 'max-w-5xl'} mx-auto mb-3`}>
+    <div className={`px-2 pt-0 sm:px-4 sm:pt-1 md:px-4 md:pt-1 flex-shrink-0 ${centered ? 'pb-2 sm:pb-3' : 'pb-2 sm:pb-4 md:pb-6'} ${mobileFloatingClass}`}>
+      <div className={`${centered ? 'max-w-3xl' : 'max-w-5xl'} mx-auto`}>
         <PermissionRequestsBanner
           provider={provider}
           pendingPermissionRequests={pendingPermissionRequests}
           handlePermissionDecision={handlePermissionDecision}
           handleGrantToolPermission={handleGrantToolPermission}
         />
-
-        {!centered && !hasQuestionPanel && (
-          <div className="flex items-center justify-center gap-2 sm:gap-3 flex-wrap">
-            <ClaudeStatus
-              status={claudeStatus}
-              isLoading={isLoading}
-              onAbort={onAbortSession}
-              provider={provider}
-            />
-            {isUserScrolledUp && hasMessages && (
-              <button
-                onClick={onScrollToBottom}
-                className="w-7 h-7 sm:w-8 sm:h-8 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg shadow-sm flex items-center justify-center transition-all duration-200 hover:scale-105"
-              >
-                <svg className="w-3.5 h-3.5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-                </svg>
-              </button>
-            )}
-          </div>
-        )}
       </div>
 
       {!hasQuestionPanel && <form onSubmit={onSubmit as (event: FormEvent<HTMLFormElement>) => void} className={`relative mx-auto ${centered ? 'max-w-3xl' : 'max-w-5xl'}`}>
+        {!centered && !hasQuestionPanel && (isLoading || (isUserScrolledUp && hasMessages)) && (
+          <div className="pointer-events-none absolute bottom-full left-0 right-0 flex justify-center pb-1.5">
+            <div className="pointer-events-auto relative flex items-center">
+              <ClaudeStatus
+                status={claudeStatus}
+                isLoading={isLoading}
+                onAbort={onAbortSession}
+                provider={provider}
+              />
+              {isUserScrolledUp && hasMessages && (
+                <button
+                  onClick={onScrollToBottom}
+                  className={`w-7 h-7 sm:w-8 sm:h-8 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg shadow-sm flex items-center justify-center transition-all duration-200 hover:scale-105 ${isLoading ? 'absolute left-full ml-2' : ''}`}
+                >
+                  <svg className="w-3.5 h-3.5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                  </svg>
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         {isDragActive && (
           <div className="absolute inset-0 bg-primary/15 border-2 border-dashed border-primary/50 rounded-3xl flex items-center justify-center z-50">
             <div className="bg-card rounded-xl p-4 shadow-lg border border-border/30">
@@ -666,9 +667,6 @@ export default function ChatComposer({
                     onToggleCommandMenu={onToggleCommandMenu}
                     hasInput={hasInput}
                     onClearInput={onClearInput}
-                    isUserScrolledUp={isUserScrolledUp}
-                    hasMessages={hasMessages}
-                    onScrollToBottom={onScrollToBottom}
                     hideCommandMenu
                     compact
                   />

--- a/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
@@ -4,7 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
-import { ExternalLink, FileText } from 'lucide-react';
+import { ExternalLink, FileText, X } from 'lucide-react';
 
 import { Button } from '../../../ui/button';
 import { api } from '../../../../utils/api';
@@ -91,6 +91,7 @@ interface ChatContextFilePreviewProps {
   projectName: string;
   file: PreviewFile;
   onOpenInEditor?: (filePath: string) => void;
+  onClose?: () => void;
   compact?: boolean;
   preloadedContent?: string | null;
 }
@@ -99,6 +100,7 @@ export default function ChatContextFilePreview({
   projectName,
   file,
   onOpenInEditor,
+  onClose,
   compact = false,
   preloadedContent,
 }: ChatContextFilePreviewProps) {
@@ -218,18 +220,32 @@ export default function ChatContextFilePreview({
             {file?.relativePath || t('sessionContext.preview.selectFile')}
           </div>
         </div>
-        {file && (
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            onClick={() => onOpenInEditor?.(openPath)}
-            className={compact ? 'h-7 px-2 text-[11px]' : undefined}
-          >
-            <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-            {t('sessionContext.preview.open')}
-          </Button>
-        )}
+        <div className="flex items-center gap-1 shrink-0">
+          {file && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={() => onOpenInEditor?.(openPath)}
+              className={compact ? 'h-7 px-2 text-[11px]' : undefined}
+            >
+              <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+              {t('sessionContext.preview.open')}
+            </Button>
+          )}
+          {onClose && (
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={onClose}
+              className="h-8 w-8 p-0"
+              title={t('sessionContext.preview.closePreview')}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
       </div>
 
       {loading && (

--- a/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextSidebar.tsx
@@ -1058,21 +1058,13 @@ export default function ChatContextSidebar({
             className="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <button
-              type="button"
-              onClick={handleClosePreview}
-              className="absolute right-3 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-              title={t('sessionContext.preview.closePreview')}
-            >
-              <X className="h-5 w-5" />
-            </button>
-
             {previewFile && (
               <div className="min-h-0 flex-1 overflow-y-auto">
                 <ChatContextFilePreview
                   projectName={projectName}
                   file={previewFile}
                   onOpenInEditor={handleOpenInEditor}
+                  onClose={handleClosePreview}
                   preloadedContent={previewContent}
                 />
               </div>
@@ -1080,18 +1072,28 @@ export default function ChatContextSidebar({
 
             {previewTask && !previewFile && (
               <div className="min-h-0 flex-1 overflow-y-auto p-5">
-                <div className="mb-4 flex items-center gap-3">
-                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl border border-sky-200/80 bg-sky-50/95 text-sky-700 shadow-sm dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-200">
-                    <ClipboardList className="h-4 w-4" />
-                  </span>
-                  <div>
-                    <div className="text-sm font-semibold text-foreground">{previewTask.label}</div>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <ItemBadge>{getTaskKindLabel(previewTask.kind)}</ItemBadge>
-                      <ItemBadge>{formatTimeLabel(previewTask.lastSeenAt, i18n.language)}</ItemBadge>
-                      <ItemBadge>{previewTask.count}x</ItemBadge>
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-sky-200/80 bg-sky-50/95 text-sky-700 shadow-sm dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-200">
+                      <ClipboardList className="h-4 w-4" />
+                    </span>
+                    <div className="min-w-0">
+                      <div className="text-sm font-semibold text-foreground truncate">{previewTask.label}</div>
+                      <div className="flex items-center gap-2 mt-0.5">
+                        <ItemBadge>{getTaskKindLabel(previewTask.kind)}</ItemBadge>
+                        <ItemBadge>{formatTimeLabel(previewTask.lastSeenAt, i18n.language)}</ItemBadge>
+                        <ItemBadge>{previewTask.count}x</ItemBadge>
+                      </div>
                     </div>
                   </div>
+                  <button
+                    type="button"
+                    onClick={handleClosePreview}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                    title={t('sessionContext.preview.closePreview')}
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
                 </div>
                 {previewTask.detail && (
                   <div className="rounded-xl border border-border/60 bg-muted/10 p-4">

--- a/src/components/chat/view/subcomponents/ChatInputControls.tsx
+++ b/src/components/chat/view/subcomponents/ChatInputControls.tsx
@@ -27,9 +27,6 @@ interface ChatInputControlsProps {
   onToggleCommandMenu: () => void;
   hasInput: boolean;
   onClearInput: () => void;
-  isUserScrolledUp: boolean;
-  hasMessages: boolean;
-  onScrollToBottom: () => void;
   hideCommandMenu?: boolean;
   compact?: boolean;
 }
@@ -51,9 +48,6 @@ export default function ChatInputControls({
   onToggleCommandMenu,
   hasInput,
   onClearInput,
-  isUserScrolledUp,
-  hasMessages,
-  onScrollToBottom,
   hideCommandMenu,
   compact,
 }: ChatInputControlsProps) {
@@ -173,17 +167,6 @@ export default function ChatInputControls({
         </button>
       )}
 
-      {isUserScrolledUp && hasMessages && (
-        <button
-          onClick={onScrollToBottom}
-          className="w-7 h-7 sm:w-8 sm:h-8 bg-primary hover:bg-primary/90 text-primary-foreground rounded-lg shadow-sm flex items-center justify-center transition-all duration-200 hover:scale-105"
-          title={t('input.scrollToBottom', { defaultValue: 'Scroll to bottom' })}
-        >
-          <svg className="w-3.5 h-3.5 sm:w-4 sm:h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-          </svg>
-        </button>
-      )}
     </>
   );
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -343,9 +343,9 @@
       "usingProvidedToken": "Using provided token",
       "noAuthentication": "No authentication",
       "sshKey": "SSH Key",
-      "existingInfo": "The workspace will be added to your project list and will be available for Claude/Cursor sessions.",
+      "existingInfo": "The workspace will be added to your project list and will be available for research sessions.",
       "newWithClone": "The repository will be cloned from this folder.",
-      "newEmpty": "The workspace will be added to your project list and will be available for Claude/Cursor sessions.",
+      "newEmpty": "The workspace will be added to your project list and will be available for research sessions.",
       "cloningRepository": "Cloning repository..."
     },
     "buttons": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -343,9 +343,9 @@
       "usingProvidedToken": "제공된 토큰 사용",
       "noAuthentication": "인증 없음",
       "sshKey": "SSH 키",
-      "existingInfo": "워크스페이스가 프로젝트 목록에 추가되며 Claude/Cursor 세션에서 사용할 수 있습니다.",
+      "existingInfo": "워크스페이스가 프로젝트 목록에 추가되며 연구 세션에서 사용할 수 있습니다.",
       "newWithClone": "이 폴더에 저장소가 clone됩니다.",
-      "newEmpty": "워크스페이스가 프로젝트 목록에 추가되며 Claude/Cursor 세션에서 사용할 수 있습니다.",
+      "newEmpty": "워크스페이스가 프로젝트 목록에 추가되며 연구 세션에서 사용할 수 있습니다.",
       "cloningRepository": "저장소 clone 중..."
     },
     "buttons": {

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -343,9 +343,9 @@
       "usingProvidedToken": "使用提供的令牌",
       "noAuthentication": "无身份验证",
       "sshKey": "SSH 密钥",
-      "existingInfo": "工作区将被添加到您的项目列表中，并可用于 Claude/Cursor 会话。",
+      "existingInfo": "工作区将被添加到您的项目列表中，并可用于研究会话。",
       "newWithClone": "仓库将从此文件夹克隆。",
-      "newEmpty": "工作区将被添加到您的项目列表中，并可用于 Claude/Cursor 会话。",
+      "newEmpty": "工作区将被添加到您的项目列表中，并可用于研究会话。",
       "cloningRepository": "正在克隆仓库..."
     },
     "buttons": {


### PR DESCRIPTION
## Summary

Fixes four UI bugs reported in the Dr. Claw interface:

- **AskUserQuestion "0 questions"**: `String(message.toolInput)` in `useChatRealtimeHandlers` corrupted object inputs to `"[object Object]"`, losing the questions array. Fixed by using `JSON.stringify()` for objects. Also added a fallback title ("Questions") when count is 0 instead of showing "0 questions".

- **Scroll-to-bottom arrow layout jitter**: Removed the duplicate arrow from `ChatInputControls` (inside the input box, caused layout shifts). Kept the one in `ChatComposer`, repositioned it to float above the form using `absolute bottom-full` so it doesn't take layout space or add a background strip. When the Processing indicator is visible, the arrow sits to its right via `absolute left-full`; when not, the arrow renders as a normal centered element.

- **Workspace creation "Cursor" reference & default**: Changed default workspace type from "existing" to "new". Replaced "Claude/Cursor sessions" with "research sessions" across en, zh-CN, and ko locale files.

- **File preview Open/X button overlap**: Moved the close button from an absolute overlay position into the `ChatContextFilePreview` toolbar header (new `onClose` prop), rendering it inline next to the Open button. Updated both `ChatInterface` and `ChatContextSidebar` modal overlays. Added a close button to the sidebar task preview header as well.

## Files Changed (11)

| File | Change |
|------|--------|
| `useChatRealtimeHandlers.ts` | Fix `String()` → `JSON.stringify()` for AskUserQuestion toolInput |
| `toolConfigs.ts` | Add count=0 fallback in AskUserQuestion title |
| `ChatComposer.tsx` | Float status bar above form, deduplicate arrow, reduce top padding |
| `ChatInputControls.tsx` | Remove scroll arrow and unused props |
| `ChatContextFilePreview.tsx` | Add `onClose` prop, render X in toolbar |
| `ChatInterface.tsx` | Remove absolute X, pass `onClose` to preview |
| `ChatContextSidebar.tsx` | Remove absolute X, pass `onClose` to preview, add X to task preview |
| `ProjectCreationWizard.jsx` | Default to 'new' workspace |
| `en/common.json` | "research sessions" instead of "Claude/Cursor sessions" |
| `zh-CN/common.json` | "研究会话" instead of "Claude/Cursor 会话" |
| `ko/common.json` | "연구 세션" instead of "Claude/Cursor 세션" |

## Test plan

- [ ] Open chat, trigger Claude Code AskUserQuestion → answer → verify collapsed display shows correct question count (not "0 questions")
- [ ] Scroll up in a chat with messages → verify single down arrow appears above input, not inside it
- [ ] Start a processing session → verify Processing indicator stays centered, arrow appears to its right without shifting it
- [ ] Verify no white background strip between messages and input area
- [ ] Open workspace creation wizard → verify "New Workspace" is pre-selected
- [ ] Proceed to step 3 → verify no "Cursor" mention in confirmation text
- [ ] Click a file link in chat → verify Open and X buttons don't overlap in preview modal
- [ ] Open a file from sidebar context → verify same non-overlapping layout

Made with [Cursor](https://cursor.com)