### PR TITLE
feat: add /btw side-question support for Gemini and Codex providers

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -26,6 +26,7 @@ import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 
 import { createRequestId, waitForToolApproval, resolveToolApproval as resolvePermApproval, matchesToolPermission } from './utils/permissions.js';
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
+import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
 
 const activeSessions = new Map();
 const pendingClaudeSessionIndexReconciles = new Map();
@@ -872,22 +873,11 @@ function getActiveClaudeSDKSessions() {
   return getAllSessions();
 }
 
-const BTW_SYSTEM_PROMPT = `You answer a short side question for someone in the middle of a coding session.
-
-Rules:
-- You have NO tools. Do not claim to read files, run commands, or fetch URLs unless that information already appears in the conversation context below.
-- Use the "Conversation context" section plus general programming knowledge. If something is not in the context, say you do not see it there.
-- Be concise.`;
-
 /**
  * One-shot, tool-free side question (Claude Code /btw-style). Does not resume the main SDK session.
  */
 async function runClaudeBtw({ question, transcript, cwd, model, signal }) {
-  const safeTranscript =
-    typeof transcript === 'string' && transcript.trim()
-      ? transcript
-      : '(No prior conversation in this session.)';
-  const userBlock = `## Conversation context\n\n${safeTranscript}\n\n---\n\n## Side question\n\n${question}`;
+  const userBlock = buildBtwUserMessage(question, transcript);
 
   const sdkOptions = {
     cwd: cwd || process.cwd(),

--- a/server/gemini-api.js
+++ b/server/gemini-api.js
@@ -12,6 +12,8 @@ import { createRequestId, waitForToolApproval, matchesToolPermission } from './u
 import { getGeminiAuthHeaders } from './utils/geminiOAuth.js';
 import { buildGeminiThinkingConfig } from '../shared/geminiThinkingSupport.js';
 import { spawnGemini } from './gemini-cli.js';
+import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
+import { GEMINI_MODELS } from '../shared/modelConstants.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1826,6 +1828,54 @@ export function getActiveGeminiApiSessions() {
       sessionId,
       startTime: session.startTime,
     }));
