### PR TITLE
test: address PR170 review residual risks (2, 3, 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   - Preserved Nano command path and active session reporting in WebSocket session status flows.
   - Ensured session lifecycle protocol is emitted consistently for Nano just like other providers.
 
+#### Migration notes
+- **Message cache key change**: Session message cache keys are now scoped by provider (`chat_messages_{project}_{provider}_{session}`). Existing localStorage entries keyed the old way (`chat_messages_{project}_{session}`) will not be read by default. To migrate, set `allowLegacyFallback: true` when calling `getSessionMessageCacheKeys()`. Users upgrading from builds prior to this sync may see empty transcript history on first load for previously-active sessions; the data is still in localStorage and can be recovered by enabling the legacy fallback or manually re-keying the entries.
+
 #### Explicitly excluded (local/private only, not part of upstream PR)
 - Codex-only product strategy and provider lock-in controls.
 - External auth / license refresh-heartbeat-offline-grace stack.

--- a/server/__tests__/session-lifecycle.test.mjs
+++ b/server/__tests__/session-lifecycle.test.mjs
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inferProviderFromMessageType,
+  resolveProjectName,
+  enrichSessionEventPayload,
+  buildLifecycleMessageFromPayload,
+} from '../utils/sessionLifecycle.js';
+
+describe('inferProviderFromMessageType', () => {
+  it.each([
+    ['claude-complete', 'claude'],
+    ['cursor-result', 'cursor'],
+    ['codex-complete', 'codex'],
+    ['gemini-complete', 'gemini'],
+    ['openrouter-complete', 'openrouter'],
+    ['localgpu-complete', 'local'],
+    ['nano-complete', 'nano'],
+  ])('infers %s → %s', (type, expected) => {
+    expect(inferProviderFromMessageType(type)).toBe(expected);
+  });
+
+  it('returns fallbackProvider when prefix is unknown', () => {
+    expect(inferProviderFromMessageType('unknown-type', 'codex')).toBe('codex');
+  });
+
+  it('returns null when no prefix matches and no fallback', () => {
+    expect(inferProviderFromMessageType('unknown-type')).toBeNull();
+  });
+
+  it('handles null/undefined type gracefully', () => {
+    expect(inferProviderFromMessageType(null)).toBeNull();
+    expect(inferProviderFromMessageType(undefined)).toBeNull();
+  });
+});
+
+describe('resolveProjectName', () => {
+  it('returns explicit projectName when provided', () => {
+    expect(resolveProjectName('my-project', null)).toBe('my-project');
+  });
+
+  it('returns null for empty projectName and no path', () => {
+    expect(resolveProjectName(null, null)).toBeNull();
+    expect(resolveProjectName('', '')).toBeNull();
+    expect(resolveProjectName('  ', null)).toBeNull();
+  });
+
+  it('resolves from projectPath via deps when projectName is missing', () => {
+    const deps = {
+      isKnownPath: () => true,
+      encodePath: (p) => `encoded-${p}`,
+    };
+    expect(resolveProjectName(null, '/some/path', deps)).toBe('encoded-/some/path');
+  });
+
+  it('returns null when isKnownPath returns false', () => {
+    const deps = {
+      isKnownPath: () => false,
+      encodePath: () => 'should-not-be-called',
+    };
+    expect(resolveProjectName(null, '/unknown/path', deps)).toBeNull();
+  });
+
+  it('returns null when encodePath throws', () => {
+    const deps = {
+      isKnownPath: () => true,
+      encodePath: () => { throw new Error('encode failed'); },
+    };
+    expect(resolveProjectName(null, '/bad/path', deps)).toBeNull();
+  });
+
+  it('returns null when deps are not provided and projectName is missing', () => {
+    expect(resolveProjectName(null, '/some/path')).toBeNull();
+  });
+});
+
+describe('enrichSessionEventPayload', () => {
+  const deps = {
+    isKnownPath: () => true,
+    encodePath: (p) => `encoded-${p}`,
+  };
+
+  it('returns non-object payloads unchanged', () => {
+    expect(enrichSessionEventPayload(null)).toBeNull();
+    expect(enrichSessionEventPayload(undefined)).toBeUndefined();
+    expect(enrichSessionEventPayload('string')).toBe('string');
+  });
+
+  it('ignores non-session message types', () => {
+    const payload = { type: 'claude-complete', projectPath: '/p' };
+    expect(enrichSessionEventPayload(payload, null, deps)).toBe(payload);
+  });
+
+  it('enriches session payload with resolved projectName from projectPath', () => {
+    const payload = { type: 'session-created', projectPath: '/my/project' };
+    const result = enrichSessionEventPayload(payload, null, deps);
+    expect(result.projectName).toBe('encoded-/my/project');
+    expect(result.type).toBe('session-created');
+  });
+
+  it('uses fallbackProjectPath when payload has no projectPath', () => {
+    const payload = { type: 'session-created' };
+    const result = enrichSessionEventPayload(payload, '/fallback/path', deps);
+    expect(result.projectName).toBe('encoded-/fallback/path');
+  });
+
+  it('does not overwrite existing projectName', () => {
+    const payload = { type: 'session-created', projectName: 'already-set' };
+    const result = enrichSessionEventPayload(payload, null, deps);
+    expect(result).toBe(payload);
+  });
+
+  it('returns original payload when resolved name matches existing', () => {
+    const depsMatch = {
+      isKnownPath: () => true,
+      encodePath: () => 'same-name',
+    };
+    const payload = { type: 'session-created', projectName: 'same-name' };
+    expect(enrichSessionEventPayload(payload, null, depsMatch)).toBe(payload);
+  });
+});
+
+describe('buildLifecycleMessageFromPayload', () => {
+  it('returns null for non-object payloads', () => {
+    expect(buildLifecycleMessageFromPayload(null)).toBeNull();
+    expect(buildLifecycleMessageFromPayload(undefined)).toBeNull();
+    expect(buildLifecycleMessageFromPayload(42)).toBeNull();
+  });
+
+  it('returns null for non-terminal message types', () => {
+    expect(buildLifecycleMessageFromPayload({ type: 'claude-chunk' })).toBeNull();
+    expect(buildLifecycleMessageFromPayload({ type: 'session-created' })).toBeNull();
+  });
+
+  it('builds completed lifecycle for -complete suffix', () => {
+    const now = Date.now();
+    const result = buildLifecycleMessageFromPayload({
+      type: 'claude-complete',
+      sessionId: 'sess-1',
+    });
+    expect(result).toMatchObject({
+      type: 'session-state-changed',
+      provider: 'claude',
+      sessionId: 'sess-1',
+      state: 'completed',
+      reason: 'claude-complete',
+    });
+    expect(result.changedAt).toBeGreaterThanOrEqual(now);
+  });
+
+  it('builds completed lifecycle for cursor-result', () => {
+    const result = buildLifecycleMessageFromPayload({
+      type: 'cursor-result',
+      sessionId: 'cursor-sess',
+    });
+    expect(result.state).toBe('completed');
+    expect(result.provider).toBe('cursor');
+  });
+
+  it('builds failed lifecycle for -error suffix', () => {
+    const result = buildLifecycleMessageFromPayload({
+      type: 'codex-error',
+      sessionId: 'codex-sess',
+    });
+    expect(result).toMatchObject({
+      state: 'failed',
+      provider: 'codex',
+      reason: 'codex-error',
+    });
+  });
+
+  it('prefers actualSessionId over sessionId', () => {
+    const result = buildLifecycleMessageFromPayload({
+      type: 'gemini-complete',
+      sessionId: 'old-id',
+      actualSessionId: 'real-id',
+    });
+    expect(result.sessionId).toBe('real-id');
+  });
+
+  it('uses fallbackProvider when type prefix is unknown', () => {
+    const result = buildLifecycleMessageFromPayload(
+      { type: 'custom-complete', sessionId: 's1' },
+      'openrouter',
+    );
+    expect(result.provider).toBe('openrouter');
+  });
+
+  it('uses payload.provider over fallbackProvider', () => {
+    const result = buildLifecycleMessageFromPayload(
+      { type: 'custom-complete', sessionId: 's1', provider: 'nano' },
+      'openrouter',
+    );
+    expect(result.provider).toBe('nano');
+  });
+
+  it('includes projectName from fallbackProjectName', () => {
+    const result = buildLifecycleMessageFromPayload(
+      { type: 'claude-complete', sessionId: 's1' },
+      null,
+      'my-project',
+    );
+    expect(result.projectName).toBe('my-project');
+  });
+
+  it('omits projectName when not resolvable', () => {
+    const result = buildLifecycleMessageFromPayload(
+      { type: 'claude-complete', sessionId: 's1' },
+      null,
+      null,
+    );
+    expect(result).not.toHaveProperty('projectName');
+  });
+
+  it('resolves projectName from projectPath via deps', () => {
+    const deps = {
+      isKnownPath: () => true,
+      encodePath: (p) => `encoded-${p}`,
+    };
+    const result = buildLifecycleMessageFromPayload(
+      { type: 'claude-error', sessionId: 's1', projectPath: '/proj' },
+      null,
+      null,
+      deps,
+    );
+    expect(result.projectName).toBe('encoded-/proj');
+    expect(result.state).toBe('failed');
+  });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -43,6 +43,12 @@ import fetch from 'node-fetch';
 import mime from 'mime-types';
 
 import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, clearProjectDirectoryCache, encodeProjectPath, resolveCodexSessionFilePath } from './projects.js';
+import {
+    inferProviderFromMessageType as _inferProviderFromMessageType,
+    resolveProjectName as _resolveProjectName,
+    enrichSessionEventPayload as _enrichSessionEventPayload,
+    buildLifecycleMessageFromPayload as _buildLifecycleMessageFromPayload,
+} from './utils/sessionLifecycle.js';
 import { getProjectTokenUsageSummary } from './project-token-usage.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, resolveToolApproval } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getCursorSessionStartTime, getActiveCursorSessions } from './cursor-cli.js';
@@ -1358,17 +1364,7 @@ wss.on('connection', (ws, request) => {
     }
 });
 
