### PR TITLE
Add reader modes and chat-area file overlay

### DIFF
--- a/src/components/CodeEditor.d.ts
+++ b/src/components/CodeEditor.d.ts
@@ -16,6 +16,7 @@ interface CodeEditorProps {
   projectPath?: string;
   selectedProject?: Project | null;
   onStartWorkspaceQa?: ((project: Project, prompt: string) => void) | null;
+  displayMode?: 'sidebar' | 'modal' | 'embedded';
   isSidebar?: boolean;
   isExpanded?: boolean;
   onToggleExpand?: (() => void) | null;

--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -22,6 +22,7 @@ import { oneDark as prismOneDark } from 'react-syntax-highlighter/dist/esm/style
 import { api } from '../utils/api';
 import { useTranslation } from 'react-i18next';
 import { Eye, Code2 } from 'lucide-react';
+import JsonTreeViewer from './JsonTreeViewer';
 
 // Custom .env file syntax highlighting
 const envLanguage = StreamLanguage.define({
@@ -173,9 +174,9 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
   const [fontSize, setFontSize] = useState(() => {
     return localStorage.getItem('codeEditorFontSize') || '12';
   });
-  const [markdownPreview, setMarkdownPreview] = useState(() => {
+  const [viewMode, setViewMode] = useState(() => {
     const ext = file?.name?.split('.').pop()?.toLowerCase();
-    return ext === 'md' || ext === 'markdown';
+    return ['md', 'markdown', 'json', 'html', 'htm'].includes(ext) ? 'preview' : 'edit';
   });
   const [candidates, setCandidates] = useState(null);
   const [resolvedPath, setResolvedPath] = useState(null);
@@ -187,18 +188,24 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
     onClose();
   };
 
+  // File type detection
+  const fileExt = useMemo(() => file.name.split('.').pop()?.toLowerCase() || '', [file.name]);
+
   // Check if file is markdown
   const isMarkdownFile = useMemo(() => {
     const ext = file.name.split('.').pop()?.toLowerCase();
     return ext === 'md' || ext === 'markdown';
   }, [file.name]);
-
-  // File type detection
-  const fileExt = useMemo(() => file.name.split('.').pop()?.toLowerCase() || '', [file.name]);
+  const isJsonFile = useMemo(() => fileExt === 'json', [fileExt]);
+  const isHtmlFile = useMemo(() => fileExt === 'html' || fileExt === 'htm', [fileExt]);
   const isPdf = useMemo(() => fileExt === 'pdf', [fileExt]);
   const isImage = useMemo(() => IMAGE_EXTENSIONS.has(fileExt), [fileExt]);
   const isUnsupported = useMemo(() => UNSUPPORTED_EXTENSIONS.has(fileExt), [fileExt]);
   const isBinary = isPdf || isImage;
+  const supportsPreviewMode = useMemo(
+    () => !isBinary && !isUnsupported && (isMarkdownFile || isJsonFile || isHtmlFile),
+    [isBinary, isUnsupported, isMarkdownFile, isJsonFile, isHtmlFile],
+  );
   const [blobUrl, setBlobUrl] = useState(null);
   const absoluteFilePath = useMemo(() => {
     if (!file?.path) {
@@ -235,7 +242,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
     setResolvedPath(null);
     setCandidates(null);
     const ext = file?.name?.split('.').pop()?.toLowerCase();
-    setMarkdownPreview(ext === 'md' || ext === 'markdown');
+    setViewMode(['md', 'markdown', 'json', 'html', 'htm'].includes(ext) ? 'preview' : 'edit');
   }, [file?.path, file?.name]);
 
   // Create minimap extension with chunk-based gutters
@@ -917,17 +924,17 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
               </button>
             )}
 
-            {!isBinary && !isUnsupported && isMarkdownFile && (
+            {supportsPreviewMode && (
               <button
-                onClick={() => setMarkdownPreview(!markdownPreview)}
+                onClick={() => setViewMode((current) => (current === 'preview' ? 'edit' : 'preview'))}
                 className={`p-1.5 rounded-md min-w-[36px] min-h-[36px] md:min-w-0 md:min-h-0 flex items-center justify-center transition-colors ${
-                  markdownPreview
+                  viewMode === 'preview'
                     ? 'text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
                     : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800'
                 }`}
-                title={markdownPreview ? t('actions.editMarkdown') : t('actions.previewMarkdown')}
+                title={viewMode === 'preview' ? t('actions.editFile') : t('actions.previewFile')}
               >
-                {markdownPreview ? <Code2 className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                {viewMode === 'preview' ? <Code2 className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
               </button>
             )}
 
@@ -1004,11 +1011,24 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
             <div className="h-full overflow-auto flex items-center justify-center bg-muted/30 p-4">
               <img src={blobUrl} alt={file.name} className="max-w-full max-h-full object-contain rounded" />
             </div>
-          ) : markdownPreview && isMarkdownFile ? (
+          ) : viewMode === 'preview' && isMarkdownFile ? (
             <div className="h-full overflow-y-auto bg-white dark:bg-gray-900">
               <div className="max-w-4xl mx-auto px-8 py-6 prose prose-sm dark:prose-invert prose-headings:font-semibold prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-code:text-sm prose-pre:bg-gray-900 prose-img:rounded-lg max-w-none">
                 <MarkdownPreview content={content} />
               </div>
+            </div>
+          ) : viewMode === 'preview' && isJsonFile ? (
+            <div className="h-full overflow-auto bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.08),transparent_28%),linear-gradient(180deg,rgba(248,250,252,0.92),rgba(255,255,255,0.94))] p-4 dark:bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_28%),linear-gradient(180deg,rgba(15,23,42,0.98),rgba(2,6,23,0.98))]">
+              <JsonTreeViewer content={content} defaultExpandDepth={1} className="min-h-full" />
+            </div>
+          ) : viewMode === 'preview' && isHtmlFile ? (
+            <div className="h-full overflow-auto bg-muted/20 p-4">
+              <iframe
+                title={file.name}
+                srcDoc={content}
+                sandbox="allow-scripts allow-same-origin"
+                className="h-full min-h-[42rem] w-full rounded-2xl border border-border/60 bg-white shadow-sm"
+              />
             </div>
           ) : (
             <CodeMirror

--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -150,8 +150,12 @@ const UNSUPPORTED_EXTENSIONS = new Set([
   'bin', 'exe', 'dll', 'npy', 'npz', 'pkl', 'pt', 'pth', 'ckpt', 'onnx',
 ]);
 
-function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStartWorkspaceQa = null, isSidebar = false, isExpanded = false, onToggleExpand = null, onPopOut = null }) {
+function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStartWorkspaceQa = null, displayMode = undefined, isSidebar = false, isExpanded = false, onToggleExpand = null, onPopOut = null }) {
   const { t } = useTranslation(['codeEditor', 'common']);
+  const resolvedDisplayMode = displayMode || (isSidebar ? 'sidebar' : 'modal');
+  const isSidebarMode = resolvedDisplayMode === 'sidebar';
+  const isModalMode = resolvedDisplayMode === 'modal';
+  const isEmbeddedMode = resolvedDisplayMode === 'embedded';
   const [content, setContent] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -311,7 +315,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
   }, [file.diffInfo, showDiff]);
 
   // Whether toolbar has any buttons worth showing
-  const hasToolbarButtons = !!(file.diffInfo || (isSidebar && onPopOut) || (isSidebar && onToggleExpand));
+  const hasToolbarButtons = !!(file.diffInfo || (isSidebarMode && onPopOut) || (isSidebarMode && onToggleExpand));
 
   // Create editor toolbar panel - only when there are buttons to show
   const editorToolbarPanel = useMemo(() => {
@@ -370,7 +374,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
         }
 
         // Pop out button (only in sidebar mode with onPopOut)
-        if (isSidebar && onPopOut) {
+        if (isSidebarMode && onPopOut) {
           toolbarHTML += `
             <button class="cm-toolbar-btn cm-popout-btn" title="Open in modal">
               <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -381,7 +385,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
         }
 
         // Expand button (only in sidebar mode)
-        if (isSidebar && onToggleExpand) {
+        if (isSidebarMode && onToggleExpand) {
           toolbarHTML += `
             <button class="cm-toolbar-btn cm-expand-btn" title="${isExpanded ? t('toolbar.collapse') : t('toolbar.expand')}">
               <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -437,14 +441,14 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
           });
         }
 
-        if (isSidebar && onPopOut) {
+        if (isSidebarMode && onPopOut) {
           const popoutBtn = dom.querySelector('.cm-popout-btn');
           popoutBtn?.addEventListener('click', () => {
             onPopOut();
           });
         }
 
-        if (isSidebar && onToggleExpand) {
+        if (isSidebarMode && onToggleExpand) {
           const expandBtn = dom.querySelector('.cm-expand-btn');
           expandBtn?.addEventListener('click', () => {
             onToggleExpand();
@@ -462,7 +466,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
     };
 
     return [showPanel.of(createPanel)];
-  }, [file.diffInfo, showDiff, isSidebar, isExpanded, onToggleExpand, onPopOut]);
+  }, [file.diffInfo, showDiff, isSidebarMode, isExpanded, onToggleExpand, onPopOut]);
 
   // Get language extension based on file extension
   const getLanguageExtension = (filename) => {
@@ -724,8 +728,18 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
             }
           `}
         </style>
-        {isSidebar ? (
+        {isSidebarMode ? (
           <div className="w-full h-full flex items-center justify-center bg-background relative">
+            <button onClick={handleAbortAndClose} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
+              <X className="w-4 h-4 text-gray-500" />
+            </button>
+            <div className="flex items-center gap-3">
+              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+              <span className="text-gray-900 dark:text-white">{t('loading', { fileName: file.name })}</span>
+            </div>
+          </div>
+        ) : isEmbeddedMode ? (
+          <div className="w-full h-full bg-background p-8 flex items-center justify-center relative">
             <button onClick={handleAbortAndClose} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
               <X className="w-4 h-4 text-gray-500" />
             </button>
@@ -785,12 +799,26 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
       </div>
     );
 
-    if (isSidebar) {
+    if (isSidebarMode) {
       return (
         <div className="w-full h-full flex flex-col bg-background relative">
           <button onClick={onClose} className="absolute top-2 right-2 p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded z-10">
             <X className="w-4 h-4 text-gray-500" />
           </button>
+          {pickerContent}
+        </div>
+      );
+    }
+
+    if (isEmbeddedMode) {
+      return (
+        <div className="w-full h-full bg-white dark:bg-gray-900 flex flex-col">
+          <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+            <span className="text-sm font-medium text-gray-900 dark:text-white truncate">{file.name}</span>
+            <button onClick={onClose} className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded">
+              <X className="w-4 h-4 text-gray-500" />
+            </button>
+          </div>
           {pickerContent}
         </div>
       );
@@ -884,19 +912,21 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
           }
         `}
       </style>
-      <div className={isSidebar ?
-        'w-full h-full flex flex-col' :
-        `fixed inset-0 z-[9999] ${
-          // Mobile: native fullscreen, Desktop: modal with backdrop
-          'md:bg-black/50 md:flex md:items-center md:justify-center md:p-4'
-        } ${isFullscreen ? 'md:p-0' : ''}`}>
-        <div className={isSidebar ?
-          'bg-background flex flex-col w-full h-full' :
-          `bg-background shadow-2xl flex flex-col ${
-          // Mobile: always fullscreen, Desktop: modal sizing
-          'w-full h-full md:rounded-lg md:shadow-2xl' +
-          (isFullscreen ? ' md:w-full md:h-full md:rounded-none' : ' md:w-full md:max-w-6xl md:h-[80vh] md:max-h-[80vh]')
-        }`}>
+      <div className={isSidebarMode
+        ? 'w-full h-full flex flex-col'
+        : isEmbeddedMode
+          ? 'absolute inset-0 z-40 flex flex-col bg-background'
+          : `fixed inset-0 z-[9999] ${
+              'md:bg-black/50 md:flex md:items-center md:justify-center md:p-4'
+            } ${isFullscreen ? 'md:p-0' : ''}`}>
+        <div className={isSidebarMode
+          ? 'bg-background flex flex-col w-full h-full'
+          : isEmbeddedMode
+            ? 'bg-background flex flex-col w-full h-full'
+            : `bg-background shadow-2xl flex flex-col ${
+                'w-full h-full md:rounded-lg md:shadow-2xl' +
+                (isFullscreen ? ' md:w-full md:h-full md:rounded-none' : ' md:w-full md:max-w-6xl md:h-[80vh] md:max-h-[80vh]')
+              }`}>
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-1.5 border-b border-border flex-shrink-0 min-w-0">
           <div className="flex items-center gap-2 min-w-0 flex-1">
@@ -977,7 +1007,7 @@ function CodeEditor({ file, onClose, projectPath, selectedProject = null, onStar
               </button>
             )}
 
-            {!isSidebar && (
+            {isModalMode && (
               <button
                 onClick={toggleFullscreen}
                 className="hidden md:flex p-1.5 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 items-center justify-center"

--- a/src/components/JsonTreeViewer.jsx
+++ b/src/components/JsonTreeViewer.jsx
@@ -1,0 +1,123 @@
+import React, { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+function formatPrimitive(value) {
+  if (typeof value === 'string') {
+    return `"${value}"`;
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'undefined') {
+    return 'undefined';
+  }
+  return String(value);
+}
+
+function valueClassName(value) {
+  if (value === null) return 'text-slate-500 dark:text-slate-400';
+  switch (typeof value) {
+    case 'string':
+      return 'text-emerald-700 dark:text-emerald-300';
+    case 'number':
+      return 'text-sky-700 dark:text-sky-300';
+    case 'boolean':
+      return 'text-violet-700 dark:text-violet-300';
+    default:
+      return 'text-foreground';
+  }
+}
+
+function getNodeSummary(value) {
+  if (Array.isArray(value)) {
+    return `Array(${value.length})`;
+  }
+  if (value && typeof value === 'object') {
+    return `Object(${Object.keys(value).length})`;
+  }
+  return formatPrimitive(value);
+}
+
+function JsonNode({ label, value, path, depth, defaultExpandDepth }) {
+  const isCollection = Boolean(value) && typeof value === 'object';
+  const startsExpanded = depth < defaultExpandDepth;
+  const [expanded, setExpanded] = useState(startsExpanded);
+
+  if (!isCollection) {
+    return (
+      <div className="flex items-start gap-2 py-0.5 leading-6">
+        <span className="min-w-0 shrink truncate font-medium text-slate-600 dark:text-slate-300">{label}</span>
+        <span className={valueClassName(value)}>{formatPrimitive(value)}</span>
+      </div>
+    );
+  }
+
+  const entries = Array.isArray(value)
+    ? value.map((item, index) => [String(index), item])
+    : Object.entries(value);
+
+  return (
+    <div className="py-0.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((current) => !current)}
+        className="flex w-full items-start gap-1 rounded-md px-1 py-0.5 text-left hover:bg-slate-100/80 dark:hover:bg-slate-800/70"
+      >
+        <span className="mt-1 text-slate-500 dark:text-slate-400">
+          {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </span>
+        <span className="min-w-0 shrink truncate font-medium text-slate-700 dark:text-slate-200">{label}</span>
+        <span className="shrink-0 text-xs text-slate-500 dark:text-slate-400">{getNodeSummary(value)}</span>
+      </button>
+      {expanded ? (
+        <div className="ml-4 border-l border-slate-200 pl-3 dark:border-slate-700">
+          {entries.map(([childKey, childValue]) => (
+            <JsonNode
+              key={`${path}.${childKey}`}
+              label={Array.isArray(value) ? `[${childKey}]` : childKey}
+              value={childValue}
+              path={`${path}.${childKey}`}
+              depth={depth + 1}
+              defaultExpandDepth={defaultExpandDepth}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default function JsonTreeViewer({
+  content,
+  defaultExpandDepth = 1,
+  className = '',
+  invalidFallbackClassName = '',
+}) {
+  const parsed = useMemo(() => {
+    try {
+      return { value: JSON.parse(content), error: null };
+    } catch (error) {
+      return { value: null, error };
+    }
+  }, [content]);
+
+  if (parsed.error) {
+    return (
+      <pre className={`overflow-x-auto whitespace-pre-wrap rounded-xl border border-border/50 bg-background/80 p-5 font-mono text-sm text-foreground shadow-sm ${invalidFallbackClassName}`.trim()}>
+        {content}
+      </pre>
+    );
+  }
+
+  return (
+    <div className={`overflow-auto rounded-xl border border-border/50 bg-[linear-gradient(180deg,rgba(255,255,255,0.95),rgba(248,250,252,0.92))] p-4 font-mono text-sm shadow-sm dark:bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(2,6,23,0.92))] ${className}`.trim()}>
+      <JsonNode
+        label={Array.isArray(parsed.value) ? '[root]' : '{root}'}
+        value={parsed.value}
+        path="root"
+        depth={0}
+        defaultExpandDepth={defaultExpandDepth}
+      />
+    </div>
+  );
+}

--- a/src/components/ResearchLab.jsx
+++ b/src/components/ResearchLab.jsx
@@ -16,6 +16,7 @@ import { ScrollArea } from './ui/scroll-area';
 import { Button } from './ui/button';
 import { api } from '../utils/api';
 import useLocalStorage from '../hooks/useLocalStorage';
+import JsonTreeViewer from './JsonTreeViewer';
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -2031,18 +2032,18 @@ function FileViewer({ projectName, file, onClose }) {
   const [viewMode, setViewMode] = useState('preview');
   const [showExpandedPreview, setShowExpandedPreview] = useState(false);
   const previewKind = useMemo(() => getArtifactPreviewKind(file), [file]);
-  const isPreviewRenderable = previewKind === 'markdown' || previewKind === 'html';
-  const isTextEditable = previewKind === 'text' || previewKind === 'markdown' || previewKind === 'html';
+  const isPreviewRenderable = previewKind === 'markdown' || previewKind === 'html' || previewKind === 'json';
+  const isTextEditable = previewKind === 'text' || previewKind === 'markdown' || previewKind === 'html' || previewKind === 'json';
   const supportsBlobPreview = previewKind === 'pdf' || previewKind === 'image' || previewKind === 'audio' || previewKind === 'video';
   const canExpandPreview = previewKind !== 'unsupported';
   const viewerHeight = previewKind === 'pdf'
-    ? '70vh'
+    ? '78vh'
     : previewKind === 'video'
       ? '32rem'
       : previewKind === 'image'
         ? '30rem'
-        : previewKind === 'markdown' || previewKind === 'html'
-          ? '40rem'
+        : previewKind === 'markdown' || previewKind === 'html' || previewKind === 'json'
+          ? '48rem'
           : '28rem';
 
   useEffect(() => {
@@ -2209,12 +2210,25 @@ function FileViewer({ projectName, file, onClose }) {
 
     if (previewKind === 'html' && viewMode === 'preview') {
       return (
-        <div className="flex-1 min-h-0 overflow-auto bg-muted/10 p-3">
+        <div className="flex-1 min-h-0 overflow-auto bg-muted/10 p-4">
           <iframe
             title={file.name}
             srcDoc={content}
             sandbox="allow-scripts allow-same-origin"
-            className={`w-full rounded-2xl border border-border/60 bg-white shadow-sm ${expanded ? 'h-full min-h-[72vh]' : 'h-full min-h-[32rem]'}`}
+            className={`w-full rounded-2xl border border-border/60 bg-white shadow-sm ${expanded ? 'h-full min-h-[78vh]' : 'h-full min-h-[40rem]'}`}
+          />
+        </div>
+      );
+    }
+
+    if (previewKind === 'json' && viewMode === 'preview') {
+      return (
+        <div className="flex-1 min-h-0 overflow-auto bg-muted/10 p-4">
+          <JsonTreeViewer
+            content={content}
+            defaultExpandDepth={1}
+            className={`${expanded ? 'min-h-[78vh]' : 'min-h-[40rem]'}`}
+            invalidFallbackClassName={expanded ? 'min-h-[78vh]' : 'min-h-[40rem]'}
           />
         </div>
       );
@@ -2312,7 +2326,7 @@ function FileViewer({ projectName, file, onClose }) {
   return (
     <>
       <div
-        className="flex min-h-[320px] max-h-[85vh] flex-col overflow-hidden rounded-[30px] border border-border/60 bg-card/80 shadow-sm backdrop-blur resize-y"
+        className="flex min-h-[360px] max-h-[88vh] flex-col overflow-hidden rounded-[30px] border border-border/60 bg-card/80 shadow-sm backdrop-blur resize-y"
         style={{ height: viewerHeight }}
       >
         <div className="flex flex-shrink-0 items-center justify-between border-b border-border/60 bg-gradient-to-r from-slate-50 via-white to-cyan-50 px-4 py-3 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">

--- a/src/components/chat/types/types.ts
+++ b/src/components/chat/types/types.ts
@@ -135,7 +135,6 @@ export interface ChatInterfaceProps {
   ws: WebSocket | null;
   sendMessage: (message: unknown) => void;
   latestMessage: any;
-  onFileOpen?: (filePath: string, diffInfo?: any) => void;
   onInputFocusChange?: (focused: boolean) => void;
   onSessionActive?: (sessionId?: string | null) => void;
   onSessionInactive?: (sessionId?: string | null) => void;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import QuickSettingsPanel from '../../QuickSettingsPanel';
+import CodeEditor from '../../CodeEditor';
 import ChatTaskProgressPill from './subcomponents/ChatTaskProgressPill';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
@@ -8,7 +9,6 @@ import ChatMessagesPane from './subcomponents/ChatMessagesPane';
 import ChatComposer from './subcomponents/ChatComposer';
 import BtwOverlay from './subcomponents/BtwOverlay';
 import ChatContextSidebar from './subcomponents/ChatContextSidebar';
-import ChatContextFilePreview, { type PreviewFileTarget } from './subcomponents/ChatContextFilePreview';
 import GuidedPromptStarter from './subcomponents/GuidedPromptStarter';
 import { RESUMING_STATUS_TEXT } from '../types/types';
 import type { ChatInterfaceProps } from '../types/types';
@@ -22,12 +22,11 @@ import { authenticatedFetch } from '../../../utils/api';
 import { readCliAvailability, writeCliAvailability } from '../../../utils/cliAvailability';
 import { Button } from '../../ui/button';
 import type { PendingAutoIntake } from '../../../types/app';
+import type { EditingFile } from '../../main-content/types/types';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, LOCAL_MODELS, NANO_CLAUDE_CODE_MODELS, OPENROUTER_MODELS } from '../../../../shared/modelConstants';
 import { getProviderDisplayName } from '../utils/chatFormatting';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
-import { X } from 'lucide-react';
-
 
 const DEFAULT_PROVIDER_AVAILABILITY: Record<Provider, ProviderAvailability> = {
   claude: { cliAvailable: true, cliCommand: 'claude', installHint: null },
@@ -86,7 +85,6 @@ function ChatInterface({
   ws,
   sendMessage,
   latestMessage,
-  onFileOpen,
   onInputFocusChange,
   onSessionActive,
   onSessionInactive,
@@ -115,28 +113,24 @@ function ChatInterface({
   const { t } = useTranslation('chat');
   const { isMobile } = useDeviceSettings({ trackPWA: false });
   const [isShellEditPromptOpen, setIsShellEditPromptOpen] = useState(false);
-  const [previewFile, setPreviewFile] = useState<PreviewFileTarget | null>(null);
+  const [editingFile, setEditingFile] = useState<EditingFile | null>(null);
 
-  const handleFilePreview = useCallback((filePath: string) => {
+  const handleFileOpen = useCallback((filePath: string, diffInfo?: unknown) => {
     const root = selectedProject?.fullPath || selectedProject?.path || '';
     const relative = toRelativePath(filePath, root);
     if (!relative || !isSafePath(relative)) return;
     const name = fileNameFromPath(normalizePath(filePath));
-    setPreviewFile({
+    setEditingFile({
       name,
-      relativePath: relative,
-      absolutePath: normalizePath(filePath),
+      path: relative,
+      projectName: selectedProject?.name,
+      diffInfo: diffInfo ?? null,
     });
   }, [selectedProject]);
 
-  const handleClosePreview = useCallback(() => {
-    setPreviewFile(null);
+  const handleCloseEditor = useCallback(() => {
+    setEditingFile(null);
   }, []);
-
-  const handleOpenPreviewInEditor = useCallback((filePath: string) => {
-    setPreviewFile(null);
-    onFileOpen?.(filePath);
-  }, [onFileOpen]);
 
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>(() => {
     if (typeof window === 'undefined') return 'context';
@@ -324,7 +318,7 @@ function ChatInterface({
     sendByCtrlEnter,
     onSessionActive,
     onInputFocusChange,
-    onFileOpen,
+    onFileOpen: handleFileOpen,
     onShowSettings,
     pendingViewSessionRef,
     scrollToBottom,
@@ -576,11 +570,11 @@ function ChatInterface({
   }, [selectedProject?.name, selectedSession?.id]);
 
   useEffect(() => {
-    setPreviewFile(null);
+    setEditingFile(null);
   }, [selectedSession?.id, selectedProject?.name]);
 
   useEffect(() => {
-    if (!previewFile) {
+    if (!editingFile) {
       return undefined;
     }
 
@@ -590,12 +584,12 @@ function ChatInterface({
       }
 
       event.stopPropagation();
-      setPreviewFile(null);
+      setEditingFile(null);
     };
 
     document.addEventListener('keydown', handlePreviewEscape);
     return () => document.removeEventListener('keydown', handlePreviewEscape);
-  }, [previewFile]);
+  }, [editingFile]);
 
   useEffect(() => {
     if (!isLoading || !canAbortSession) {
@@ -750,7 +744,7 @@ function ChatInterface({
   return (
     <>
       <div className={`h-full flex min-h-0 ${isMobile ? 'flex-col' : 'flex-row'}`}>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
           <div className={`flex min-h-0 flex-1 flex-col ${isEmpty ? 'justify-start pt-[18vh] overflow-y-auto' : ''}`}>
         {shouldShowImportedProjectAnalysisPrompt && (
           <div className="mx-auto mt-4 w-full max-w-3xl px-3 sm:px-4">
@@ -841,7 +835,7 @@ function ChatInterface({
           loadAllJustFinished={loadAllJustFinished}
           showLoadAllOverlay={showLoadAllOverlay}
           createDiff={createDiff}
-          onFileOpen={onFileOpen}
+          onFileOpen={handleFileOpen}
           onShowSettings={onShowSettings}
           onGrantToolPermission={handleGrantToolPermission}
           onSuggestShellEdit={handleOpenShellEditPrompt}
@@ -959,6 +953,17 @@ function ChatInterface({
           />
         )}
 
+        {editingFile && selectedProject && (
+          <CodeEditor
+            file={editingFile}
+            onClose={handleCloseEditor}
+            projectPath={selectedProject.fullPath || selectedProject.path}
+            selectedProject={selectedProject}
+            onStartWorkspaceQa={onStartWorkspaceQa}
+            displayMode="embedded"
+          />
+        )}
+
           </div>
         </div>
 
@@ -969,7 +974,7 @@ function ChatInterface({
           provider={provider}
           newSessionMode={newSessionMode}
           chatMessages={chatMessages}
-          onFileOpen={handleFilePreview}
+          onFileOpen={handleFileOpen}
           activeSidebarTab={sidebarTab}
           onSidebarTabChange={setSidebarTab}
           isCollapsed={isSidebarCollapsed}
@@ -978,34 +983,6 @@ function ChatInterface({
           onStartTask={handleStartTaskInChat}
         />
       </div>
-
-      {previewFile && selectedProject && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
-          onClick={handleClosePreview}
-        >
-          <div
-            className="relative flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-xl"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <button
-              type="button"
-              onClick={handleClosePreview}
-              className="absolute right-3 top-3 z-10 inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-              title={t('sessionContext.preview.closePreview')}
-            >
-              <X className="h-5 w-5" />
-            </button>
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <ChatContextFilePreview
-                projectName={selectedProject.name}
-                file={previewFile}
-                onOpenInEditor={handleOpenPreviewInEditor}
-              />
-            </div>
-          </div>
-        </div>
-      )}
 
       {isShellEditPromptOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center px-4">

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -12,12 +12,10 @@ import NewsDashboard from '../../news-dashboard/view/NewsDashboard';
 
 import MainContentHeader from './subcomponents/MainContentHeader';
 import MainContentStateView from './subcomponents/MainContentStateView';
-import EditorSidebar from './subcomponents/EditorSidebar';
 import type { MainContentProps } from '../types/types';
 
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
-import { useEditorSidebar } from '../hooks/useEditorSidebar';
 import type { Project } from '../../../types/app';
 import type { Reference } from '../../references/types';
 import { queueSkillCommandDraft } from '../../../utils/skillCommandDraft';
@@ -66,20 +64,6 @@ function MainContent({
 
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const shouldShowTasksTab = false;
-
-  const {
-    editingFile,
-    editorWidth,
-    editorExpanded,
-    resizeHandleRef,
-    handleFileOpen,
-    handleCloseEditor,
-    handleToggleEditorExpand,
-    handleResizeStart,
-  } = useEditorSidebar({
-    selectedProject,
-    isMobile,
-  });
 
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
@@ -263,7 +247,7 @@ function MainContent({
       />
 
       <div className="flex-1 flex min-h-0 overflow-hidden">
-        <div className={`flex flex-col min-h-0 overflow-hidden ${editorExpanded ? 'hidden' : ''} flex-1`}>
+        <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
           <div className={`h-full ${activeTab === 'chat' ? 'block' : 'hidden'}`}>
             <ErrorBoundary showDetails>
               <ChatInterface
@@ -272,7 +256,6 @@ function MainContent({
                 ws={ws}
                 sendMessage={sendMessage}
                 latestMessage={latestMessage}
-                onFileOpen={handleFileOpen}
                 onInputFocusChange={onInputFocusChange}
                 onSessionActive={onSessionActive}
                 onSessionInactive={onSessionInactive}
@@ -310,21 +293,6 @@ function MainContent({
 
           <div className={`h-full overflow-hidden ${activeTab === 'preview' ? 'block' : 'hidden'}`} />
         </div>
-
-        <EditorSidebar
-          editingFile={editingFile}
-          isMobile={isMobile}
-          editorExpanded={editorExpanded}
-          editorWidth={editorWidth}
-          resizeHandleRef={resizeHandleRef}
-          onResizeStart={handleResizeStart}
-          onCloseEditor={handleCloseEditor}
-          onToggleEditorExpand={handleToggleEditorExpand}
-          projectPath={selectedProject.path}
-          selectedProject={selectedProject}
-          onStartWorkspaceQa={onStartWorkspaceQa}
-          fillSpace={false}
-        />
       </div>
     </div>
   );

--- a/src/components/main-content/view/subcomponents/EditorSidebar.tsx
+++ b/src/components/main-content/view/subcomponents/EditorSidebar.tsx
@@ -26,17 +26,18 @@ export default function EditorSidebar({
 
   if (isMobile || poppedOut) {
     return (
-      <AnyCodeEditor
-        file={editingFile}
-        onClose={() => {
-          setPoppedOut(false);
-          onCloseEditor();
-        }}
-        projectPath={projectPath}
-        selectedProject={selectedProject}
-        onStartWorkspaceQa={onStartWorkspaceQa}
-        isSidebar={false}
-      />
+        <AnyCodeEditor
+          file={editingFile}
+          onClose={() => {
+            setPoppedOut(false);
+            onCloseEditor();
+          }}
+          projectPath={projectPath}
+          selectedProject={selectedProject}
+          onStartWorkspaceQa={onStartWorkspaceQa}
+          displayMode="modal"
+          isSidebar={false}
+        />
     );
   }
 
@@ -65,6 +66,7 @@ export default function EditorSidebar({
           projectPath={projectPath}
           selectedProject={selectedProject}
           onStartWorkspaceQa={onStartWorkspaceQa}
+          displayMode="sidebar"
           isSidebar
           isExpanded={editorExpanded}
           onToggleExpand={onToggleEditorExpand}

--- a/src/components/survey/view/SurveyPage.tsx
+++ b/src/components/survey/view/SurveyPage.tsx
@@ -27,6 +27,7 @@ import MermaidDiagramViewer from './MermaidDiagramViewer';
 import { saveSurveyDiagramSource } from '../utils/diagramWindow';
 import ReferencesPanel from '../../references/view/ReferencesPanel';
 import type { Reference } from '../../references/types';
+import JsonTreeViewer from '../../JsonTreeViewer';
 
 type SurveyPageProps = {
   selectedProject: Project;
@@ -222,11 +223,13 @@ function PreviewContent({
   return (
     <>
       {file.previewKind === 'pdf' && preview.pdfUrl ? (
-        <iframe
-          title={file.name}
-          src={preview.pdfUrl}
-          className="h-full w-full rounded-xl border border-border/50 bg-background shadow-sm"
-        />
+        <div className="h-full min-h-[48rem]">
+          <iframe
+            title={file.name}
+            src={preview.pdfUrl}
+            className="h-full w-full rounded-xl border border-border/50 bg-background shadow-sm"
+          />
+        </div>
       ) : null}
 
       {preview.mermaidSvg ? (
@@ -234,24 +237,37 @@ function PreviewContent({
       ) : null}
 
       {file.previewKind === 'html' && preview.content ? (
-        <iframe
-          title={file.name}
-          srcDoc={preview.content}
-          sandbox="allow-scripts allow-same-origin"
-          className="h-full w-full rounded-xl border border-border/50 bg-white shadow-sm"
-        />
+        <div className="h-full min-h-[42rem]">
+          <iframe
+            title={file.name}
+            srcDoc={preview.content}
+            sandbox="allow-scripts allow-same-origin"
+            className="h-full w-full rounded-xl border border-border/50 bg-white shadow-sm"
+          />
+        </div>
       ) : null}
 
       {file.previewKind === 'markdown' && preview.content ? (
-        <div className="prose prose-sm max-w-none rounded-xl border border-border/50 bg-background/60 p-6 shadow-sm dark:prose-invert">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{preview.content}</ReactMarkdown>
+        <div className="min-h-[42rem] overflow-auto rounded-xl border border-border/50 bg-background/60 p-6 shadow-sm">
+          <div className="prose prose-sm max-w-none dark:prose-invert">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{preview.content}</ReactMarkdown>
+          </div>
         </div>
       ) : null}
 
       {(file.previewKind === 'json' || file.previewKind === 'text') && preview.content ? (
-        <pre className="overflow-x-auto whitespace-pre-wrap rounded-xl border border-border/50 bg-background/80 p-5 text-sm text-foreground shadow-sm">
-          {preview.content}
-        </pre>
+        file.previewKind === 'json' ? (
+          <JsonTreeViewer
+            content={preview.content}
+            defaultExpandDepth={1}
+            className="min-h-[42rem]"
+            invalidFallbackClassName="min-h-[42rem]"
+          />
+        ) : (
+          <pre className="min-h-[42rem] overflow-x-auto whitespace-pre-wrap rounded-xl border border-border/50 bg-background/80 p-5 text-sm text-foreground shadow-sm">
+            {preview.content}
+          </pre>
+        )
       ) : null}
 
       {file.previewKind === 'unsupported' ? (
@@ -560,11 +576,13 @@ export default function SurveyPage({ selectedProject, onChatFromReference }: Sur
                   : t('surveyPage.preview.failed')}
             </div>
           ) : (
-            <PreviewContent
-              file={selectedItem.value}
-              preview={preview}
-              onOpenMermaidWindow={handleOpenMermaidWindow}
-            />
+            <div className="h-full min-h-[42rem]">
+              <PreviewContent
+                file={selectedItem.value}
+                preview={preview}
+                onOpenMermaidWindow={handleOpenMermaidWindow}
+              />
+            </div>
           )}
         </div>
 

--- a/src/i18n/locales/en/codeEditor.json
+++ b/src/i18n/locales/en/codeEditor.json
@@ -22,6 +22,8 @@
     "exitFullscreen": "Exit fullscreen",
     "fullscreen": "Fullscreen",
     "close": "Close",
+    "previewFile": "Preview file",
+    "editFile": "Edit file",
     "previewMarkdown": "Preview markdown",
     "editMarkdown": "Edit markdown"
   },

--- a/src/i18n/locales/ko/codeEditor.json
+++ b/src/i18n/locales/ko/codeEditor.json
@@ -22,6 +22,8 @@
     "exitFullscreen": "전체화면 종료",
     "fullscreen": "전체화면",
     "close": "닫기",
+    "previewFile": "파일 미리보기",
+    "editFile": "파일 편집",
     "previewMarkdown": "마크다운 미리보기",
     "editMarkdown": "마크다운 편집"
   },

--- a/src/i18n/locales/zh-CN/codeEditor.json
+++ b/src/i18n/locales/zh-CN/codeEditor.json
@@ -22,6 +22,8 @@
     "exitFullscreen": "退出全屏",
     "fullscreen": "全屏",
     "close": "关闭",
+    "previewFile": "预览文件",
+    "editFile": "编辑文件",
     "previewMarkdown": "预览 Markdown",
     "editMarkdown": "编辑 Markdown"
   },


### PR DESCRIPTION
## Summary
- add a shared JSON tree viewer with manual expand/collapse support
- extend file preview mode switching so markdown, JSON, and HTML all support preview/edit flows
- enlarge HTML/PDF preview cards in Research Lab and Knowledge Base so embedded previews are easier to read
- open chat files in a chat-area overlay instead of taking over the whole page, so closing returns directly to the active chat view

## Testing
- npm run typecheck
- npm run build