+}
+
+/**
+ * One-shot, tool-free side question for the /btw overlay.
+ * Uses the non-streaming generateContent endpoint for simplicity.
+ */
+export async function runGeminiBtw({ question, transcript, model, env, userId, signal }) {
+  const userBlock = buildBtwUserMessage(question, transcript);
+  const effectiveModel = model || GEMINI_MODELS.DEFAULT;
+
+  let auth = null;
+  if (env?.GEMINI_API_KEY) {
+    auth = { headers: { 'x-goog-api-key': env.GEMINI_API_KEY }, authMethod: 'api-key' };
+  } else if (env?.GOOGLE_API_KEY) {
+    auth = { headers: { 'x-goog-api-key': env.GOOGLE_API_KEY }, authMethod: 'api-key' };
+  } else {
+    auth = await getGeminiAuthHeaders(userId);
+  }
+
+  if (!auth?.headers) {
+    throw new Error('No Gemini API credentials available');
+  }
+
+  const requestBody = {
+    systemInstruction: { parts: [{ text: BTW_SYSTEM_PROMPT }] },
+    contents: [{ role: 'user', parts: [{ text: userBlock }] }],
+  };
+
+  const url = `${GEMINI_API_BASE}/models/${encodeURIComponent(effectiveModel)}:generateContent`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { ...auth.headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(requestBody),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(`Gemini API error (${response.status}): ${errorBody.slice(0, 500)}`);
+  }
+
+  const data = await response.json();
+  const answer = data?.candidates?.[0]?.content?.parts
+    ?.map((p) => p.text)
+    .filter(Boolean)
+    .join('') || '';
+
+  return { answer };
 }
 
 setInterval(() => {

--- a/server/gemini-api.js
+++ b/server/gemini-api.js
@@ -18,7 +18,8 @@ import { GEMINI_MODELS } from '../shared/modelConstants.js';
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
-export const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+export const GEMINI_API_BASE =
+  process.env.GEMINI_API_BASE || 'https://generativelanguage.googleapis.com/v1beta';
 const CODE_ASSIST_BASE = 'https://cloudcode-pa.googleapis.com/v1internal';
 const MAX_AGENT_TURNS = 30;
 const BASH_TIMEOUT_MS = 120_000;

--- a/server/index.js
+++ b/server/index.js
@@ -59,6 +59,7 @@ import taskmasterRoutes from './routes/taskmaster.js';
 import mcpUtilsRoutes from './routes/mcp-utils.js';
 import commandsRoutes from './routes/commands.js';
 import claudeBtwRoutes from './routes/claude-btw.js';
+import btwRoutes from './routes/btw.js';
 import settingsRoutes from './routes/settings.js';
 import agentRoutes from './routes/agent.js';
 import projectsRoutes, { WORKSPACES_ROOT, getWorkspacesRoot, validateWorkspacePath } from './routes/projects.js';
@@ -495,7 +496,9 @@ app.use('/api/mcp-utils', authenticateToken, mcpUtilsRoutes);
 // Commands API Routes (protected)
 app.use('/api/commands', authenticateToken, commandsRoutes);
 
-// Claude ephemeral side question (/btw)
+// Ephemeral side question (/btw) — unified multi-provider endpoint
+app.use('/api/btw', authenticateToken, btwRoutes);
+// Legacy Claude-only /btw endpoint (backward compat)
 app.use('/api/claude', authenticateToken, claudeBtwRoutes);
 
 // Settings API Routes (protected)

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -16,6 +16,7 @@
 import { Codex } from '@openai/codex-sdk';
 import { promises as fs } from 'fs';
 import path from 'path';
+import os from 'os';
 import { encodeProjectPath, reconcileCodexSessionIndex } from './projects.js';
 import { sessionDb } from './database/db.js';
 import { applyStageTagsToSession, recordIndexedSession } from './utils/sessionIndex.js';
@@ -23,6 +24,8 @@ import { classifyError, classifySDKError } from '../shared/errorClassifier.js';
 import { buildTempAttachmentFilename } from './utils/imageAttachmentFiles.js';
 import { buildCodexRealtimeTokenBudget } from './utils/sessionTokenUsage.js';
 import { expandSkillCommand } from './utils/skillExpander.js';
+import { CODEX_MODELS } from '../shared/modelConstants.js';
+import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
 
 // Track active sessions
 const activeCodexSessions = new Map();
@@ -710,6 +713,62 @@ function sendMessage(ws, data) {
   } catch (error) {
     console.error('[Codex] Error sending message:', error);
   }
+}
+
+/**
+ * Resolve an OpenAI API key from environment or ~/.codex/auth.json.
+ */
+async function resolveOpenAIApiKey(env) {
+  if (env?.OPENAI_API_KEY) return env.OPENAI_API_KEY;
+  if (process.env.OPENAI_API_KEY) return process.env.OPENAI_API_KEY;
+  try {
+    const authPath = path.join(os.homedir(), '.codex', 'auth.json');
+    const content = await fs.readFile(authPath, 'utf8');
+    const auth = JSON.parse(content);
+    if (auth?.OPENAI_API_KEY) return auth.OPENAI_API_KEY;
+  } catch {
+    // auth.json missing or unreadable
+  }
+  return null;
+}
+
+/**
+ * One-shot, tool-free side question for the /btw overlay.
+ * Bypasses the Codex SDK and calls the OpenAI Chat Completions API directly.
+ */
+export async function runCodexBtw({ question, transcript, model, env, signal }) {
+  const apiKey = await resolveOpenAIApiKey(env);
+  if (!apiKey) {
+    throw new Error('No OpenAI API key available for Codex /btw');
+  }
+
+  const userBlock = buildBtwUserMessage(question, transcript);
+  const effectiveModel = model || CODEX_MODELS.DEFAULT;
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: effectiveModel,
+      messages: [
+        { role: 'system', content: BTW_SYSTEM_PROMPT },
+        { role: 'user', content: userBlock },
+      ],
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(`OpenAI API error (${response.status}): ${errorBody.slice(0, 500)}`);
+  }
+
+  const data = await response.json();
+  const answer = data?.choices?.[0]?.message?.content || '';
+  return { answer };
 }
 
 // Clean up old completed sessions periodically