-function inferProviderFromMessageType(type, fallbackProvider = null) {
-    const messageType = String(type || '');
-    if (messageType.startsWith('claude-')) return 'claude';
-    if (messageType.startsWith('cursor-')) return 'cursor';
-    if (messageType.startsWith('codex-')) return 'codex';
-    if (messageType.startsWith('gemini-')) return 'gemini';
-    if (messageType.startsWith('openrouter-')) return 'openrouter';
-    if (messageType.startsWith('localgpu-')) return 'local';
-    if (messageType.startsWith('nano-')) return 'nano';
-    return fallbackProvider || null;
-}
+// --- Session lifecycle helpers (delegated to server/utils/sessionLifecycle.js) ---
 
 const DEBUG_SESSION_LIFECYCLE = process.env.DEBUG_SESSION_LIFECYCLE === '1';
 const warnedUnknownLifecycleProjectPaths = new Set();
@@ -1400,91 +1396,43 @@ function warnUnknownLifecycleProjectPath(projectPath) {
     console.warn(`[WARN] Ignoring lifecycle projectPath that is not a known project: ${normalizedPath}`);
 }
 
-function resolveProjectName(projectName = null, projectPath = null) {
-    if (typeof projectName === 'string' && projectName.trim().length > 0) {
-        return projectName;
-    }
+function inferProviderFromMessageType(type, fallbackProvider = null) {
+    return _inferProviderFromMessageType(type, fallbackProvider);
+}
 
-    if (typeof projectPath !== 'string' || projectPath.trim().length === 0) {
-        return null;
-    }
-
-    const normalizedProjectPath = path.resolve(projectPath);
-    if (!isKnownLifecycleProjectPath(normalizedProjectPath)) {
-        warnUnknownLifecycleProjectPath(normalizedProjectPath);
-        return null;
-    }
-
-    try {
-        return encodeProjectPath(normalizedProjectPath);
-    } catch (error) {
-        if (DEBUG_SESSION_LIFECYCLE) {
-            console.debug('[DEBUG] Failed to encode project path for lifecycle payload:', normalizedProjectPath, error?.message || error);
+/** Shared deps object that wires the extracted helpers to real DB + fs. */
+const _lifecycleDeps = {
+    isKnownPath(projectPath) {
+        const normalizedPath = path.resolve(projectPath);
+        if (!isKnownLifecycleProjectPath(normalizedPath)) {
+            warnUnknownLifecycleProjectPath(normalizedPath);
+            return false;
         }
-        return null;
-    }
+        return true;
+    },
+    encodePath(projectPath) {
+        const normalizedPath = path.resolve(projectPath);
+        try {
+            return encodeProjectPath(normalizedPath);
+        } catch (error) {
+            if (DEBUG_SESSION_LIFECYCLE) {
+                console.debug('[DEBUG] Failed to encode project path for lifecycle payload:', normalizedPath, error?.message || error);
+            }
+            throw error;
+        }
+    },
+};
+
+function resolveProjectName(projectName = null, projectPath = null) {
+    return _resolveProjectName(projectName, projectPath, _lifecycleDeps);
 }
 
 function enrichSessionEventPayload(payload, fallbackProjectPath = null) {
-    if (!payload || typeof payload !== 'object') {
-        return payload;
-    }
-
-    const messageType = String(payload.type || '');
-    if (!messageType.startsWith('session-')) {
-        return payload;
-    }
-
-    const resolvedProjectName = resolveProjectName(
-        payload.projectName,
-        payload.projectPath || fallbackProjectPath || null,
-    );
-    if (!resolvedProjectName || payload.projectName === resolvedProjectName) {
-        return payload;
-    }
-
-    return {
-        ...payload,
-        projectName: resolvedProjectName,
-    };
+    return _enrichSessionEventPayload(payload, fallbackProjectPath, _lifecycleDeps);
 }
 
 function buildLifecycleMessageFromPayload(payload, fallbackProvider = null, fallbackProjectName = null) {
-    if (!payload || typeof payload !== 'object') {
-        return null;
-    }
-
-    const messageType = String(payload.type || '');
-    let state = null;
-
-    if (messageType === 'cursor-result' || messageType.endsWith('-complete')) {
-        state = 'completed';
-    } else if (messageType.endsWith('-error')) {
-        state = 'failed';
-    }
-
-    if (!state) {
-        return null;
-    }
-
-    const provider = inferProviderFromMessageType(
-        messageType,
-        typeof payload.provider === 'string' ? payload.provider : fallbackProvider,
-    );
-    const projectName = resolveProjectName(
-        payload.projectName || fallbackProjectName || null,
-        payload.projectPath || null,
-    );
-
-    return {
-        type: 'session-state-changed',
-        provider,
-        sessionId: payload.actualSessionId || payload.sessionId || null,
-        state,
-        reason: messageType,
-        changedAt: Date.now(),
-        ...(projectName ? { projectName } : {}),
-    };
+    return _buildLifecycleMessageFromPayload(payload, fallbackProvider, fallbackProjectName, _lifecycleDeps);
 }
 
 /**

--- a/server/utils/sessionLifecycle.js
+++ b/server/utils/sessionLifecycle.js
@@ -1,0 +1,148 @@
+/**
+ * Session lifecycle helpers — extracted from server/index.js for testability.
+ *
+ * These pure-ish functions handle:
+ *   - provider inference from message type prefixes
+ *   - project-name resolution (with optional filesystem + DB validation)
+ *   - session-event payload enrichment
+ *   - lifecycle message construction from completion/error payloads
+ */
+
+/**
+ * Infer the canonical provider name from a message-type prefix.
+ * Falls back to `fallbackProvider` when no prefix matches.
+ */
+export function inferProviderFromMessageType(type, fallbackProvider = null) {
+  const messageType = String(type || '');
+  if (messageType.startsWith('claude-')) return 'claude';
+  if (messageType.startsWith('cursor-')) return 'cursor';
+  if (messageType.startsWith('codex-')) return 'codex';
+  if (messageType.startsWith('gemini-')) return 'gemini';
+  if (messageType.startsWith('openrouter-')) return 'openrouter';
+  if (messageType.startsWith('localgpu-')) return 'local';
+  if (messageType.startsWith('nano-')) return 'nano';
+  return fallbackProvider || null;
+}
+
+/**
+ * Resolve a human-readable project name from either an explicit name or a
+ * filesystem path.  When `isKnownPath` and `encodePath` callbacks are
+ * provided the function validates the path before encoding; otherwise it
+ * performs a simple passthrough (useful in unit tests that don't need a
+ * real filesystem).
+ *
+ * @param {string|null} projectName  - explicit project name (returned as-is when non-empty)
+ * @param {string|null} projectPath  - filesystem path to resolve from
+ * @param {object}      [deps]       - optional dependency overrides for testing
+ * @param {function}    [deps.isKnownPath]  - (path) => boolean
+ * @param {function}    [deps.encodePath]   - (path) => string
+ */
+export function resolveProjectName(
+  projectName = null,
+  projectPath = null,
+  deps = {},
+) {
+  if (typeof projectName === 'string' && projectName.trim().length > 0) {
+    return projectName;
+  }
+
+  if (typeof projectPath !== 'string' || projectPath.trim().length === 0) {
+    return null;
+  }
+
+  const { isKnownPath, encodePath } = deps;
+
+  // When no validators are injected we cannot resolve from path alone.
+  if (typeof isKnownPath !== 'function' || typeof encodePath !== 'function') {
+    return null;
+  }
+
+  if (!isKnownPath(projectPath)) {
+    return null;
+  }
+
+  try {
+    return encodePath(projectPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enrich a session-event payload with a resolved `projectName` when the
+ * original payload is missing one.
+ */
+export function enrichSessionEventPayload(payload, fallbackProjectPath = null, deps = {}) {
+  if (!payload || typeof payload !== 'object') {
+    return payload;
+  }
+
+  const messageType = String(payload.type || '');
+  if (!messageType.startsWith('session-')) {
+    return payload;
+  }
+
+  const resolvedProjectName = resolveProjectName(
+    payload.projectName,
+    payload.projectPath || fallbackProjectPath || null,
+    deps,
+  );
+  if (!resolvedProjectName || payload.projectName === resolvedProjectName) {
+    return payload;
+  }
+
+  return {
+    ...payload,
+    projectName: resolvedProjectName,
+  };
+}
+
+/**
+ * Build a normalised `session-state-changed` lifecycle message from a
+ * provider completion or error payload.
+ *
+ * Returns `null` when the payload does not represent a terminal state.
+ */
+export function buildLifecycleMessageFromPayload(
+  payload,
+  fallbackProvider = null,
+  fallbackProjectName = null,
+  deps = {},
+) {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const messageType = String(payload.type || '');
+  let state = null;
+
+  if (messageType === 'cursor-result' || messageType.endsWith('-complete')) {
+    state = 'completed';
+  } else if (messageType.endsWith('-error')) {
+    state = 'failed';
+  }
+
+  if (!state) {
+    return null;
+  }
+
+  const provider = inferProviderFromMessageType(
+    messageType,
+    typeof payload.provider === 'string' ? payload.provider : fallbackProvider,
+  );
+  const projectName = resolveProjectName(
+    payload.projectName || fallbackProjectName || null,
+    payload.projectPath || null,
+    deps,
+  );
+
+  return {
+    type: 'session-state-changed',
+    provider,
+    sessionId: payload.actualSessionId || payload.sessionId || null,
+    state,
+    reason: messageType,
+    changedAt: Date.now(),
+    ...(projectName ? { projectName } : {}),
+  };
+}

--- a/src/components/chat/utils/__tests__/codexQueue.test.ts
+++ b/src/components/chat/utils/__tests__/codexQueue.test.ts
@@ -186,4 +186,112 @@ describe("codexQueue", () => {
 
     expect(reconciled).toBe(queueBySession);
   });
+
+  it("preserves order under concurrent temp→settled promotions from multiple temp sessions", () => {
+    const settledId = "session-settled";
+    const tempA = "new-session-aaa";
+    const tempB = "new-session-bbb";
+
+    const initialQueue: SessionQueueMap = {
+      [settledId]: [
+        buildQueuedTurn({
+          id: "settled-1",
+          sessionId: settledId,
+          text: "settled turn",
+          kind: "normal",
+        }),
+      ],
+      [tempA]: [
+        buildQueuedTurn({
+          id: "tempA-1",
+          sessionId: tempA,
+          text: "temp A first",
+          kind: "normal",
+        }),
+        buildQueuedTurn({
+          id: "tempA-2",
+          sessionId: tempA,
+          text: "temp A second",
+          kind: "steer",
+        }),
+      ],
+      [tempB]: [
+        buildQueuedTurn({
+          id: "tempB-1",
+          sessionId: tempB,
+          text: "temp B first",
+          kind: "normal",
+        }),
+      ],
+    };
+
+    // Simulate two sequential temp→settled promotions (the order they arrive)
+    const afterA = reconcileSettledSessionQueue(initialQueue, settledId, tempA);
+    const afterBoth = reconcileSettledSessionQueue(afterA, settledId, tempB);
+
+    // tempA and tempB queues should be gone
+    expect(afterBoth[tempA]).toBeUndefined();
+    expect(afterBoth[tempB]).toBeUndefined();
+
+    // Settled queue should contain all turns in order:
+    // existing settled → tempA turns → tempB turns
+    const ids = afterBoth[settledId].map((t) => t.id);
+    expect(ids).toEqual([
+      "settled-1",
+      "tempA-1",
+      "tempA-2",
+      "tempB-1",
+    ]);
+
+    // All turns should have the settled sessionId
+    expect(
+      afterBoth[settledId].every((t) => t.sessionId === settledId),
+    ).toBe(true);
+
+    // Steer kind should be preserved through reconciliation
+    const steerTurn = afterBoth[settledId].find((t) => t.id === "tempA-2");
+    expect(steerTurn?.kind).toBe("steer");
+  });
+
+  it("preserves order when promotion and reconciliation interleave", () => {
+    const tempId = "new-session-xyz";
+    const settledId = "session-final";
+
+    let queue: SessionQueueMap = {
+      [tempId]: [
+        buildQueuedTurn({
+          id: "t-1",
+          sessionId: tempId,
+          text: "first",
+          kind: "normal",
+        }),
+        buildQueuedTurn({
+          id: "t-2",
+          sessionId: tempId,
+          text: "second",
+          kind: "normal",
+        }),
+        buildQueuedTurn({
+          id: "t-3",
+          sessionId: tempId,
+          text: "third",
+          kind: "normal",
+        }),
+      ],
+    };
+
+    // Promote t-3 to steer (moves to front) before reconciliation
+    queue = promoteQueuedTurnToSteer(queue, tempId, "t-3");
+    expect(queue[tempId].map((t) => t.id)).toEqual(["t-3", "t-1", "t-2"]);
+
+    // Now reconcile temp → settled
+    queue = reconcileSettledSessionQueue(queue, settledId, tempId);
+
+    expect(queue[tempId]).toBeUndefined();
+    const ids = queue[settledId].map((t) => t.id);
+    // Promoted steer turn stays at front, then remaining in original order
+    expect(ids).toEqual(["t-3", "t-1", "t-2"]);
+    expect(queue[settledId][0].kind).toBe("steer");
+    expect(queue[settledId].every((t) => t.sessionId === settledId)).toBe(true);
+  });
 });


### PR DESCRIPTION
- Extract lifecycle helpers (inferProviderFromMessageType, resolveProjectName, enrichSessionEventPayload, buildLifecycleMessageFromPayload) into server/utils/sessionLifecycle.js for testability; server/index.js delegates to the extracted module with real DB/fs deps via a shared singleton.
- Add 33 unit tests for the extracted lifecycle functions covering provider inference, project name resolution, payload enrichment, and lifecycle message construction (risk 2).
- Add 2 codexQueue tests for order preservation under concurrent temp→settled promotions and promotion-then-reconciliation interleave (risk 3).
- Document localStorage message cache key migration in CHANGELOG (risk 5).
- Risk 4 (provider array consolidation) deferred — too invasive for this PR.

All 149 tests pass.