### PR TITLE
fix: Gemini session output rendering, session resume after page refresh

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -172,13 +172,14 @@ function mapCliOptionsToSDK(options = {}) {
  * @param {Array<string>} tempImagePaths - Temp image file paths for cleanup
  * @param {string} tempDir - Temp directory for cleanup
  */
-function addSession(sessionId, queryInstance, tempImagePaths = [], tempDir = null) {
+function addSession(sessionId, queryInstance, tempImagePaths = [], tempDir = null, writer = null) {
   activeSessions.set(sessionId, {
     instance: queryInstance,
     startTime: Date.now(),
     status: 'active',
     tempImagePaths,
-    tempDir
+    tempDir,
+    writer,
   });
 }
 
@@ -645,7 +646,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
 
     // Track the query instance for abort capability
     if (capturedSessionId) {
-      addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir);
+      addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws);
     }
 
     // Process streaming messages
@@ -657,7 +658,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
       if (message.session_id && !capturedSessionId) {
 
         capturedSessionId = message.session_id;
-        addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir);
+        addSession(capturedSessionId, queryInstance, tempImagePaths, tempDir, ws);
 
         // Set session ID on writer
         if (ws.setSessionId && typeof ws.setSessionId === 'function') {
@@ -940,12 +941,23 @@ async function runClaudeBtw({ question, transcript, cwd, model, signal }) {
 }
 
 // Export public API
+function rebindClaudeSDKSessionWriter(sessionId, newWriter) {
+  const session = getSession(sessionId);
+  if (!session || !session.writer) return false;
+  if (typeof session.writer.replaceSocket === 'function') {
+    session.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
+}
+
 export {
   queryClaudeSDK,
   abortClaudeSDKSession,
   isClaudeSDKSessionActive,
   getClaudeSDKSessionStartTime,
   getActiveClaudeSDKSessions,
+  rebindClaudeSDKSessionWriter,
   resolveToolApproval,
   getContextWindowForModel,
   runClaudeBtw,

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -711,7 +711,8 @@ export async function spawnGemini(command, options = {}, ws) {
       startTime: startTimeValue,
       options,
       sessionAllowedTools,
-      sessionDisallowedTools
+      sessionDisallowedTools,
+      writer: ws,
     };
 
     const statusHeartbeat = setInterval(() => {
@@ -1366,4 +1367,14 @@ export function getGeminiSessionStartTime(sessionId) {
 
 export function getActiveGeminiSessions() {
   return Array.from(activeGeminiSessions.keys());
+}
+
+export function rebindGeminiSessionWriter(sessionId, newWriter) {
+  const session = activeGeminiSessions.get(sessionId);
+  if (!session || !session.writer) return false;
+  if (typeof session.writer.replaceSocket === 'function') {
+    session.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -50,13 +50,13 @@ import {
     buildLifecycleMessageFromPayload as _buildLifecycleMessageFromPayload,
 } from './utils/sessionLifecycle.js';
 import { getProjectTokenUsageSummary } from './project-token-usage.js';
-import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, resolveToolApproval } from './claude-sdk.js';
+import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, rebindClaudeSDKSessionWriter, resolveToolApproval } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getCursorSessionStartTime, getActiveCursorSessions } from './cursor-cli.js';
-import { queryCodex, abortCodexSession, isCodexSessionActive, getCodexSessionStartTime, getActiveCodexSessions } from './openai-codex.js';
-import { spawnGemini, abortGeminiSession, isGeminiSessionActive, getGeminiSessionStartTime, getActiveGeminiSessions } from './gemini-cli.js';
-import { queryOpenRouter, abortOpenRouterSession, isOpenRouterSessionActive, getOpenRouterSessionStartTime, getActiveOpenRouterSessions } from './openrouter.js';
-import { queryLocalGPU, abortLocalGPUSession, isLocalGPUSessionActive, getLocalGPUSessionStartTime, getActiveLocalGPUSessions } from './local-gpu.js';
-import { spawnNanoClaudeCode, abortNanoClaudeCodeSession, isNanoClaudeCodeSessionActive, getNanoClaudeCodeSessionStartTime, getActiveNanoClaudeCodeSessions } from './nano-claude-code.js';
+import { queryCodex, abortCodexSession, isCodexSessionActive, getCodexSessionStartTime, getActiveCodexSessions, rebindCodexSessionWriter } from './openai-codex.js';
+import { spawnGemini, abortGeminiSession, isGeminiSessionActive, getGeminiSessionStartTime, getActiveGeminiSessions, rebindGeminiSessionWriter } from './gemini-cli.js';
+import { queryOpenRouter, abortOpenRouterSession, isOpenRouterSessionActive, getOpenRouterSessionStartTime, getActiveOpenRouterSessions, rebindOpenRouterSessionWriter } from './openrouter.js';
+import { queryLocalGPU, abortLocalGPUSession, isLocalGPUSessionActive, getLocalGPUSessionStartTime, getActiveLocalGPUSessions, rebindLocalGPUSessionWriter } from './local-gpu.js';
+import { spawnNanoClaudeCode, abortNanoClaudeCodeSession, isNanoClaudeCodeSessionActive, getNanoClaudeCodeSessionStartTime, getActiveNanoClaudeCodeSessions, rebindNanoClaudeCodeSessionWriter } from './nano-claude-code.js';
 import gitRoutes from './routes/git.js';
 import authRoutes from './routes/auth.js';
 import mcpRoutes from './routes/mcp.js';
@@ -1463,6 +1463,10 @@ class WebSocketWriter {
     }
   }
 
+  replaceSocket(newWs) {
+    this.ws = newWs;
+  }
+
   setSessionId(sessionId) {
     this.sessionId = sessionId;
   }
@@ -2104,6 +2108,29 @@ function handleChatConnection(ws, request) {
                     // Use Claude Agents SDK
                     isActive = isClaudeSDKSessionActive(sessionId);
                     startTime = getClaudeSDKSessionStartTime(sessionId);
+                }
+
+                // If the session is still running, rebind its writer to the
+                // current WebSocket so that subsequent messages reach the
+                // reconnected client instead of the stale (closed) socket.
+                if (isActive && sessionId) {
+                    let rebound = false;
+                    if (provider === 'codex') {
+                        rebound = rebindCodexSessionWriter(sessionId, writer);
+                    } else if (provider === 'gemini') {
+                        rebound = rebindGeminiSessionWriter(sessionId, writer);
+                    } else if (provider === 'openrouter') {
+                        rebound = rebindOpenRouterSessionWriter(sessionId, writer);
+                    } else if (provider === 'local') {
+                        rebound = rebindLocalGPUSessionWriter(sessionId, writer);
+                    } else if (provider === 'nano') {
+                        rebound = rebindNanoClaudeCodeSessionWriter(sessionId, writer);
+                    } else if (provider !== 'cursor') {
+                        rebound = rebindClaudeSDKSessionWriter(sessionId, writer);
+                    }
+                    if (rebound) {
+                        console.log(`[INFO] Rebound ${provider} session ${sessionId} writer to new WebSocket`);
+                    }
                 }
 
                 writer.send({

--- a/server/local-gpu.js
+++ b/server/local-gpu.js
@@ -737,6 +737,7 @@ export async function queryLocalGPU(command, options = {}, ws) {
       status: 'running',
       abortController,
       startTime: Date.now(),
+      writer: ws,
     });
 
     const userText = (command || '').replace(/\s*\[Context:[^\]]*\]\s*/gi, '').trim();
@@ -990,6 +991,16 @@ export function getActiveLocalGPUSessions() {
   return Array.from(activeLocalGPUSessions.entries())
     .filter(([, s]) => s.status === 'running')
     .map(([id, s]) => ({ sessionId: id, startTime: s.startTime }));
+}
+
+export function rebindLocalGPUSessionWriter(sessionId, newWriter) {
+  const session = activeLocalGPUSessions.get(sessionId);
+  if (!session || !session.writer) return false;
+  if (typeof session.writer.replaceSocket === 'function') {
+    session.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
 }
 
 setInterval(() => {

--- a/server/nano-claude-code.js
+++ b/server/nano-claude-code.js
@@ -174,7 +174,7 @@ export async function spawnNanoClaudeCode(command, options = {}, ws) {
       env: { ...(env || process.env) },
     });
 
-    activeNanoSessions.set(capturedSessionId, { process: child, startTime: Date.now() });
+    activeNanoSessions.set(capturedSessionId, { process: child, startTime: Date.now(), writer: ws });
 
     const getSessionStartTime = () => activeNanoSessions.get(capturedSessionId)?.startTime;
 
@@ -323,6 +323,16 @@ export function getNanoClaudeCodeSessionStartTime(sessionId) {
 
 export function getActiveNanoClaudeCodeSessions() {
   return Array.from(activeNanoSessions.keys());
+}
+
+export function rebindNanoClaudeCodeSessionWriter(sessionId, newWriter) {
+  const sessionData = activeNanoSessions.get(sessionId);
+  if (!sessionData || !sessionData.writer) return false;
+  if (typeof sessionData.writer.replaceSocket === 'function') {
+    sessionData.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
 }
 
 /** Kill all in-flight Nano CLI children (e.g. before process exit). */

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -415,7 +415,8 @@ export async function queryCodex(command, options = {}, ws) {
       codex,
       status: 'running',
       abortController,
-      startTime: Date.now()
+      startTime: Date.now(),
+      writer: ws,
     });
 
     const publishSessionId = (resolvedSessionId) => {
@@ -694,6 +695,16 @@ export function getActiveCodexSessions() {
   }
 
   return sessions;
+}
+
+export function rebindCodexSessionWriter(sessionId, newWriter) {
+  const session = activeCodexSessions.get(sessionId);
+  if (!session || !session.writer) return false;
+  if (typeof session.writer.replaceSocket === 'function') {
+    session.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -627,6 +627,7 @@ export async function queryOpenRouter(command, options = {}, ws) {
       status: 'running',
       abortController,
       startTime: Date.now(),
+      writer: ws,
     });
 
     // Strip [Context: ...] prefixes to extract the user's actual text for the display name
@@ -892,6 +893,16 @@ export function getActiveOpenRouterSessions() {
   return Array.from(activeOpenRouterSessions.entries())
     .filter(([, s]) => s.status === 'running')
     .map(([id, s]) => ({ sessionId: id, startTime: s.startTime }));
+}
+
+export function rebindOpenRouterSessionWriter(sessionId, newWriter) {
+  const session = activeOpenRouterSessions.get(sessionId);
+  if (!session || !session.writer) return false;
+  if (typeof session.writer.replaceSocket === 'function') {
+    session.writer.replaceSocket(newWriter.ws || newWriter);
+    return true;
+  }
+  return false;
 }
 
 // Periodic cleanup (mirrors Codex pattern)

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -638,26 +638,28 @@ export function useChatRealtimeHandlers({
       activeViewSessionId?.startsWith("new-session-")
         ? activeViewSessionId
         : null;
-    const shouldRebindCodexTemporarySession =
+    const shouldRebindTemporarySession =
       Boolean(
         temporaryActiveSessionId &&
-          inferredMessageProvider === "codex" &&
+          (inferredMessageProvider === "codex" || inferredMessageProvider === "gemini") &&
           routedMessageSessionId &&
           routedMessageSessionId !== temporaryActiveSessionId,
       ) && !selectedSession?.id;
 
     if (
-      shouldRebindCodexTemporarySession &&
+      shouldRebindTemporarySession &&
       temporaryActiveSessionId &&
       routedMessageSessionId
     ) {
-      onCodexSessionIdResolved?.(
-        temporaryActiveSessionId,
-        routedMessageSessionId,
-      );
+      if (inferredMessageProvider === "codex") {
+        onCodexSessionIdResolved?.(
+          temporaryActiveSessionId,
+          routedMessageSessionId,
+        );
+      }
       onReplaceTemporarySession?.(
         routedMessageSessionId,
-        "codex",
+        inferredMessageProvider as "codex" | "gemini",
         latestMessageProjectName,
         temporaryActiveSessionId,
       );
@@ -708,7 +710,7 @@ export function useChatRealtimeHandlers({
       isGlobalMessage ||
       Boolean(isSystemInitForView) ||
       Boolean(isPendingViewSession && inferredMessageProvider === provider) ||
-      shouldRebindCodexTemporarySession;
+      shouldRebindTemporarySession;
     const isUnscopedError =
       !latestMessage.sessionId &&
       pendingViewSessionRef.current &&
@@ -734,7 +736,7 @@ export function useChatRealtimeHandlers({
           activeViewProjectName,
           isGlobalMessage,
           isPendingViewSession: Boolean(pendingViewSessionRef.current),
-          shouldRebindCodexTemporarySession,
+          shouldRebindTemporarySession,
           isUnscopedError: Boolean(isUnscopedError),
           shouldBypassSessionFilter: Boolean(shouldBypassSessionFilter),
           extra,

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -42,7 +42,7 @@ import {
 const MESSAGES_PER_PAGE = 20;
 const INITIAL_VISIBLE_MESSAGES = 100;
 /** Grace period for WebSocket status-check response before clearing stale resume state */
-const STATUS_VALIDATION_TIMEOUT_MS = 5000;
+const STATUS_VALIDATION_TIMEOUT_MS = 10_000;
 const MAX_SESSION_SNAPSHOT_CACHE_ENTRIES = 40;
 /**
  * Infer provider from project session lists when session metadata is incomplete.
@@ -1289,6 +1289,13 @@ export function useChatSessionState({
       return;
     }
 
+    // Don't start the timeout until the WebSocket is connected — the
+    // check-session-status message can't be delivered until then, so
+    // timing out before the server even receives the query is premature.
+    if (!ws) {
+      return;
+    }
+
     const persistedStartTime = readSessionTimerStart(activeViewSessionId);
     if (
       !persistedStartTime ||
@@ -1336,6 +1343,7 @@ export function useChatSessionState({
     selectedProject?.name,
     selectedSession?.id,
     selectedSession?.__provider,
+    ws,
   ]);
 
   // Show "Load all" overlay after a batch finishes loading, persist for 2s then hide

--- a/src/components/chat/utils/sessionFilterDebug.ts
+++ b/src/components/chat/utils/sessionFilterDebug.ts
@@ -15,7 +15,7 @@ export interface SessionFilterDebugPayload {
   activeViewProjectName?: string | null;
   isGlobalMessage?: boolean;
   isPendingViewSession?: boolean;
-  shouldRebindCodexTemporarySession?: boolean;
+  shouldRebindTemporarySession?: boolean;
   canUseActiveTemporarySessionForCodex?: boolean;
   isUnscopedError?: boolean;
   shouldBypassSessionFilter?: boolean;


### PR DESCRIPTION
- Extend temporary session rebind logic to cover Gemini (previously Codex-only), fixing the race where gemini-response messages arrive before React updates activeViewSessionId from the new-session-* placeholder.

- Add WebSocketWriter.replaceSocket() hot-swap method and store writer references in all provider session maps (Claude SDK, Codex, Gemini, OpenRouter, Local GPU, Nano). On check-session-status, if the session is still running, rebind the writer to the reconnected WebSocket so messages reach the new client.

- Increase STATUS_VALIDATION_TIMEOUT_MS from 5s to 10s and guard the timeout effect with a !ws check so it only starts counting after the WebSocket connects.