--- a/server/routes/btw.js
+++ b/server/routes/btw.js
@@ -1,0 +1,92 @@
+import express from 'express';
+import { runClaudeBtw } from '../claude-sdk.js';
+import { runGeminiBtw } from '../gemini-api.js';
+import { runCodexBtw } from '../openai-codex.js';
+import { MAX_QUESTION_CHARS, MAX_TRANSCRIPT_CHARS } from '../utils/btw.js';
+import { getGeminiApiKeyForUser, withGeminiApiKeyEnv } from '../utils/geminiApiKey.js';
+
+const router = express.Router();
+
+const SUPPORTED_PROVIDERS = new Set(['claude', 'gemini', 'codex']);
+
+/**
+ * POST /api/btw
+ * Ephemeral side question (no tools, separate from main chat session).
+ * Dispatches to the appropriate provider backend.
+ */
+router.post('/', async (req, res) => {
+  try {
+    const { question, transcript, projectPath, model, provider } = req.body || {};
+
+    const effectiveProvider = typeof provider === 'string' ? provider.trim() : 'claude';
+    if (!SUPPORTED_PROVIDERS.has(effectiveProvider)) {
+      return res.status(400).json({
+        error: `/btw is supported for ${[...SUPPORTED_PROVIDERS].join(', ')} providers. Got: ${effectiveProvider}`,
+      });
+    }
+
+    const q = typeof question === 'string' ? question.trim() : '';
+    if (!q) {
+      return res.status(400).json({ error: 'question is required' });
+    }
+    if (q.length > MAX_QUESTION_CHARS) {
+      return res.status(400).json({ error: `question exceeds ${MAX_QUESTION_CHARS} character limit` });
+    }
+
+    const raw = typeof transcript === 'string' ? transcript : '';
+    const text = raw.length > MAX_TRANSCRIPT_CHARS ? raw.slice(raw.length - MAX_TRANSCRIPT_CHARS) : raw;
+    const cwd = typeof projectPath === 'string' && projectPath.trim() ? projectPath.trim() : undefined;
+    const modelId = typeof model === 'string' && model.trim() ? model.trim() : undefined;
+
+    const ac = new AbortController();
+    res.on('close', () => {
+      if (!res.writableFinished) {
+        ac.abort();
+      }
+    });
+
+    const userId = req.user?.id;
+    const geminiApiKey = getGeminiApiKeyForUser(userId);
+    const sessionEnv = withGeminiApiKeyEnv(process.env, geminiApiKey);
+
+    let result;
+
+    if (effectiveProvider === 'claude') {
+      result = await runClaudeBtw({
+        question: q,
+        transcript: text,
+        cwd,
+        model: modelId,
+        signal: ac.signal,
+      });
+    } else if (effectiveProvider === 'gemini') {
+      result = await runGeminiBtw({
+        question: q,
+        transcript: text,
+        model: modelId,
+        env: sessionEnv,
+        userId,
+        signal: ac.signal,
+      });
+    } else if (effectiveProvider === 'codex') {
+      result = await runCodexBtw({
+        question: q,
+        transcript: text,
+        model: modelId,
+        env: sessionEnv,
+        signal: ac.signal,
+      });
+    }
+
+    if (!res.headersSent) {
+      res.json({ answer: result?.answer || '' });
+    }
+  } catch (error) {
+    if (!res.headersSent) {
+      console.error('[ERROR] /api/btw:', error.message);
+      res.status(500).json({ error: error.message || 'btw request failed' });
+    }
+  }
+});
+
+export default router;

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -129,7 +129,7 @@ const builtInCommands = [
   },
   {
     name: '/btw',
-    description: 'Ask a quick side question in an overlay (Claude only; does not add to chat history)',
+    description: 'Ask a quick side question in an overlay (does not add to chat history)',
     namespace: 'builtin',
     metadata: { type: 'builtin' }
   }

