### PR TITLE
fix: remove dead code flagged by Copilot static analysis

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1399,10 +1399,6 @@ function warnUnknownLifecycleProjectPath(projectPath) {
     console.warn(`[WARN] Ignoring lifecycle projectPath that is not a known project: ${normalizedPath}`);
 }
 
-function inferProviderFromMessageType(type, fallbackProvider = null) {
-    return _inferProviderFromMessageType(type, fallbackProvider);
-}
-
 /** Shared deps object that wires the extracted helpers to real DB + fs. */
 const _lifecycleDeps = {
     isKnownPath(projectPath) {

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -2047,12 +2047,11 @@ export function useChatComposerState({
         currentSessionId === sessionToActivate;
       const isCodexSessionBusy =
         resolvedProvider === "codex" &&
-        (hasProcessingSession(
+        hasProcessingSession(
           sessionToActivate,
           resolvedProvider,
           selectedProject?.name || currentProjectName,
-        ) ||
-          (isLoading && isCurrentViewSession));
+        );
       const useSteerForThisSubmit =
         resolvedProvider === "codex" && (steerMode || forceSteerForSubmit);
 


### PR DESCRIPTION
- Remove unused inferProviderFromMessageType wrapper from server/index.js; no call sites exist after the sessionLifecycle.js extraction.
- Remove always-false (isLoading && isCurrentViewSession) sub-condition from isCodexSessionBusy; isLoading is always false at that point.

No behavior change. All 149 tests pass.