### PR TITLE
feat: rewrite managing-obsidian-notes skill v2.0 with CLI + onboarding

### DIFF
--- a/.agents/skills/skills-index.md
+++ b/.agents/skills/skills-index.md
@@ -1,0 +1,253 @@
+# Skills Index
+
+> **Do NOT read all SKILL.md files at once.** Use this index to find the right skill, then read only that one.
+
+## Core Pipeline Skills
+
+| Skill | Path | Description |
+|-------|------|-------------|
+| dataset-discovery | `.agents/skills/dataset-discovery/SKILL.md` | Multi-source ML dataset discovery. Search HuggingFace Hub, OpenML, GitHub, and paper cross-references for datasets re... |
+| init-analysis | `.agents/skills/init-analysis/SKILL.md` | This skill should be used when the user asks to "run initial analysis", "analyze single-cell data", "QC my data", "ru... |
+| inno-code-survey | `.agents/skills/inno-code-survey/SKILL.md` | Acquires missing code repositories for the selected idea (Phase A) and conducts comprehensive code survey mapping aca... |
+| inno-deep-research | `.agents/skills/inno-deep-research/SKILL.md` | Comprehensive research assistant that synthesizes information from multiple sources with citations. Use when: conduct... |
+| inno-experiment-analysis | `.agents/skills/inno-experiment-analysis/SKILL.md` | This skill should be used when the user asks to "analyze experimental results", "generate results section", "statisti... |
+| inno-experiment-dev | `.agents/skills/inno-experiment-dev/SKILL.md` | Creates implementation plan, writes project code with judge feedback loop, and submits final experiment run. Use afte... |
+| inno-figure-gen | `.agents/skills/inno-figure-gen/SKILL.md` | Generate/edit images with Gemini image models (default: gemini-3.1-flash-image-preview). Use for image create/modify ... |
+| inno-grant-proposal | `.agents/skills/inno-grant-proposal/SKILL.md` | Help professors and researchers write, revise, adapt, and polish grant proposals for US agencies (NSF, NIH, DOE, DARP... |
+| inno-humanizer | `.agents/skills/inno-humanizer/SKILL.md` | Remove signs of AI-generated writing from text. Use when editing or reviewing text to make it sound more natural and ... |
+| inno-idea-eval | `.agents/skills/inno-idea-eval/SKILL.md` | Multi-persona idea evaluation with quality gate. Evaluates ideas across 5 InnoEval dimensions (Clarity, Novelty, Vali... |
+| inno-idea-generation | `.agents/skills/inno-idea-generation/SKILL.md` | Facilitates structured brainstorming sessions, conducts comprehensive research, and generates creative solutions usin... |
+| inno-paper-reviewer | `.agents/skills/inno-paper-reviewer/SKILL.md` | Structured manuscript/grant review with checklist-based evaluation. Use when writing formal peer reviews with specifi... |
+| inno-paper-writing | `.agents/skills/inno-paper-writing/SKILL.md` | Creates formal academic research papers following IEEE/ACM formatting standards with proper structure, citations, and... |
+| managing-obsidian-notes | `skills/managing-obsidian-notes/SKILL.md` | Obsidian vault CRUD via CLI. Vault bootstrap (PARA structure), per-project scaffolding, templates. Pops open notes in Obsidian after create/update. |
+| inno-pipeline-planner | `.agents/skills/inno-pipeline-planner/SKILL.md` | Guides the user through an interactive conversation to define their research project, then generates research_brief.j... |
+| inno-prepare-resources | `.agents/skills/inno-prepare-resources/SKILL.md` | Loads the evaluation instance, searches GitHub for related repositories, builds a dataset description, queries the Pr... |
+| inno-rclone-to-overleaf | `.agents/skills/inno-rclone-to-overleaf/SKILL.md` | Access Overleaf projects via CLI. Use for reading/writing LaTeX files, syncing local .tex files to Overleaf, download... |
+| inno-rebuttal | `.agents/skills/inno-rebuttal/SKILL.md` | Drafting and refining academic rebuttals for top-tier AI/CS conferences (NeurIPS, ICML, ICLR, CVPR, ECCV, AAAI, ARR, ... |
+| inno-reference-audit | `.agents/skills/inno-reference-audit/SKILL.md` | This skill provides reference guidance for citation verification in academic writing. Use when the user asks about "c... |
+
+## Library Skills
+
+| Skill | Path | Description |
+|-------|------|-------------|
+| ml-paper-writing | `.agents/skills/library/20-ml-paper-writing/SKILL.md` | Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research... |
+| academic-researcher | `.agents/skills/library/academic-researcher/SKILL.md` | Academic research assistant for literature reviews, paper analysis, and scholarly writing. Use when: reviewing academ... |
+| huggingface-accelerate | `.agents/skills/library/accelerate/SKILL.md` | Simplest distributed training API. 4 lines to add distributed support to any PyTorch script. Unified API for DeepSpee... |
+| huggingface-accelerate | `.agents/skills/library/accelerate/SKILL.md` | Simplest distributed training API. 4 lines to add distributed support to any PyTorch script. Unified API for DeepSpee... |
+| adding-leetcode-templates | `.agents/skills/library/adding-leetcode-templates/SKILL.md` | Add algorithm/data structure template code to the leetcode-template Anki deck with proper HTML formatting. Use this s... |
+| ai-reference-audit | `.agents/skills/library/ai-reference-audit/SKILL.md` | Run strong reference audits for AI research papers and repos. Use when asked to check LaTeX/BibTeX citations for miss... |
+| audiocraft-audio-generation | `.agents/skills/library/audiocraft/SKILL.md` | PyTorch library for audio generation including text-to-music (MusicGen) and text-to-sound (AudioGen). Use when you ne... |
+| audiocraft-audio-generation | `.agents/skills/library/audiocraft/SKILL.md` | PyTorch library for audio generation including text-to-music (MusicGen) and text-to-sound (AudioGen). Use when you ne... |
+| autogpt-agents | `.agents/skills/library/autogpt/SKILL.md` | Autonomous AI agent platform for building and deploying continuous agents. Use when creating visual workflow agents, ... |
+| autogpt-agents | `.agents/skills/library/autogpt/SKILL.md` | Autonomous AI agent platform for building and deploying continuous agents. Use when creating visual workflow agents, ... |
+| awq-quantization | `.agents/skills/library/awq/SKILL.md` | Activation-aware weight quantization for 4-bit LLM compression with 3x speedup and minimal accuracy loss. Use when de... |
+| awq-quantization | `.agents/skills/library/awq/SKILL.md` | Activation-aware weight quantization for 4-bit LLM compression with 3x speedup and minimal accuracy loss. Use when de... |
+| axolotl | `.agents/skills/library/axolotl/SKILL.md` | Expert guidance for fine-tuning LLMs with Axolotl - YAML configs, 100+ models, LoRA/QLoRA, DPO/KTO/ORPO/GRPO, multimo... |
+| axolotl | `.agents/skills/library/axolotl/SKILL.md` | Expert guidance for fine-tuning LLMs with Axolotl - YAML configs, 100+ models, LoRA/QLoRA, DPO/KTO/ORPO/GRPO, multimo... |
+| batch-condensing-arxiv-papers | `.agents/skills/library/batch-condensing-arxiv-papers/SKILL.md` | Downloads and condenses multiple arXiv papers to their essential LaTeX content. Use when the user requests to "downlo... |
+| evaluating-code-models | `.agents/skills/library/bigcode-evaluation-harness/SKILL.md` | Evaluates code generation models across HumanEval, MBPP, MultiPL-E, and 15+ benchmarks with pass@k metrics. Use when ... |
+| evaluating-code-models | `.agents/skills/library/bigcode-evaluation-harness/SKILL.md` | Evaluates code generation models across HumanEval, MBPP, MultiPL-E, and 15+ benchmarks with pass@k metrics. Use when ... |
+| biorxiv-database | `.agents/skills/library/biorxiv-database/SKILL.md` | Efficient database search tool for bioRxiv preprint server. Use this skill when searching for life sciences preprints... |
+| quantizing-models-bitsandbytes | `.agents/skills/library/bitsandbytes/SKILL.md` | Quantizes LLMs to 8-bit or 4-bit for 50-75% memory reduction with minimal accuracy loss. Use when GPU memory is limit... |
+| quantizing-models-bitsandbytes | `.agents/skills/library/bitsandbytes/SKILL.md` | Quantizes LLMs to 8-bit or 4-bit for 50-75% memory reduction with minimal accuracy loss. Use when GPU memory is limit... |
+| blip-2-vision-language | `.agents/skills/library/blip-2/SKILL.md` | Vision-language pre-training framework bridging frozen image encoders and LLMs. Use when you need image captioning, v... |
+| blip-2-vision-language | `.agents/skills/library/blip-2/SKILL.md` | Vision-language pre-training framework bridging frozen image encoders and LLMs. Use when you need image captioning, v... |
+| brainstorming-research-ideas | `.agents/skills/library/brainstorming-research-ideas/SKILL.md` | Guides researchers through structured ideation frameworks to discover high-impact research directions. Use when explo... |
+| chroma | `.agents/skills/library/chroma/SKILL.md` | Open-source embedding database for AI applications. Store embeddings and metadata, perform vector and full-text searc... |
+| chroma | `.agents/skills/library/chroma/SKILL.md` | Open-source embedding database for AI applications. Store embeddings and metadata, perform vector and full-text searc... |
+| clip | `.agents/skills/library/clip/SKILL.md` | OpenAI's model connecting vision and language. Enables zero-shot image classification, image-text matching, and cross... |
+| clip | `.agents/skills/library/clip/SKILL.md` | OpenAI's model connecting vision and language. Enables zero-shot image classification, image-text matching, and cross... |
+| constitutional-ai | `.agents/skills/library/constitutional-ai/SKILL.md` | Anthropic's method for training harmless AI through self-improvement. Two-phase approach - supervised learning with s... |
+| constitutional-ai | `.agents/skills/library/constitutional-ai/SKILL.md` | Anthropic's method for training harmless AI through self-improvement. Two-phase approach - supervised learning with s... |
+| converting-pptx-to-images | `.agents/skills/library/converting-pptx-to-images/SKILL.md` | Convert a PPTX file into a folder of per-slide PNG images using LibreOffice and pdftoppm. Use when the user asks to "... |
+| creative-thinking-for-research | `.agents/skills/library/creative-thinking-for-research/SKILL.md` | Applies cognitive science frameworks for creative thinking to CS and AI research ideation. Use when seeking genuinely... |
+| crewai-multi-agent | `.agents/skills/library/crewai/SKILL.md` | Multi-agent orchestration framework for autonomous AI collaboration. Use when building teams of specialized agents wo... |
+| crewai-multi-agent | `.agents/skills/library/crewai/SKILL.md` | Multi-agent orchestration framework for autonomous AI collaboration. Use when building teams of specialized agents wo... |
+| cross-machine-sync | `.agents/skills/library/cross-machine-sync/SKILL.md` | Sync and push files, text, and clipboard between MacBook Pro and Mac Mini over Tailscale SSH. Use when user asks to "... |
+| deepspeed | `.agents/skills/library/deepspeed/SKILL.md` | Expert guidance for distributed training with DeepSpeed - ZeRO optimization stages, pipeline parallelism, FP16/BF16/F... |
+| deepspeed | `.agents/skills/library/deepspeed/SKILL.md` | Expert guidance for distributed training with DeepSpeed - ZeRO optimization stages, pipeline parallelism, FP16/BF16/F... |
+| dspy | `.agents/skills/library/dspy/SKILL.md` | Build complex AI systems with declarative programming, optimize prompts automatically, create modular RAG systems and... |
+| dspy | `.agents/skills/library/dspy/SKILL.md` | Build complex AI systems with declarative programming, optimize prompts automatically, create modular RAG systems and... |
+| excalidraw | `.agents/skills/library/excalidraw/SKILL.md` | Create and edit Excalidraw diagrams programmatically. Use when the user asks to create diagrams, flowcharts, architec... |
+| experimental-rigor-audit | `.agents/skills/library/experimental-rigor-audit/SKILL.md` | Audit experiments and writeups for scientific rigor, reasoning transparency, and common pitfalls. Use when reviewing ... |
+| faiss | `.agents/skills/library/faiss/SKILL.md` | Facebook's library for efficient similarity search and clustering of dense vectors. Supports billions of vectors, GPU... |
+| faiss | `.agents/skills/library/faiss/SKILL.md` | Facebook's library for efficient similarity search and clustering of dense vectors. Supports billions of vectors, GPU... |
+| optimizing-attention-flash | `.agents/skills/library/flash-attention/SKILL.md` | Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction. Use when training/... |
+| optimizing-attention-flash | `.agents/skills/library/flash-attention/SKILL.md` | Optimizes transformer attention with Flash Attention for 2-4x speedup and 10-20x memory reduction. Use when training/... |
+| gemini-deep-research | `.agents/skills/library/gemini-deep-research/SKILL.md` | Perform deep, multi-source research using Google Gemini's Deep Research Agent. Use this skill whenever the user asks ... |
+| gguf-quantization | `.agents/skills/library/gguf/SKILL.md` | GGUF format and llama.cpp quantization for efficient CPU/GPU inference. Use when deploying models on consumer hardwar... |
+| gguf-quantization | `.agents/skills/library/gguf/SKILL.md` | GGUF format and llama.cpp quantization for efficient CPU/GPU inference. Use when deploying models on consumer hardwar... |
+| gptq | `.agents/skills/library/gptq/SKILL.md` | Post-training 4-bit quantization for LLMs with minimal accuracy loss. Use for deploying large models (70B, 405B) on c... |
+| gptq | `.agents/skills/library/gptq/SKILL.md` | Post-training 4-bit quantization for LLMs with minimal accuracy loss. Use for deploying large models (70B, 405B) on c... |
+| grpo-rl-training | `.agents/skills/library/grpo-rl-training/SKILL.md` | Expert guidance for GRPO/RL fine-tuning with TRL for reasoning and task-specific model training |
+| grpo-rl-training | `.agents/skills/library/grpo-rl-training/SKILL.md` | Expert guidance for GRPO/RL fine-tuning with TRL for reasoning and task-specific model training |
+| guidance | `.agents/skills/library/guidance/SKILL.md` | Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and... |
+| guidance | `.agents/skills/library/guidance/SKILL.md` | Control LLM output with regex and grammars, guarantee valid JSON/XML/code generation, enforce structured formats, and... |
+| hqq-quantization | `.agents/skills/library/hqq/SKILL.md` | Half-Quadratic Quantization for LLMs without calibration data. Use when quantizing models to 4/3/2-bit precision with... |
+| hqq-quantization | `.agents/skills/library/hqq/SKILL.md` | Half-Quadratic Quantization for LLMs without calibration data. Use when quantizing models to 4/3/2-bit precision with... |
+| huggingface-tokenizers | `.agents/skills/library/huggingface-tokenizers/SKILL.md` | Fast tokenizers optimized for research and production. Rust-based implementation tokenizes 1GB in <20 seconds. Suppor... |
+| huggingface-tokenizers | `.agents/skills/library/huggingface-tokenizers/SKILL.md` | Fast tokenizers optimized for research and production. Rust-based implementation tokenizes 1GB in <20 seconds. Suppor... |
+| instructor | `.agents/skills/library/instructor/SKILL.md` | Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse co... |
+| instructor | `.agents/skills/library/instructor/SKILL.md` | Extract structured data from LLM responses with Pydantic validation, retry failed extractions automatically, parse co... |
+| invoking-codex | `.agents/skills/library/invoking-codex/SKILL.md` | Invoke Codex CLI as a subagent to perform tasks and return results. Use when you want a second opinion, need Codex's ... |
+| invoking-gemini | `.agents/skills/library/invoking-gemini/SKILL.md` | Invoke Gemini CLI as a subagent to perform tasks and return results. Use when you want a second opinion from Gemini, ... |
+| json-canvas | `.agents/skills/library/json-canvas/SKILL.md` | Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and connections. Use when working with .canvas... |
+| knowledge-distillation | `.agents/skills/library/knowledge-distillation/SKILL.md` | Compress large language models using knowledge distillation from teacher to student models. Use when deploying smalle... |
+| knowledge-distillation | `.agents/skills/library/knowledge-distillation/SKILL.md` | Compress large language models using knowledge distillation from teacher to student models. Use when deploying smalle... |
+| lambda-labs-gpu-cloud | `.agents/skills/library/lambda-labs/SKILL.md` | Reserved and on-demand GPU cloud instances for ML training and inference. Use when you need dedicated GPU instances w... |
+| lambda-labs-gpu-cloud | `.agents/skills/library/lambda-labs/SKILL.md` | Reserved and on-demand GPU cloud instances for ML training and inference. Use when you need dedicated GPU instances w... |
+| langchain | `.agents/skills/library/langchain/SKILL.md` | Framework for building LLM-powered applications with agents, chains, and RAG. Supports multiple providers (OpenAI, An... |
+| langchain | `.agents/skills/library/langchain/SKILL.md` | Framework for building LLM-powered applications with agents, chains, and RAG. Supports multiple providers (OpenAI, An... |
+| langsmith-observability | `.agents/skills/library/langsmith/SKILL.md` | LLM observability platform for tracing, evaluation, and monitoring. Use when debugging LLM applications, evaluating m... |
+| langsmith-observability | `.agents/skills/library/langsmith/SKILL.md` | LLM observability platform for tracing, evaluation, and monitoring. Use when debugging LLM applications, evaluating m... |
+| lehigh-aisp-gpu | `.agents/skills/library/lehigh-aisp-gpu/SKILL.md` | Connect to Lehigh AISP GPU server (aisp.cse.lehigh.edu) as yila22 with key ~/.ssh/id_rsa_unify, and quickly browse co... |
+| implementing-llms-litgpt | `.agents/skills/library/litgpt/SKILL.md` | Implements and trains LLMs using Lightning AI's LitGPT with 20+ pretrained architectures (Llama, Gemma, Phi, Qwen, Mi... |
+| implementing-llms-litgpt | `.agents/skills/library/litgpt/SKILL.md` | Implements and trains LLMs using Lightning AI's LitGPT with 20+ pretrained architectures (Llama, Gemma, Phi, Qwen, Mi... |
+| llama-cpp | `.agents/skills/library/llama-cpp/SKILL.md` | Runs LLM inference on CPU, Apple Silicon, and consumer GPUs without NVIDIA hardware. Use for edge deployment, M1/M2/M... |
+| llama-cpp | `.agents/skills/library/llama-cpp/SKILL.md` | Runs LLM inference on CPU, Apple Silicon, and consumer GPUs without NVIDIA hardware. Use for edge deployment, M1/M2/M... |
+| llama-factory | `.agents/skills/library/llama-factory/SKILL.md` | Expert guidance for fine-tuning LLMs with LLaMA-Factory - WebUI no-code, 100+ models, 2/3/4/5/6/8-bit QLoRA, multimod... |
+| llama-factory | `.agents/skills/library/llama-factory/SKILL.md` | Expert guidance for fine-tuning LLMs with LLaMA-Factory - WebUI no-code, 100+ models, 2/3/4/5/6/8-bit QLoRA, multimod... |
+| llamaguard | `.agents/skills/library/llamaguard/SKILL.md` | Meta's 7-8B specialized moderation model for LLM input/output filtering. 6 safety categories - violence/hate, sexual ... |
+| llamaguard | `.agents/skills/library/llamaguard/SKILL.md` | Meta's 7-8B specialized moderation model for LLM input/output filtering. 6 safety categories - violence/hate, sexual ... |
+| llamaindex | `.agents/skills/library/llamaindex/SKILL.md` | Data framework for building LLM applications with RAG. Specializes in document ingestion (300+ connectors), indexing,... |
+| llamaindex | `.agents/skills/library/llamaindex/SKILL.md` | Data framework for building LLM applications with RAG. Specializes in document ingestion (300+ connectors), indexing,... |
+| llava | `.agents/skills/library/llava/SKILL.md` | Large Language and Vision Assistant. Enables visual instruction tuning and image-based conversations. Combines CLIP v... |
+| llava | `.agents/skills/library/llava/SKILL.md` | Large Language and Vision Assistant. Enables visual instruction tuning and image-based conversations. Combines CLIP v... |
+| evaluating-llms-harness | `.agents/skills/library/lm-evaluation-harness/SKILL.md` | Evaluates LLMs across 60+ academic benchmarks (MMLU, HumanEval, GSM8K, TruthfulQA, HellaSwag). Use when benchmarking ... |
+| evaluating-llms-harness | `.agents/skills/library/lm-evaluation-harness/SKILL.md` | Evaluates LLMs across 60+ academic benchmarks (MMLU, HumanEval, GSM8K, TruthfulQA, HellaSwag). Use when benchmarking ... |
+| long-context | `.agents/skills/library/long-context/SKILL.md` | Extend context windows of transformer models using RoPE, YaRN, ALiBi, and position interpolation techniques. Use when... |
+| long-context | `.agents/skills/library/long-context/SKILL.md` | Extend context windows of transformer models using RoPE, YaRN, ALiBi, and position interpolation techniques. Use when... |
+| mac-mini-ssh | `.agents/skills/library/mac-mini-ssh/SKILL.md` | Connect to Mac Mini via SSH over Tailscale. Use for running commands remotely, syncing files between MacBook Pro and ... |
+| macbook-ssh | `.agents/skills/library/macbook-ssh/SKILL.md` | Connect to MacBook Pro via SSH over Tailscale. Use for running commands remotely, syncing files between Mac Mini and ... |
+| making-academic-presentations | `.agents/skills/library/making-academic-presentations/SKILL.md` | Create academic presentation slide decks and optionally demo videos from research papers. Use when the user asks to "... |
+| making-nsf-pose-insight-slides | `.agents/skills/library/making-nsf-pose-insight-slides/SKILL.md` | Create NSF-POSE insight slides as a PPTX. Use when the user asks for "NSF-POSE slides", "POSE insight PPTX", "insight... |
+| making-skills | `.agents/skills/library/making-skills/SKILL.md` | Build new Claude Skills following best practices. Use this skill when the user asks to "create a skill", "make a new ... |
+| mamba-architecture | `.agents/skills/library/mamba/SKILL.md` | State-space model with O(n) complexity vs Transformers' O(n²). 5× faster inference, million-token sequences, no KV ca... |
+| mamba-architecture | `.agents/skills/library/mamba/SKILL.md` | State-space model with O(n) complexity vs Transformers' O(n²). 5× faster inference, million-token sequences, no KV ca... |
+| managing-calendar-events | `.agents/skills/library/managing-calendar-events/SKILL.md` | Manage Google Calendar events using gcalcli. Use this skill when the user asks to "create a calendar event", "add eve... |
+| managing-cli-wrapper-apis | `.agents/skills/library/managing-cli-wrapper-apis/SKILL.md` | Set up and reuse local OpenAI-compatible API servers that wrap Codex CLI or Claude Code. Use this when asked to copy ... |
+| managing-github-repos | `.agents/skills/library/managing-github-repos/SKILL.md` | Manage GitHub repositories using the gh CLI. Use this skill when the user asks to "create a repo", "clone a repo", "l... |
+| managing-obsidian-notes | `.agents/skills/library/managing-obsidian-notes/SKILL.md` | CRUD operations for Obsidian vault notes. Use when asked to "create a note", "add a folder", "update notes", "organiz... |
+| managing-omnifocus-tasks | `.agents/skills/library/managing-omnifocus-tasks/SKILL.md` | Manage OmniFocus tasks using AppleScript/osascript. Use this skill when the user asks to "add task to OmniFocus", "cr... |
+| managing-python-packages | `.agents/skills/library/managing-python-packages/SKILL.md` | Manage Python package installations using uv (ultra-fast Python package installer). Use this skill when the user asks... |
+| managing-uf-gpu | `.agents/skills/library/managing-uf-gpu/SKILL.md` |  |
+| training-llms-megatron | `.agents/skills/library/megatron-core/SKILL.md` | Trains large language models (2B-462B parameters) using NVIDIA Megatron-Core with advanced parallelism strategies. Us... |
+| training-llms-megatron | `.agents/skills/library/megatron-core/SKILL.md` | Trains large language models (2B-462B parameters) using NVIDIA Megatron-Core with advanced parallelism strategies. Us... |
+| miles-rl-training | `.agents/skills/library/miles/SKILL.md` | Provides guidance for enterprise-grade RL training using miles, a production-ready fork of slime. Use when training l... |
+| miles-rl-training | `.agents/skills/library/miles/SKILL.md` | Provides guidance for enterprise-grade RL training using miles, a production-ready fork of slime. Use when training l... |
+| ml-paper-writing | `.agents/skills/library/ml-paper-writing/SKILL.md` | Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research... |
+| mlflow | `.agents/skills/library/mlflow/SKILL.md` | Track ML experiments, manage model registry with versioning, deploy models to production, and reproduce experiments w... |
+| mlflow | `.agents/skills/library/mlflow/SKILL.md` | Track ML experiments, manage model registry with versioning, deploy models to production, and reproduce experiments w... |
+| modal-serverless-gpu | `.agents/skills/library/modal/SKILL.md` | Serverless GPU cloud platform for running ML workloads. Use when you need on-demand GPU access without infrastructure... |
+| modal-serverless-gpu | `.agents/skills/library/modal/SKILL.md` | Serverless GPU cloud platform for running ML workloads. Use when you need on-demand GPU access without infrastructure... |
+| model-merging | `.agents/skills/library/model-merging/SKILL.md` | Merge multiple fine-tuned models using mergekit to combine capabilities without retraining. Use when creating special... |
+| model-merging | `.agents/skills/library/model-merging/SKILL.md` | Merge multiple fine-tuned models using mergekit to combine capabilities without retraining. Use when creating special... |
+| model-pruning | `.agents/skills/library/model-pruning/SKILL.md` | Reduce LLM size and accelerate inference using pruning techniques like Wanda and SparseGPT. Use when compressing mode... |
+| model-pruning | `.agents/skills/library/model-pruning/SKILL.md` | Reduce LLM size and accelerate inference using pruning techniques like Wanda and SparseGPT. Use when compressing mode... |
+| moe-training | `.agents/skills/library/moe-training/SKILL.md` | Train Mixture of Experts (MoE) models using DeepSpeed or HuggingFace. Use when training large-scale models with limit... |
+| moe-training | `.agents/skills/library/moe-training/SKILL.md` | Train Mixture of Experts (MoE) models using DeepSpeed or HuggingFace. Use when training large-scale models with limit... |
+| nano-banana | `.agents/skills/library/nano-banana/SKILL.md` | Render images from text prompts via PaperBanana (multi-agent academic figure pipeline) or Gemini CLI's nanobanana ext... |
+| nanobanana-prompt-architect | `.agents/skills/library/nanobanana-prompt-architect/SKILL.md` | Generate high-fidelity, math-accurate prompts for academic framework figures (ICML/NeurIPS style) and optionally rend... |
+| nanogpt | `.agents/skills/library/nanogpt/SKILL.md` | Educational GPT implementation in ~300 lines. Reproduces GPT-2 (124M) on OpenWebText. Clean, hackable code for learni... |
+| nanogpt | `.agents/skills/library/nanogpt/SKILL.md` | Educational GPT implementation in ~300 lines. Reproduces GPT-2 (124M) on OpenWebText. Clean, hackable code for learni... |
+| nemo-curator | `.agents/skills/library/nemo-curator/SKILL.md` | GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× fa... |
+| nemo-curator | `.agents/skills/library/nemo-curator/SKILL.md` | GPU-accelerated data curation for LLM training. Supports text/image/video/audio. Features fuzzy deduplication (16× fa... |
+| nemo-evaluator-sdk | `.agents/skills/library/nemo-evaluator/SKILL.md` | Evaluates LLMs across 100+ benchmarks from 18+ harnesses (MMLU, HumanEval, GSM8K, safety, VLM) with multi-backend exe... |
+| nemo-evaluator-sdk | `.agents/skills/library/nemo-evaluator/SKILL.md` | Evaluates LLMs across 100+ benchmarks from 18+ harnesses (MMLU, HumanEval, GSM8K, safety, VLM) with multi-backend exe... |
+| nemo-guardrails | `.agents/skills/library/nemo-guardrails/SKILL.md` | NVIDIA's runtime safety framework for LLM applications. Features jailbreak detection, input/output validation, fact-c... |
+| nemo-guardrails | `.agents/skills/library/nemo-guardrails/SKILL.md` | NVIDIA's runtime safety framework for LLM applications. Features jailbreak detection, input/output validation, fact-c... |
+| nnsight-remote-interpretability | `.agents/skills/library/nnsight/SKILL.md` | Provides guidance for interpreting and manipulating neural network internals using nnsight with optional NDIF remote ... |
+| nnsight-remote-interpretability | `.agents/skills/library/nnsight/SKILL.md` | Provides guidance for interpreting and manipulating neural network internals using nnsight with optional NDIF remote ... |
+| obsidian-bases | `.agents/skills/library/obsidian-bases/SKILL.md` | Create and edit Obsidian Bases (.base files) with views, filters, formulas, and summaries. Use when working with .bas... |
+| obsidian-markdown | `.agents/skills/library/obsidian-markdown/SKILL.md` | Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts, properties, and other Obsidian-specific ... |
+| openrlhf-training | `.agents/skills/library/openrlhf/SKILL.md` | High-performance RLHF framework with Ray+vLLM acceleration. Use for PPO, GRPO, RLOO, DPO training of large models (7B... |
+| openrlhf-training | `.agents/skills/library/openrlhf/SKILL.md` | High-performance RLHF framework with Ray+vLLM acceleration. Use for PPO, GRPO, RLOO, DPO training of large models (7B... |
+| outlines | `.agents/skills/library/outlines/SKILL.md` | Guarantee valid JSON/XML/code structure during generation, use Pydantic models for type-safe outputs, support local m... |
+| outlines | `.agents/skills/library/outlines/SKILL.md` | Guarantee valid JSON/XML/code structure during generation, use Pydantic models for type-safe outputs, support local m... |
+| paper-analyzer | `.agents/skills/library/paper-analyzer/SKILL.md` | Deep analysis of a single paper — generate structured notes with figures, evaluation, and knowledge graph updates |
+| paper-finder | `.agents/skills/library/paper-finder/SKILL.md` | Search existing paper notes by title, author, keyword, or research domain |
+| paper-image-extractor | `.agents/skills/library/paper-image-extractor/SKILL.md` | Extract figures from papers — prioritizes arXiv source package for high-quality images |
+| peft-fine-tuning | `.agents/skills/library/peft/SKILL.md` | Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Use when fine-tuning large models (7B-70... |
+| peft-fine-tuning | `.agents/skills/library/peft/SKILL.md` | Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Use when fine-tuning large models (7B-70... |
+| phoenix-observability | `.agents/skills/library/phoenix/SKILL.md` | Open-source AI observability platform for LLM tracing, evaluation, and monitoring. Use when debugging LLM application... |
+| phoenix-observability | `.agents/skills/library/phoenix/SKILL.md` | Open-source AI observability platform for LLM tracing, evaluation, and monitoring. Use when debugging LLM application... |
+| pinecone | `.agents/skills/library/pinecone/SKILL.md` | Managed vector database for production AI applications. Fully managed, auto-scaling, with hybrid search (dense + spar... |
+| pinecone | `.agents/skills/library/pinecone/SKILL.md` | Managed vector database for production AI applications. Fully managed, auto-scaling, with hybrid search (dense + spar... |
+| pose-interview-logging | `.agents/skills/library/pose-interview-logging/SKILL.md` | Log POSE program interviews into the Innovation Within discovery platform using Playwright automation. Creates interv... |
+| pose-schedule | `.agents/skills/library/pose-schedule/SKILL.md` | Add POSE program tasks to OmniFocus and Google Calendar, and create session calendar invitations with Zoom links and ... |
+| processing-forum-posts | `.agents/skills/library/processing-forum-posts/SKILL.md` | Process and clean forum posts from 一亩三分地 (1point3acres) for interview preparation. Use this skill when the user asks ... |
+| processing-gemini-talks | `.agents/skills/library/processing-gemini-talks/SKILL.md` | Split Gemini conversation exports into individual knowledge notes and place them in the Obsidian vault. Use when the ... |
+| prompt-guard | `.agents/skills/library/prompt-guard/SKILL.md` | Meta's 86M prompt injection and jailbreak detector. Filters malicious prompts and third-party data for LLM apps. 99%+... |
+| prompt-guard | `.agents/skills/library/prompt-guard/SKILL.md` | Meta's 86M prompt injection and jailbreak detector. Filters malicious prompts and third-party data for LLM apps. 99%+... |
+| pytorch-fsdp2 | `.agents/skills/library/pytorch-fsdp2/SKILL.md` | Adds PyTorch FSDP2 (fully_shard) to training scripts with correct init, sharding, mixed precision/offload config, and... |
+| pytorch-fsdp2 | `.agents/skills/library/pytorch-fsdp2/SKILL.md` | Adds PyTorch FSDP2 (fully_shard) to training scripts with correct init, sharding, mixed precision/offload config, and... |
+| pytorch-lightning | `.agents/skills/library/pytorch-lightning/SKILL.md` | High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks syste... |
+| pytorch-lightning | `.agents/skills/library/pytorch-lightning/SKILL.md` | High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks syste... |
+| pyvene-interventions | `.agents/skills/library/pyvene/SKILL.md` | Provides guidance for performing causal interventions on PyTorch models using pyvene's declarative intervention frame... |
+| pyvene-interventions | `.agents/skills/library/pyvene/SKILL.md` | Provides guidance for performing causal interventions on PyTorch models using pyvene's declarative intervention frame... |
+| qdrant-vector-search | `.agents/skills/library/qdrant/SKILL.md` | High-performance vector similarity search engine for RAG and semantic search. Use when building production RAG system... |
+| qdrant-vector-search | `.agents/skills/library/qdrant/SKILL.md` | High-performance vector similarity search engine for RAG and semantic search. Use when building production RAG system... |
+| ray-data | `.agents/skills/library/ray-data/SKILL.md` | Scalable data processing for ML workloads. Streaming execution across CPU/GPU, supports Parquet/CSV/JSON/images. Inte... |
+| ray-data | `.agents/skills/library/ray-data/SKILL.md` | Scalable data processing for ML workloads. Streaming execution across CPU/GPU, supports Parquet/CSV/JSON/images. Inte... |
+| ray-train | `.agents/skills/library/ray-train/SKILL.md` | Distributed training orchestration across clusters. Scales PyTorch/TensorFlow/HuggingFace from laptop to 1000s of nod... |
+| ray-train | `.agents/skills/library/ray-train/SKILL.md` | Distributed training orchestration across clusters. Scales PyTorch/TensorFlow/HuggingFace from laptop to 1000s of nod... |
+| research-landscape-assessment | `.agents/skills/library/research-landscape-assessment/SKILL.md` | Assess the research landscape for a given topic: quantify hotness/saturation, identify sub-directions, find key paper... |
+| research-news | `.agents/skills/library/research-news/SKILL.md` | Daily paper recommendation workflow — search arXiv and Semantic Scholar, score and recommend papers |
+| rwkv-architecture | `.agents/skills/library/rwkv/SKILL.md` | RNN+Transformer hybrid with O(n) inference. Linear time, infinite context, no KV cache. Train like GPT (parallel), in... |
+| rwkv-architecture | `.agents/skills/library/rwkv/SKILL.md` | RNN+Transformer hybrid with O(n) inference. Linear time, infinite context, no KV cache. Train like GPT (parallel), in... |
+| sparse-autoencoder-training | `.agents/skills/library/saelens/SKILL.md` | Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network act... |
+| sparse-autoencoder-training | `.agents/skills/library/saelens/SKILL.md` | Provides guidance for training and analyzing Sparse Autoencoders (SAEs) using SAELens to decompose neural network act... |
+| scientific-writing | `.agents/skills/library/scientific-writing/SKILL.md` | Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet poin... |
+| searching-agent-sessions | `.agents/skills/library/searching-agent-sessions/SKILL.md` | Search and browse past coding agent sessions (Claude Code, Codex, Gemini) via CASS CLI. Use when the user asks to "fi... |
+| searching-ai-papers | `.agents/skills/library/searching-ai-papers/SKILL.md` | Search general-domain AI/ML papers across arXiv, Semantic Scholar, OpenAlex, OpenReview, ICLR accepted papers (OpenRe... |
+| searching-local-papers | `.agents/skills/library/searching-local-papers/SKILL.md` | Search the local corpus of 115K+ AI/ML research papers (79% with abstracts, 84% for 2025+ papers) using a precomputed... |
+| searching-rednote-posts | `.agents/skills/library/searching-rednote-posts/SKILL.md` | Search Xiaohongshu (小红书/RedNote) posts using Playwright MCP browser automation. Use when the user asks to "search Red... |
+| segment-anything-model | `.agents/skills/library/segment-anything/SKILL.md` | Foundation model for image segmentation with zero-shot transfer. Use when you need to segment any object in images us... |
+| segment-anything-model | `.agents/skills/library/segment-anything/SKILL.md` | Foundation model for image segmentation with zero-shot transfer. Use when you need to segment any object in images us... |
+| sending-lehigh-emails | `.agents/skills/library/sending-lehigh-emails/SKILL.md` | Send emails using Lehigh University Gmail account (yila22@lehigh.edu) via Gmail MCP. Use this skill when the user ask... |
+| sentence-transformers | `.agents/skills/library/sentence-transformers/SKILL.md` | Framework for state-of-the-art sentence, text, and image embeddings. Provides 5000+ pre-trained models for semantic s... |
+| sentence-transformers | `.agents/skills/library/sentence-transformers/SKILL.md` | Framework for state-of-the-art sentence, text, and image embeddings. Provides 5000+ pre-trained models for semantic s... |
+| sentencepiece | `.agents/skills/library/sentencepiece/SKILL.md` | Language-independent tokenizer treating text as raw Unicode. Supports BPE and Unigram algorithms. Fast (50k sentences... |
+| sentencepiece | `.agents/skills/library/sentencepiece/SKILL.md` | Language-independent tokenizer treating text as raw Unicode. Supports BPE and Unigram algorithms. Fast (50k sentences... |
+| session-migrate | `.agents/skills/library/session-migrate/SKILL.md` | Migrate Claude Code sessions between MacBook Pro and Mac Mini over Tailscale SSH. Remaps user paths so sessions creat... |
+| sglang | `.agents/skills/library/sglang/SKILL.md` | Fast structured generation and serving for LLMs with RadixAttention prefix caching. Use for JSON/regex outputs, const... |
+| sglang | `.agents/skills/library/sglang/SKILL.md` | Fast structured generation and serving for LLMs with RadixAttention prefix caching. Use for JSON/regex outputs, const... |
+| simpo-training | `.agents/skills/library/simpo/SKILL.md` | Simple Preference Optimization for LLM alignment. Reference-free alternative to DPO with better performance (+6.4 poi... |
+| simpo-training | `.agents/skills/library/simpo/SKILL.md` | Simple Preference Optimization for LLM alignment. Reference-free alternative to DPO with better performance (+6.4 poi... |
+| skypilot-multi-cloud-orchestration | `.agents/skills/library/skypilot/SKILL.md` | Multi-cloud orchestration for ML workloads with automatic cost optimization. Use when you need to run training or bat... |
+| skypilot-multi-cloud-orchestration | `.agents/skills/library/skypilot/SKILL.md` | Multi-cloud orchestration for ML workloads with automatic cost optimization. Use when you need to run training or bat... |
+| slime-rl-training | `.agents/skills/library/slime/SKILL.md` | Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework. Use when training GLM model... |
+| slime-rl-training | `.agents/skills/library/slime/SKILL.md` | Provides guidance for LLM post-training with RL using slime, a Megatron+SGLang framework. Use when training GLM model... |
+| speculative-decoding | `.agents/skills/library/speculative-decoding/SKILL.md` | Accelerate LLM inference using speculative decoding, Medusa multiple heads, and lookahead decoding techniques. Use wh... |
+| speculative-decoding | `.agents/skills/library/speculative-decoding/SKILL.md` | Accelerate LLM inference using speculative decoding, Medusa multiple heads, and lookahead decoding techniques. Use wh... |
+| stable-diffusion-image-generation | `.agents/skills/library/stable-diffusion/SKILL.md` | State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers. Use when generating... |
+| stable-diffusion-image-generation | `.agents/skills/library/stable-diffusion/SKILL.md` | State-of-the-art text-to-image generation with Stable Diffusion models via HuggingFace Diffusers. Use when generating... |
+| syncing-overleaf-papers | `.agents/skills/library/syncing-overleaf-papers/SKILL.md` | Two-way file management between local and remote Dropbox/Overleaf via rclone. Use when the user asks to "sync to over... |
+| syncing-skill-hub | `.agents/skills/library/syncing-skill-hub/SKILL.md` | Check skill sync status and optionally back up to git. Use when the user asks to "sync skills", "save skills", "push ... |
+| tensorboard | `.agents/skills/library/tensorboard/SKILL.md` | Visualize training metrics, debug models with histograms, compare experiments, visualize model graphs, and profile pe... |
+| tensorboard | `.agents/skills/library/tensorboard/SKILL.md` | Visualize training metrics, debug models with histograms, compare experiments, visualize model graphs, and profile pe... |
+| tensorrt-llm | `.agents/skills/library/tensorrt-llm/SKILL.md` | Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency. Use for production deployment... |
+| tensorrt-llm | `.agents/skills/library/tensorrt-llm/SKILL.md` | Optimizes LLM inference with NVIDIA TensorRT for maximum throughput and lowest latency. Use for production deployment... |
+| toggling-mac-displays | `.agents/skills/library/toggling-mac-displays/SKILL.md` | Toggle physical monitors on/off for Mac Mini to enable virtual displays for remote desktop access. Use when asked to ... |
+| torchforge-rl-training | `.agents/skills/library/torchforge/SKILL.md` | Provides guidance for PyTorch-native agentic RL using torchforge, Meta's library separating infra from algorithms. Us... |
+| torchforge-rl-training | `.agents/skills/library/torchforge/SKILL.md` | Provides guidance for PyTorch-native agentic RL using torchforge, Meta's library separating infra from algorithms. Us... |
+| distributed-llm-pretraining-torchtitan | `.agents/skills/library/torchtitan/SKILL.md` | Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP). Use whe... |
+| distributed-llm-pretraining-torchtitan | `.agents/skills/library/torchtitan/SKILL.md` | Provides PyTorch-native distributed LLM pretraining using torchtitan with 4D parallelism (FSDP2, TP, PP, CP). Use whe... |
+| transformer-lens-interpretability | `.agents/skills/library/transformer-lens/SKILL.md` | Provides guidance for mechanistic interpretability research using TransformerLens to inspect and manipulate transform... |
+| transformer-lens-interpretability | `.agents/skills/library/transformer-lens/SKILL.md` | Provides guidance for mechanistic interpretability research using TransformerLens to inspect and manipulate transform... |
+| trending-research-scanner | `.agents/skills/library/trending-research-scanner/SKILL.md` | Iterative field radar — scan trending research papers across Semantic Scholar, OpenAlex, HF Daily Papers, and arXiv w... |
+| fine-tuning-with-trl | `.agents/skills/library/trl-fine-tuning/SKILL.md` | Fine-tune LLMs using reinforcement learning with TRL - SFT for instruction tuning, DPO for preference alignment, PPO/... |
+| fine-tuning-with-trl | `.agents/skills/library/trl-fine-tuning/SKILL.md` | Fine-tune LLMs using reinforcement learning with TRL - SFT for instruction tuning, DPO for preference alignment, PPO/... |
+| unsloth | `.agents/skills/library/unsloth/SKILL.md` | Expert guidance for fast fine-tuning with Unsloth - 2-5x faster training, 50-80% less memory, LoRA/QLoRA optimization |
+| unsloth | `.agents/skills/library/unsloth/SKILL.md` | Expert guidance for fast fine-tuning with Unsloth - 2-5x faster training, 50-80% less memory, LoRA/QLoRA optimization |
+| updating-leetcode-anki-cards | `.agents/skills/library/updating-leetcode-anki-cards/SKILL.md` | Transform LeetCode Anki flashcards from code-implementation-heavy format to semantic-reasoning-focused format followi... |
+| verl-rl-training | `.agents/skills/library/verl/SKILL.md` | Provides guidance for training LLMs with reinforcement learning using verl (Volcano Engine RL). Use when implementing... |
+| verl-rl-training | `.agents/skills/library/verl/SKILL.md` | Provides guidance for training LLMs with reinforcement learning using verl (Volcano Engine RL). Use when implementing... |
+| serving-llms-vllm | `.agents/skills/library/vllm/SKILL.md` | Serves LLMs with high throughput using vLLM's PagedAttention and continuous batching. Use when deploying production L... |
+| serving-llms-vllm | `.agents/skills/library/vllm/SKILL.md` | Serves LLMs with high throughput using vLLM's PagedAttention and continuous batching. Use when deploying production L... |
+| weights-and-biases | `.agents/skills/library/weights-and-biases/SKILL.md` | Track ML experiments with automatic logging, visualize training in real-time, optimize hyperparameters with sweeps, a... |
+| weights-and-biases | `.agents/skills/library/weights-and-biases/SKILL.md` | Track ML experiments with automatic logging, visualize training in real-time, optimize hyperparameters with sweeps, a... |
+| whisper | `.agents/skills/library/whisper/SKILL.md` | OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and ... |
+| whisper | `.agents/skills/library/whisper/SKILL.md` | OpenAI's general-purpose speech recognition model. Supports 99 languages, transcription, translation to English, and ... |
+| writing-experiment-reports | `.agents/skills/library/writing-experiment-reports/SKILL.md` | Generate comprehensive LaTeX experiment reports for machine learning ablation studies. Use when user requests "create... |
+| writing-standup-notes | `.agents/skills/library/writing-standup-notes/SKILL.md` | Create structured daily standup notes following the Yesterday/Today/Blockers format. Use this skill when the user ask... |

--- a/README.md
+++ b/README.md
@@ -824,7 +824,8 @@ The plugin is installed and will be available in future sessions. Run `/drclaw:s
 
 ### What's Included
 
-- **60+ bundled skills** — a curated subset of Dr. Claw's skill library covering literature survey, idea generation, experiment development, paper writing, and more
+- **60+ bundled skills** — a curated subset of Dr. Claw's skill library covering literature survey, idea generation, experiment development, paper writing, knowledge management, and more
+- **2 MCP servers** — `drclaw-papers` for multi-source paper search (arXiv, Semantic Scholar, OpenAlex, OpenReview, HF Daily) and `drclaw-notes` for Obsidian vault operations via CLI
 - **3 project templates** — Method/Model, Dataset/Benchmark, and Position Paper, each with a pre-configured task pipeline
 - **Auto-detection** — the plugin detects existing pipeline projects on session start and shows your current progress
 - **Same data format** — projects created with the plugin use the same `research_brief.json` and `tasks.json` schemas as the full Dr. Claw workspace, so you can switch between them

--- a/skills/README.md
+++ b/skills/README.md
@@ -55,6 +55,9 @@ skills/
 ├─ Promotion
 │  └─ making-academic-presentations         Slides, narration, TTS audio, and demo-video generation
 │
+├─ Knowledge Management
+│  └─ managing-obsidian-notes               Obsidian vault CRUD via CLI, vault bootstrap, project scaffolding
+│
 └─ Domain-Specific
    └─ bioinformatics-init-analysis          CyTOF / scRNA-seq / flow cytometry pipeline
 ```

--- a/skills/managing-obsidian-notes/CHANGELOG.md
+++ b/skills/managing-obsidian-notes/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## 2026-04-10 (v2.0)
+- **Rewritten for Obsidian CLI**: All operations now use `Obsidian` CLI instead of direct filesystem access
+- **Setup warmup**: Detects missing CLI, guides user through installation
+- **Vault discovery**: Auto-discovers vaults via `Obsidian vaults verbose` instead of hardcoding paths
+- **Open in Obsidian**: Always offers to pop open notes in a new tab after create/update
+- **iCloud sync guard**: `sleep 1` before opening notes after edits to prevent sync race
+- **No personal paths**: Removed all hardcoded vault paths — works with any user's vault
+- **Public-ready**: Suitable for bundling in dr-claw plugin
+
+## 2025-01-26 (v1.3)
+- **Fixed vault path**: Corrected to `iCloud~md~obsidian/Documents/kobo-note/`
+- **Added vault structure**: Documented all main folders (Career, Coding, Engineering, Research, Journal, etc.)
+- **Enhanced CREATE NOTE routing**: Added folder mappings for all content types
+
+## 2025-12-13 (v1.2)
+- **Chinese Headline Summary (总结)**: Content-rich subpages MUST start with `## 总结` in Chinese
+- Added to quality checklist
+
+## 2025-12-13 (v1.1)
+- **Index Page Philosophy**: Index pages = MINIMAL, Subpages = STRUCTURED
+- Index pages should be simple navigation hubs, easy to manually edit
+- All detailed content goes in subpages
+
+## 2025-12-13 (v1.0)
+- Initial release
+- CRUD operations for Obsidian vault notes
+- Folder-with-index pattern support
+- Obsidian syntax reference (wikilinks, callouts, tags, frontmatter)
+- Vault location: kobo-note in iCloud

--- a/skills/managing-obsidian-notes/SKILL.md
+++ b/skills/managing-obsidian-notes/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: managing-obsidian-notes
+description: >-
+  CRUD operations for Obsidian vault notes using the Obsidian CLI. Use when asked to "create a note",
+  "add a folder", "update notes", "organize notes", "save to obsidian", "open in obsidian", or manage
+  any Obsidian/markdown note structure. Handles folder-with-index-file pattern, wikilinks, tags,
+  frontmatter, and Obsidian-specific syntax. Requires Obsidian v1.8+ with CLI enabled.
+---
+
+# Managing Obsidian Notes — Execution Rules
+
+## Goal & Scope
+Perform Create, Read, Update, Delete operations on Obsidian vault notes using the Obsidian CLI,
+following consistent patterns and Obsidian best practices.
+
+## Audience & Tone
+Users with Obsidian vaults who want consistent note organization. Technical, concise.
+
+## Setup & Onboarding
+
+Follow these steps in order. Skip any step where the check already passes.
+
+### Step 1: Check if Obsidian App is Installed
+
+```bash
+ls /Applications/Obsidian.app 2>/dev/null && echo "APP_OK" || echo "APP_MISSING"
+```
+
+If `APP_MISSING`, guide the user:
+
+> **Obsidian is not installed.** Let's set it up:
+>
+> **macOS:**
+> ```bash
+> brew install --cask obsidian
+> ```
+> Or download from [obsidian.md/download](https://obsidian.md/download)
+>
+> **Linux:**
+> ```bash
+> # Snap
+> sudo snap install obsidian --classic
+> # Or AppImage from obsidian.md/download
+> ```
+>
+> **Windows:**
+> Download installer from [obsidian.md/download](https://obsidian.md/download)
+>
+> After installing, **open Obsidian once** to complete initial setup, then continue.
+
+### Step 2: Check CLI Availability
+
+```bash
+Obsidian version 2>/dev/null && echo "CLI_OK" || echo "CLI_MISSING"
+```
+
+If `CLI_MISSING` but app is installed:
+
+> **Obsidian CLI needs to be enabled:**
+>
+> 1. Open Obsidian
+> 2. Go to **Settings → General**
+> 3. Scroll down and enable **"Enable CLI"**
+> 4. **Restart Obsidian** (quit and reopen)
+> 5. Run `Obsidian version` to verify
+>
+> The CLI requires Obsidian v1.8+. If you don't see the option, update Obsidian first.
+
+**Important:** Obsidian must be running for the CLI to work. The CLI talks to the app process.
+
+### Step 3: Vault Discovery
+
+Check if the user has any vaults:
+
+```bash
+Obsidian vaults verbose
+```
+
+**If vaults exist:** Ask the user which one to use. Store the vault name for the session.
+
+**If no vaults exist:** Guide vault creation:
+
+> **No vaults found.** Let's create one:
+>
+> 1. Open Obsidian
+> 2. Click **"Create new vault"**
+> 3. Name it (e.g. "research", "notes", or your project name)
+> 4. Choose a location (default is fine, or pick a cloud-synced folder)
+> 5. Click **Create**
+>
+> Then run `Obsidian vaults verbose` again and tell me the vault name.
+
+**Store the vault name for the session** — don't ask again after the first command.
+
+### Step 4: Vault Structure Bootstrap
+
+After discovering the vault, check if it has structure:
+
+```bash
+Obsidian vault=<name> folders
+```
+
+If the vault is **empty or flat** (no folders, or only `.obsidian/` and `.trash/`), offer to
+bootstrap a research-friendly structure.
+
+> Your vault is empty. I can set up a starter structure designed for research and project work.
+> It follows a lightweight PARA-inspired layout:
+>
+> ```
+> <vault>/
+> ├── Home.md              ← Dashboard with quick links
+> ├── Projects/            ← Active research projects (one folder per project)
+> ├── Areas/               ← Ongoing responsibilities (teaching, advising, admin)
+> ├── Resources/           ← Reference material, learning notes, how-tos
+> │   ├── Papers/          ← Paper reading notes
+> │   └── Learning/        ← Tutorials, courses, concepts
+> ├── Archive/             ← Completed/inactive projects and notes
+> ├── Inbox/               ← Quick capture — sort later
+> ├── Templates/           ← Reusable note templates
+> └── Attachments/         ← Images, PDFs, media
+> ```
+>
+> Want me to create this?
+
+If the user agrees, create the scaffold:
+
+```bash
+# Home — vault dashboard
+Obsidian vault=<name> create name="Home" content="# Home\n\nDashboard for your research vault.\n\n## Navigation\n- [[Projects/Projects|Projects]] — active research\n- [[Areas/Areas|Areas]] — ongoing responsibilities\n- [[Resources/Resources|Resources]] — reference material\n- [[Inbox/Inbox|Inbox]] — quick capture\n- [[Archive/Archive|Archive]] — completed work\n\n## Recent Projects\n\n## Quick Notes\n" silent
+
+# Projects hub
+Obsidian vault=<name> create name="Projects" folder="Projects" content="# Projects\n\nOne folder per active research project.\n\n## Active\n\n## On Hold\n\n---\nSee [[Archive/Archive|Archive]] for completed projects.\n" silent
+
+# Areas hub
+Obsidian vault=<name> create name="Areas" folder="Areas" content="# Areas\n\nOngoing responsibilities with no end date.\n\n## Research\n\n## Teaching\n\n## Service\n" silent
+
+# Resources hub
+Obsidian vault=<name> create name="Resources" folder="Resources" content="# Resources\n\nReference material and learning notes.\n\n- [[Resources/Papers/Papers|Papers]] — reading notes\n- [[Resources/Learning/Learning|Learning]] — tutorials & concepts\n" silent
+
+# Papers subfolder
+Obsidian vault=<name> create name="Papers" folder="Resources/Papers" content="# Papers\n\nReading notes and paper summaries. One note per paper.\n\n## By Topic\n\n## Recent\n" silent
+
+# Learning subfolder
+Obsidian vault=<name> create name="Learning" folder="Resources/Learning" content="# Learning\n\nConcepts, tutorials, courses, and study notes.\n" silent
+
+# Archive
+Obsidian vault=<name> create name="Archive" folder="Archive" content="# Archive\n\nCompleted or paused projects and old notes.\nMove items here instead of deleting.\n" silent
+
+# Inbox
+Obsidian vault=<name> create name="Inbox" folder="Inbox" content="# Inbox\n\nQuick capture — review and sort weekly.\n" silent
+
+# Templates folder (empty index)
+Obsidian vault=<name> create name="Templates" folder="Templates" content="# Templates\n\nReusable note templates.\n" silent
+
+# Attachments folder marker
+Obsidian vault=<name> create name="Attachments" folder="Attachments" content="# Attachments\n\nImages, PDFs, and media files.\nSet this as the attachment folder in Settings → Files & Links.\n" silent
+```
+
+Then create starter templates:
+
+```bash
+# Project template
+Obsidian vault=<name> create name="Project Template" folder="Templates" content="# {{title}}\n\n> [!info] Created {{date}}\n\n## Goal\n\n## Pages\n- [[system-design]]\n- [[progress]]\n- [[key-links]]\n- [[experiment-log]]\n\n## Related Papers\n\n## Notes\n" silent
+
+# Paper note template
+Obsidian vault=<name> create name="Paper Template" folder="Templates" content="---\ntitle: \"{{title}}\"\nauthors: \"\"\nyear: \nvenue: \"\"\nurl: \"\"\ntags: [paper]\n---\n\n# {{title}}\n\n## Key Contributions\n\n## Method\n\n## Results\n\n## Relevance\n" silent
+
+# Meeting note template
+Obsidian vault=<name> create name="Meeting Template" folder="Templates" content="# Meeting: {{title}}\n\n**Date:** {{date}}\n**Attendees:**\n\n## Agenda\n\n## Notes\n\n## Action Items\n- [ ] \n" silent
+```
+
+Finally, open Home:
+```bash
+sleep 1 && Obsidian vault=<name> open newtab file="Home"
+```
+
+Tell the user:
+> Vault is ready! I set up a PARA-style structure:
+> - **Projects/** — create a subfolder for each research project
+> - **Resources/Papers/** — one note per paper you read
+> - **Inbox/** — quick capture, sort weekly
+> - **Templates/** — I added templates for projects, papers, and meetings
+>
+> Tip: In Obsidian Settings → Templates, set the template folder to `Templates/`.
+
+### Per-Project Folder Structure
+
+When the user starts a new research project, create a dedicated project folder:
+
+```bash
+# Project index (minimal — just links)
+Obsidian vault=<name> create name="<ProjectName>" folder="Projects/<ProjectName>" content="# <ProjectName>\n\n> [!info] Created YYYY-MM-DD\n\n## Pages\n- [[system-design]]\n- [[progress]]\n- [[key-links]]\n- [[experiment-log]]\n\n## Related Papers\n" silent
+
+# System design doc
+Obsidian vault=<name> create name="system-design" folder="Projects/<ProjectName>" content="# System Design\n\n## Architecture\n\n## Key Decisions\n" silent
+
+# Progress tracker
+Obsidian vault=<name> create name="progress" folder="Projects/<ProjectName>" content="# Progress\n\n## Timeline\n\n### YYYY-MM-DD\n- Project started\n" silent
+
+# Key links (repo, server, docs)
+Obsidian vault=<name> create name="key-links" folder="Projects/<ProjectName>" content="# Key Links\n\n| Resource | Link |\n|----------|------|\n| GitHub | |\n| Server | |\n| Paper | |\n| Data | |\n" silent
+
+# Experiment log
+Obsidian vault=<name> create name="experiment-log" folder="Projects/<ProjectName>" content="# Experiment Log\n\nAppend entries as experiments run.\n" silent
+```
+
+Set properties on the project index:
+```bash
+Obsidian vault=<name> property:set name="created" value="YYYY-MM-DD" file="<ProjectName>"
+Obsidian vault=<name> property:set name="status" value="active" file="<ProjectName>"
+Obsidian vault=<name> property:set name="tags" value="project" file="<ProjectName>"
+```
+
+Then add it to the Projects hub and open:
+```bash
+Obsidian vault=<name> append file="Projects" content="\n- [[Projects/<ProjectName>|<ProjectName>]]"
+sleep 1 && Obsidian vault=<name> open newtab file="<ProjectName>"
+```
+
+## CLI Command Reference
+
+All operations use the `Obsidian` binary (capital O on macOS). Commands follow:
+```bash
+Obsidian vault=<name> <command> [params...]
+```
+
+### CRUD Operations
+
+**Create:**
+```bash
+Obsidian vault=<name> create name="Note Title" content="# Note Title\n\nContent here" silent
+# With folder:
+Obsidian vault=<name> create name="Note Title" folder="Projects/Active" content="..." silent
+# Overwrite existing:
+Obsidian vault=<name> create name="Note Title" content="..." silent overwrite
+```
+
+**Read:**
+```bash
+# By wikilink name:
+Obsidian vault=<name> read file="Note Title"
+# By exact path:
+Obsidian vault=<name> read path="Projects/Active/plan.md"
+```
+
+**Append:**
+```bash
+Obsidian vault=<name> append file="Note Title" content="\n## New Section\nContent here"
+```
+
+**Search:**
+```bash
+Obsidian vault=<name> search query="search terms" limit=10
+# JSON output for programmatic use:
+Obsidian vault=<name> search query="search terms" format=json
+```
+
+**List files:**
+```bash
+Obsidian vault=<name> files folder="Projects"
+```
+
+**List folders:**
+```bash
+Obsidian vault=<name> folders folder="Projects"
+```
+
+### Opening Notes in Obsidian
+
+**ALWAYS use `newtab`** so the note opens in a new tab, not replacing the current one:
+
+```bash
+Obsidian vault=<name> open newtab file="Note Title"
+Obsidian vault=<name> open newtab path="Projects/Active/plan.md"
+```
+
+**After creating or editing a note, ALWAYS offer to open it:**
+```
+Created "Note Title". Open in Obsidian? (I'll pop it up in a new tab)
+```
+
+If the user says yes:
+```bash
+sleep 1 && Obsidian vault=<name> open newtab file="Note Title"
+```
+
+> **Why `sleep 1`?** If the vault is on iCloud/Dropbox, the file watcher can race with sync.
+> Without the delay, Obsidian may show the old cached version.
+
+### Properties (Frontmatter)
+
+```bash
+# Get all properties:
+Obsidian vault=<name> properties file="Note Title" format=json
+
+# Set a property:
+Obsidian vault=<name> property:set name="status" value="active" file="Note Title"
+```
+
+### Tags & Backlinks
+
+```bash
+# List all tags with counts:
+Obsidian vault=<name> tags format=json counts
+
+# Tags for a specific note:
+Obsidian vault=<name> tags file="Note Title" format=json
+
+# Backlinks (who links to this note):
+Obsidian vault=<name> backlinks file="Note Title" format=json
+```
+
+### Tasks
+
+```bash
+# List incomplete tasks:
+Obsidian vault=<name> tasks todo format=json
+
+# List completed tasks:
+Obsidian vault=<name> tasks done format=json
+
+# Toggle a task:
+Obsidian vault=<name> task file="Note Title" line=15 toggle
+```
+
+### Vault Info
+
+```bash
+Obsidian vault=<name> vault
+```
+
+## Core Patterns
+
+### Folder-with-Index Pattern
+When creating a topic that needs multiple sub-notes:
+```
+Topic Name/
+├── Topic Name.md      # Index file (same name as folder) - MINIMAL
+├── Subtopic 1.md      # Detailed content
+├── Subtopic 2.md      # Detailed content
+└── Resources/
+```
+
+### Index Page Philosophy
+> **Index pages = MINIMAL** | **Subpages = STRUCTURED**
+
+**Index pages:** Simple list of wikilinks to subpages — just navigation.
+**Subpages:** Detailed and well-organized — tables, callouts, checklists.
+
+### Single Note Pattern
+For standalone topics, just create a single `.md` file in the appropriate location.
+
+## Required Structure / Algorithm
+
+### CREATE NOTE
+1. Check CLI is available (run `Obsidian version`)
+2. If first time, discover vault (`Obsidian vaults verbose`)
+3. If vault is empty/unstructured, offer to bootstrap (see Vault Structure Bootstrap above)
+4. If user mentions a "project", use Per-Project Folder Structure to create the full scaffold
+5. Determine folder based on content type (ask user if unclear)
+4. Decide pattern: single note vs folder-with-index
+5. Create with CLI:
+   ```bash
+   Obsidian vault=<name> create name="Title" folder="Target/Folder" content="..." silent
+   ```
+6. Set frontmatter properties if needed:
+   ```bash
+   Obsidian vault=<name> property:set name="created" value="2026-04-10" file="Title"
+   Obsidian vault=<name> property:set name="tags" value="tag1, tag2" file="Title"
+   ```
+7. **Offer to open in Obsidian** — always ask, then:
+   ```bash
+   sleep 1 && Obsidian vault=<name> open newtab file="Title"
+   ```
+
+### READ/FIND NOTE
+1. Search by content:
+   ```bash
+   Obsidian vault=<name> search query="keyword" format=json limit=10
+   ```
+2. Read specific note:
+   ```bash
+   Obsidian vault=<name> read file="Note Title"
+   ```
+3. Browse folder:
+   ```bash
+   Obsidian vault=<name> files folder="Projects/Active"
+   ```
+
+### UPDATE NOTE
+1. Read existing content first:
+   ```bash
+   Obsidian vault=<name> read file="Note Title"
+   ```
+2. For appending:
+   ```bash
+   Obsidian vault=<name> append file="Note Title" content="\n## New Section\nContent"
+   ```
+3. For full rewrite:
+   ```bash
+   Obsidian vault=<name> create name="Note Title" content="..." silent overwrite
+   ```
+4. Update properties:
+   ```bash
+   Obsidian vault=<name> property:set name="modified" value="2026-04-10" file="Note Title"
+   ```
+
+### DELETE/ARCHIVE NOTE
+1. Prefer archiving over deletion — move to an archive folder
+2. For deletion, confirm with user first
+3. Use filesystem operations for moves (CLI doesn't have a move command):
+   ```bash
+   mv "<vault-path>/Notes/old.md" "<vault-path>/.archive/old.md"
+   ```
+
+## Obsidian Syntax Quick Reference
+
+| Syntax | Example |
+|--------|---------|
+| Internal link | `[[Note Name]]` |
+| Aliased link | `[[Note Name\|Display Text]]` |
+| Heading link | `[[Note Name#Heading]]` |
+| Embed note | `![[Note Name]]` |
+| Tag | `#tag/subtag` |
+| Callout | `> [!note] Title` |
+| Task | `- [ ] Todo` / `- [x] Done` |
+
+## Quality Checklist
+- [ ] CLI is available (`Obsidian version` returns version)
+- [ ] Vault is specified (not hardcoded)
+- [ ] Frontmatter is valid YAML (if used)
+- [ ] Internal links use `[[wikilink]]` syntax
+- [ ] Folder pattern used for multi-part topics
+- [ ] Index file has same name as parent folder
+- [ ] Offered to open note in Obsidian after create/update
+
+## Failure Modes & Recovery
+
+**CLI not installed**
+→ Show setup instructions (see Setup & Warmup section)
+
+**Obsidian not running**
+→ Tell user: "Obsidian needs to be running for the CLI to work. Please open Obsidian first."
+
+**Vault not found**
+→ Run `Obsidian vaults verbose` and ask user to pick from the list
+
+**Note already exists**
+→ Offer to update existing or create with different name. Use `overwrite` flag if user confirms.
+
+**iCloud/Dropbox sync race**
+→ Always `sleep 1` before opening a note after create/edit
+
+## Limits
+- Only manage markdown/Obsidian files
+- Don't modify `.obsidian/` config folder
+- Don't delete without explicit confirmation
+- Don't create files outside the vault
+- CLI requires Obsidian v1.8+ to be running

--- a/skills/skills-catalog-v2.json
+++ b/skills/skills-catalog-v2.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "2026-03-24T17:51:17.721Z",
   "schema": "skills-taxonomy-v2",
-  "totalSkills": 170,
+  "totalSkills": 171,
   "skills": [
     {
       "name": "academic-researcher",
@@ -7456,6 +7456,45 @@
         "ds-write",
         "ds-review"
       ]
+    },
+    {
+      "name": "managing-obsidian-notes",
+      "primaryIntent": "research",
+      "intents": [
+        "research",
+        "writing"
+      ],
+      "capabilities": [
+        "infrastructure-ops"
+      ],
+      "domains": [
+        "general"
+      ],
+      "keywords": [
+        "obsidian",
+        "notes",
+        "vault",
+        "knowledge-management",
+        "markdown",
+        "wikilinks",
+        "create-note",
+        "read-note",
+        "search-notes",
+        "obsidian-cli",
+        "backlinks",
+        "tags",
+        "frontmatter",
+        "project-notes"
+      ],
+      "source": "imported",
+      "status": "verified",
+      "summary": "CRUD operations for Obsidian vault notes using the Obsidian CLI. Handles vault bootstrap for new users, per-project folder scaffolding, folder-with-index pattern, wikilinks, tags, frontmatter, and pops open notes in Obsidian after create/update. Requires Obsidian v1.8+ with CLI enabled.",
+      "legacy": {
+        "dirPath": "managing-obsidian-notes",
+        "skillFile": "skills/managing-obsidian-notes/SKILL.md",
+        "topLevelGroup": "Standalone",
+        "subGroup": null
+      }
     }
   ]
 }

--- a/skills/stage-skill-map.json
+++ b/skills/stage-skill-map.json
@@ -8,7 +8,8 @@
       "biorxiv-database",
       "aris-idea-discovery",
       "aris-research-lit",
-      "ds-scout"
+      "ds-scout",
+      "managing-obsidian-notes"
     ],
     "byTaskType": {
       "analysis": [
@@ -43,7 +44,8 @@
       "academic-researcher",
       "aris-idea-discovery",
       "aris-idea-creator",
-      "ds-idea"
+      "ds-idea",
+      "managing-obsidian-notes"
     ],
     "byTaskType": {
       "analysis": [
@@ -81,7 +83,8 @@
       "aris-run-experiment",
       "autoresearch",
       "ds-experiment",
-      "ds-baseline"
+      "ds-baseline",
+      "managing-obsidian-notes"
     ],
     "byTaskType": {
       "implementation": [
@@ -126,7 +129,8 @@
       "aris-rebuttal",
       "ds-write",
       "ds-review",
-      "ds-rebuttal"
+      "ds-rebuttal",
+      "managing-obsidian-notes"
     ],
     "byTaskType": {
       "writing": [
@@ -164,7 +168,8 @@
     "base": [
       "making-academic-presentations",
       "aris-paper-poster",
-      "aris-paper-slides"
+      "aris-paper-slides",
+      "managing-obsidian-notes"
     ],
     "byTaskType": {
       "scripting": [


### PR DESCRIPTION
## Summary

- Rewrite `managing-obsidian-notes` skill from direct filesystem access to Obsidian CLI
- Full onboarding flow: app install → CLI enable → vault creation → PARA scaffold
- Per-project folder scaffolding with templates (project, paper, meeting)
- Always pops open notes in Obsidian after create/update
- No hardcoded personal paths — works with any user's vault
- Added to skills catalog (171 total) and all 5 pipeline stages

## Onboarding Flow

```
No Obsidian app → brew install --cask obsidian
No CLI         → Settings → General → Enable CLI → restart
No vault       → Create in Obsidian UI
Empty vault    → PARA scaffold: Projects/Areas/Resources/Archive/Inbox/Templates
New project    → Per-project folder: index, system-design, progress, key-links, experiment-log
```

## Vault Structure (PARA-inspired)

```
vault/
├── Home.md              ← Dashboard
├── Projects/            ← One folder per project
├── Areas/               ← Ongoing responsibilities
├── Resources/
│   ├── Papers/          ← Paper reading notes
│   └── Learning/        ← Tutorials, courses
├── Archive/             ← Completed work
├── Inbox/               ← Quick capture
├── Templates/           ← Project, Paper, Meeting templates
└── Attachments/         ← Media files
```

## Files Changed

| File | Change |
|------|--------|
| `skills/managing-obsidian-notes/SKILL.md` | Full rewrite (459 lines) |
| `skills/managing-obsidian-notes/CHANGELOG.md` | v2.0 entry |
| `skills/skills-catalog-v2.json` | Added entry (171 total) |
| `skills/stage-skill-map.json` | Added to all 5 stages |
| `skills/README.md` | Added Knowledge Management section to taxonomy |
| `.agents/skills/skills-index.md` | Added entry |
| `README.md` | Updated plugin section with MCP mention |

## Test plan

- [x] No PII in skill file
- [x] Skill registered in catalog and stage map
- [x] CLI commands match Obsidian CLI v1.8+ syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)