--- a/server/utils/btw.js
+++ b/server/utils/btw.js
@@ -1,0 +1,25 @@
+/**
+ * Shared constants and helpers for the /btw ephemeral side-question feature.
+ * Used by all provider-specific btw implementations (Claude, Gemini, Codex).
+ */
+
+export const BTW_SYSTEM_PROMPT = `You answer a short side question for someone in the middle of a coding session.
+
+Rules:
+- You have NO tools. Do not claim to read files, run commands, or fetch URLs unless that information already appears in the conversation context below.
+- Use the "Conversation context" section plus general programming knowledge. If something is not in the context, say you do not see it there.
+- Be concise.`;
+
+export const MAX_QUESTION_CHARS = 2000;
+export const MAX_TRANSCRIPT_CHARS = 150_000;
+
+/**
+ * Build the user-facing prompt block that combines transcript context with the side question.
+ */
+export function buildBtwUserMessage(question, transcript) {
+  const safeTranscript =
+    typeof transcript === 'string' && transcript.trim()
+      ? transcript
+      : '(No prior conversation in this session.)';
+  return `## Conversation context\n\n${safeTranscript}\n\n---\n\n## Side question\n\n${question}`;
+}

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -89,7 +89,7 @@ interface UseChatComposerStateArgs {
   setIsUserScrolledUp: (isScrolledUp: boolean) => void;
   setPendingPermissionRequests: Dispatch<SetStateAction<PendingPermissionRequest[]>>;
   newSessionMode?: SessionMode;
-  /** Current chat messages for /btw context (Claude provider). */
+  /** Current chat messages for /btw context. */
   getChatMessagesForBtw?: () => ChatMessage[];
 }
 
@@ -606,13 +606,14 @@ export function useChatComposerState({
             ]);
             return;
           }
-          if (provider !== 'claude') {
+          const btwSupportedProviders = new Set(['claude', 'gemini', 'codex']);
+          if (!btwSupportedProviders.has(provider)) {
             setChatMessages((previous) => [
               ...previous,
               {
                 type: 'assistant',
                 content:
-                  '`/btw` is only available with the Claude Code provider. Switch to Claude in the chat controls, then try again.',
+                  '`/btw` is available with Claude, Gemini, and Codex providers. Switch to one of them in the chat controls, then try again.',
                 timestamp: Date.now(),
               },
             ]);
@@ -634,7 +635,13 @@ export function useChatComposerState({
           });
           try {
             const transcript = buildBtwTranscript(getChatMessagesForBtw?.() ?? []);
-            const btwResponse = await authenticatedFetch('/api/claude/btw', {
+            const btwModel =
+              provider === 'gemini'
+                ? geminiModel
+                : provider === 'codex'
+                  ? codexModel
+                  : claudeModel;
+            const btwResponse = await authenticatedFetch('/api/btw', {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -643,7 +650,8 @@ export function useChatComposerState({
                 question,
                 transcript,
                 projectPath: selectedProject.fullPath || selectedProject.path,
-                model: claudeModel,
+                model: btwModel,
+                provider,
               }),
               signal: abortController.signal,
             });


### PR DESCRIPTION
## Summary

- Extends the `/btw` ephemeral side-question overlay from Claude-only to also support **Gemini** and **Codex** providers
- Gemini: calls the non-streaming `generateContent` REST API directly with `systemInstruction` and no `tools` field
- Codex: bypasses the Codex SDK (which has no stateless mode) and calls the **OpenAI Chat Completions API** directly with no tools
- Extracts shared `BTW_SYSTEM_PROMPT`, constants, and `buildBtwUserMessage()` into `server/utils/btw.js` for all three providers
- Creates a unified `POST /api/btw` endpoint with `provider` dispatch, keeping the legacy `/api/claude/btw` for backward compatibility

## Changed files

| File | Change |
|------|--------|
| `server/utils/btw.js` | **New** — shared system prompt, constants, helper |
| `server/routes/btw.js` | **New** — unified `/api/btw` route with provider dispatch |
| `server/claude-sdk.js` | Refactored `runClaudeBtw()` to use shared module |
| `server/gemini-api.js` | Added `runGeminiBtw()` via Gemini REST API |
| `server/openai-codex.js` | Added `runCodexBtw()` via OpenAI Chat Completions API |
| `server/index.js` | Mount new `/api/btw` route |
| `server/routes/commands.js` | Updated `/btw` description (removed "Claude only") |
| `useChatComposerState.ts` | Support all 3 providers, send `provider` field, select correct model |

## Test plan

- [ ] Test `/btw <question>` with Claude provider — should work as before
- [ ] Test `/btw <question>` with Gemini provider — answer appears in overlay
- [ ] Test `/btw <question>` with Codex provider — answer appears in overlay
- [ ] Test `/btw` with unsupported provider (e.g. openrouter) — shows informative error message
- [ ] Test `/btw` while a main session is streaming — overlay should work concurrently
- [ ] Verify legacy `/api/claude/btw` endpoint still works

Made with [Cursor](https://cursor.com)