### PR TITLE
feat: multi-session parallel tabs with instant switching and split pane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@xterm/xterm": "^5.5.0",
         "adm-zip": "^0.5.16",
         "bcryptjs": "^3.0.2",
-        "better-sqlite3": "^12.2.0",
+        "better-sqlite3": "^12.9.0",
         "chokidar": "^4.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -68,7 +68,8 @@
         "sqlite": "^5.1.1",
         "sqlite3": "^5.1.7",
         "tailwind-merge": "^3.3.1",
-        "ws": "^8.14.2"
+        "ws": "^8.14.2",
+        "zustand": "^5.0.12"
       },
       "bin": {
         "dr-claw": "server/cli.js",
@@ -6270,9 +6271,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
-      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -18789,6 +18790,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@xterm/xterm": "^5.5.0",
     "adm-zip": "^0.5.16",
     "bcryptjs": "^3.0.2",
-    "better-sqlite3": "^12.2.0",
+    "better-sqlite3": "^12.9.0",
     "chokidar": "^4.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -124,7 +124,8 @@
     "sqlite": "^5.1.1",
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^3.3.1",
-    "ws": "^8.14.2"
+    "ws": "^8.14.2",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -485,7 +485,7 @@ async function loadMcpConfig(cwd) {
  * @returns {Promise<void>}
  */
 async function queryClaudeSDK(command, options = {}, ws) {
-  const { sessionId, sessionMode, stageTagKeys, stageTagSource = 'task_context' } = options;
+  const { sessionId, clientSessionId, sessionMode, stageTagKeys, stageTagSource = 'task_context' } = options;
   let capturedSessionId = sessionId;
   let sessionCreatedSent = false;
   let tempImagePaths = [];
@@ -680,6 +680,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
           ws.send({
             type: 'session-created',
             sessionId: capturedSessionId,
+            clientSessionId: clientSessionId || undefined,
             provider: 'claude',
             mode: sessionMode || 'research'
           });
@@ -777,6 +778,7 @@ async function queryClaudeSDK(command, options = {}, ws) {
       ws.send({
         type: 'session-created',
         sessionId: capturedSessionId,
+        clientSessionId: clientSessionId || undefined,
         provider: 'claude',
         mode: sessionMode || 'research',
       });

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -10,7 +10,7 @@ let activeCursorProcesses = new Map(); // Track active processes by session ID
 
 async function spawnCursor(command, options = {}, ws) {
   return new Promise(async (resolve, reject) => {
-    const { sessionId, projectPath, cwd, resume, toolsSettings, skipPermissions, model, images, sessionMode, stageTagKeys, stageTagSource = 'task_context', env } = options;
+    const { sessionId, clientSessionId, projectPath, cwd, resume, toolsSettings, skipPermissions, model, images, sessionMode, stageTagKeys, stageTagSource = 'task_context', env } = options;
     let capturedSessionId = sessionId; // Track session ID throughout the process
     let sessionCreatedSent = false; // Track if we've already sent session-created event
     let messageBuffer = ''; // Buffer for accumulating assistant messages
@@ -156,6 +156,7 @@ async function spawnCursor(command, options = {}, ws) {
                     ws.send({
                       type: 'session-created',
                       sessionId: capturedSessionId,
+                      clientSessionId: clientSessionId || undefined,
                       model: response.model,
                       cwd: response.cwd,
                       mode: sessionMode || 'research',

--- a/server/gemini-api.js
+++ b/server/gemini-api.js
@@ -1405,6 +1405,7 @@ function getNextGeminiFallbackModel(model) {
 export async function queryGeminiApi(command, options = {}, ws) {
   const {
     sessionId,
+    clientSessionId,
     cwd,
     projectPath,
     model: requestedModel = 'gemini-2.5-flash',
@@ -1525,6 +1526,7 @@ export async function queryGeminiApi(command, options = {}, ws) {
     sendMessage(ws, {
       type: 'session-created',
       sessionId: currentSessionId,
+      clientSessionId: clientSessionId || undefined,
       provider: 'gemini',
       mode: sessionMode || 'research',
       startTime: sessionStartTime,

--- a/server/gemini-cli.js
+++ b/server/gemini-cli.js
@@ -552,7 +552,7 @@ async function syncSessionMetadata(sessionId, projectPath, sessionMode = 'resear
  */
 export async function spawnGemini(command, options = {}, ws) {
   return new Promise(async (resolve, reject) => {
-    const { sessionId, projectPath, cwd, model, images, attachments, permissionMode, thinkingMode, toolsSettings, sessionMode, stageTagKeys, stageTagSource = 'task_context', env } = options;
+    const { sessionId, clientSessionId, projectPath, cwd, model, images, attachments, permissionMode, thinkingMode, toolsSettings, sessionMode, stageTagKeys, stageTagSource = 'task_context', env } = options;
     let capturedSessionId = sessionId;
     let sessionCreatedSent = false;
     let messageStartedSent = false;
@@ -931,7 +931,7 @@ export async function spawnGemini(command, options = {}, ws) {
                   stageTagKeys,
                   tagSource: stageTagSource,
                 });
-                ws.send({ type: 'session-created', sessionId: capturedSessionId, provider: 'gemini', mode: sessionMode || 'research' });
+                ws.send({ type: 'session-created', sessionId: capturedSessionId, clientSessionId: clientSessionId || undefined, provider: 'gemini', mode: sessionMode || 'research' });
               }
             }
             break;

--- a/server/index.js
+++ b/server/index.js
@@ -1559,7 +1559,7 @@ function handleChatConnection(ws, request) {
                     return;
                 }
                 
-                queryClaudeSDK(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                queryClaudeSDK(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Claude query error:', error);
                 });
             } else if (data.type === 'cursor-command') {
@@ -1588,7 +1588,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'cursor', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                spawnCursor(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                spawnCursor(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Cursor spawn error:', error);
                 });
             } else if (data.type === 'codex-command') {
@@ -1617,7 +1617,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'codex', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                queryCodex(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                queryCodex(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Codex query error:', error);
                 });
             } else if (data.type === 'gemini-command') {
@@ -1646,7 +1646,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'gemini', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                spawnGemini(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                spawnGemini(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Gemini spawn error:', error);
                 });
             } else if (data.type === 'openrouter-command') {
@@ -1675,7 +1675,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'openrouter', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                queryOpenRouter(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                queryOpenRouter(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] OpenRouter query error:', error);
                 });
             } else if (data.type === 'local-command') {
@@ -1705,7 +1705,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'local', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                queryLocalGPU(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                queryLocalGPU(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Local GPU query error:', error);
                 });
             } else if (data.type === 'nano-command') {
@@ -1734,7 +1734,7 @@ function handleChatConnection(ws, request) {
                 );
                 writer.telemetryContext = { ...telemetryContext, provider: 'nano', telemetryEnabled: commandTelemetryEnabled };
                 writer.setProjectPath(data.options?.projectPath || data.options?.cwd || null);
-                spawnNanoClaudeCode(data.command, { ...data.options, env: sessionEnv }, writer).catch(error => {
+                spawnNanoClaudeCode(data.command, { ...data.options, clientSessionId: data.clientSessionId || null, env: sessionEnv }, writer).catch(error => {
                     console.error('[ERROR] Nano Claude Code error:', error);
                 });
             } else if (data.type === 'cursor-resume') {

--- a/server/local-gpu.js
+++ b/server/local-gpu.js
@@ -670,6 +670,7 @@ async function buildSystemPrompt(workingDir) {
 export async function queryLocalGPU(command, options = {}, ws) {
   const {
     sessionId,
+    clientSessionId,
     cwd,
     projectPath,
     model = 'qwen3-32b',
@@ -757,6 +758,7 @@ export async function queryLocalGPU(command, options = {}, ws) {
     sendMessage(ws, {
       type: 'session-created',
       sessionId: currentSessionId,
+      clientSessionId: clientSessionId || undefined,
       provider: 'local',
       mode: sessionMode || 'research',
       startTime: activeLocalGPUSessions.get(currentSessionId).startTime,

--- a/server/nano-claude-code.js
+++ b/server/nano-claude-code.js
@@ -78,6 +78,7 @@ export async function spawnNanoClaudeCode(command, options = {}, ws) {
   installNanoProcessShutdownHooks();
   const {
     sessionId,
+    clientSessionId,
     projectPath,
     cwd,
     model,
@@ -135,6 +136,7 @@ export async function spawnNanoClaudeCode(command, options = {}, ws) {
     ws.send({
       type: 'session-created',
       sessionId: capturedSessionId,
+      clientSessionId: clientSessionId || undefined,
       provider: 'nano',
       mode: sessionMode || 'research',
       projectName: encodeProjectPath(workingDir),

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -353,6 +353,7 @@ async function cleanupCodexTempFiles(tempImagePaths, tempDir) {
 export async function queryCodex(command, options = {}, ws) {
   const {
     sessionId,
+    clientSessionId,
     cwd,
     projectPath,
     model,
@@ -443,6 +444,7 @@ export async function queryCodex(command, options = {}, ws) {
       sendMessage(ws, {
         type: 'session-created',
         sessionId: currentSessionId,
+        clientSessionId: clientSessionId || undefined,
         provider: 'codex',
         mode: sessionMode || 'research'
       });

--- a/server/openrouter.js
+++ b/server/openrouter.js
@@ -576,6 +576,7 @@ async function consumeStream(response, { onText, onAbortCheck }) {
 export async function queryOpenRouter(command, options = {}, ws) {
   const {
     sessionId,
+    clientSessionId,
     cwd,
     projectPath,
     model = 'anthropic/claude-sonnet-4',
@@ -649,6 +650,7 @@ export async function queryOpenRouter(command, options = {}, ws) {
     sendMessage(ws, {
       type: 'session-created',
       sessionId: currentSessionId,
+      clientSessionId: clientSessionId || undefined,
       provider: 'openrouter',
       mode: sessionMode || 'research',
       startTime: activeOpenRouterSessions.get(currentSessionId).startTime,

--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -13,6 +13,7 @@ import { useSessionProtection } from '../../hooks/useSessionProtection';
 import { useProjectsState } from '../../hooks/useProjectsState';
 import { useInteractionTelemetry } from '../../hooks/useInteractionTelemetry';
 import { useUiPreferences } from '../../hooks/useUiPreferences';
+import { useSessionTabsStore } from '../../stores/useSessionTabsStore';
 import {
   ensureTelemetryDefaultEnabled,
   isTelemetryEnabled,
@@ -150,6 +151,17 @@ export default function AppContent() {
       window.removeEventListener(TELEMETRY_SETTINGS_EVENT, syncTelemetrySetting);
     };
   }, [isConnected, sendMessage]);
+
+  // Sync session tab store -> selectedSession when user clicks a tab in the tab bar
+  const tabStoreActiveId = useSessionTabsStore((s) => s.activeTabId);
+  const tabStoreTabs = useSessionTabsStore((s) => s.tabs);
+  useEffect(() => {
+    if (!tabStoreActiveId) return;
+    if (selectedSession?.id === tabStoreActiveId) return;
+    const tab = tabStoreTabs.find((t) => t.id === tabStoreActiveId);
+    if (!tab) return;
+    handleNavigateToSession(tab.id, tab.provider, tab.projectName);
+  }, [tabStoreActiveId, tabStoreTabs, selectedSession?.id, handleNavigateToSession]);
 
   useEffect(() => {
     if (!isDesktop || !onDesktopEvent) {

--- a/src/components/chat/hooks/__tests__/conversationSessionIds.test.ts
+++ b/src/components/chat/hooks/__tests__/conversationSessionIds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveConversationSessionIds } from '../useChatComposerState';
+
+describe('resolveConversationSessionIds', () => {
+  it('lets a selected temporary tab override the previously mounted session', () => {
+    expect(resolveConversationSessionIds({
+      selectedSessionId: 'new-session-client-1',
+      currentSessionId: 'existing-session',
+      routedSessionId: null,
+      pendingViewSessionId: null,
+      providerSessionId: null,
+    })).toEqual({
+      effectiveSessionId: 'new-session-client-1',
+      temporarySessionId: 'new-session-client-1',
+      serverSessionId: null,
+    });
+  });
+
+  it('resumes a real selected session', () => {
+    expect(resolveConversationSessionIds({
+      selectedSessionId: 'real-session',
+      currentSessionId: 'stale-session',
+    })).toEqual({
+      effectiveSessionId: 'real-session',
+      temporarySessionId: null,
+      serverSessionId: 'real-session',
+    });
+  });
+});

--- a/src/components/chat/hooks/__tests__/createdSessionOwnership.test.ts
+++ b/src/components/chat/hooks/__tests__/createdSessionOwnership.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldHandleCreatedSession } from '../useChatRealtimeHandlers';
+
+describe('shouldHandleCreatedSession', () => {
+  it('routes a correlated session-created event only to its originating temporary tab', () => {
+    expect(shouldHandleCreatedSession({
+      currentSessionId: 'new-session-a',
+      clientSessionId: 'new-session-b',
+      activeTabId: 'new-session-b',
+    })).toBe(false);
+
+    expect(shouldHandleCreatedSession({
+      currentSessionId: 'new-session-b',
+      clientSessionId: 'new-session-b',
+      activeTabId: 'new-session-a',
+    })).toBe(true);
+  });
+
+  it('falls back to the active temporary tab for legacy server events', () => {
+    expect(shouldHandleCreatedSession({
+      currentSessionId: 'new-session-a',
+      activeTabId: 'new-session-b',
+    })).toBe(false);
+    expect(shouldHandleCreatedSession({
+      currentSessionId: 'new-session-b',
+      activeTabId: 'new-session-b',
+    })).toBe(true);
+  });
+});

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -195,6 +195,35 @@ function formatRejectedFileMessage(rejection: FileRejection) {
 const isTemporarySessionId = (sessionId: string | null | undefined) =>
   Boolean(sessionId && sessionId.startsWith('new-session-'));
 
+export function resolveConversationSessionIds({
+  selectedSessionId,
+  currentSessionId,
+  routedSessionId,
+  pendingViewSessionId,
+  providerSessionId,
+}: {
+  selectedSessionId?: string | null;
+  currentSessionId?: string | null;
+  routedSessionId?: string | null;
+  pendingViewSessionId?: string | null;
+  providerSessionId?: string | null;
+}) {
+  const effectiveSessionId =
+    selectedSessionId ||
+    currentSessionId ||
+    routedSessionId ||
+    pendingViewSessionId ||
+    providerSessionId ||
+    null;
+  const temporarySessionId = isTemporarySessionId(effectiveSessionId) ? effectiveSessionId : null;
+
+  return {
+    effectiveSessionId,
+    temporarySessionId,
+    serverSessionId: temporarySessionId ? null : effectiveSessionId,
+  };
+}
+
 const BTW_TRANSCRIPT_MAX_CHARS = 120_000;
 
 function buildBtwTranscript(messages: ChatMessage[]): string {
@@ -1300,16 +1329,17 @@ export function useChatComposerState({
           ? sessionStorage.getItem('cursorSessionId')
           : null;
       const pendingViewSessionId = pendingViewSessionRef.current?.sessionId || null;
-      const effectiveSessionId =
-        currentSessionId ||
-        selectedSession?.id ||
-        routedSessionId ||
-        pendingViewSessionId ||
-        providerSessionId;
-      const isNewSession = !effectiveSessionId;
+      const { effectiveSessionId, temporarySessionId, serverSessionId } = resolveConversationSessionIds({
+        selectedSessionId: selectedSession?.id,
+        currentSessionId,
+        routedSessionId,
+        pendingViewSessionId,
+        providerSessionId,
+      });
+      const isNewSession = !serverSessionId;
       const sessionToActivate = effectiveSessionId || `new-session-${Date.now()}`;
 
-      if (!effectiveSessionId && !selectedSession?.id) {
+      if (!serverSessionId) {
         if (typeof window !== 'undefined') {
           // Reset stale pending IDs from previous interrupted runs before creating a new one.
           sessionStorage.removeItem('pendingSessionId');
@@ -1356,12 +1386,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'cursor-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: cursorModel,
             skipPermissions: toolsSettings?.skipPermissions || false,
             toolsSettings,
@@ -1376,12 +1407,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'gemini-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: geminiModel,
             permissionMode: effectivePermissionMode,
             thinkingMode: geminiThinkingMode,
@@ -1398,12 +1430,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'codex-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: codexModel,
             permissionMode: effectivePermissionMode === 'plan' ? 'default' : effectivePermissionMode,
             modelReasoningEffort: codexReasoningEffort === 'default' ? undefined : codexReasoningEffort,
@@ -1420,12 +1453,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'openrouter-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: openrouterModel,
             permissionMode: effectivePermissionMode,
             toolsSettings,
@@ -1440,12 +1474,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'local-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: localModel,
             serverUrl: localStorage.getItem('local-gpu-server-url') || 'http://localhost:11434',
             gpuId: localStorage.getItem('local-gpu-selected') || undefined,
@@ -1462,12 +1497,13 @@ export function useChatComposerState({
         sendMessage({
           type: 'nano-command',
           command: messageContent,
-          sessionId: effectiveSessionId,
+          sessionId: serverSessionId,
+          clientSessionId: temporarySessionId,
           options: {
             cwd: resolvedProjectPath,
             projectPath: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             model: nanoModel,
             toolsSettings,
             telemetryEnabled,
@@ -1481,11 +1517,12 @@ export function useChatComposerState({
         sendMessage({
           type: 'claude-command',
           command: messageContent,
+          clientSessionId: temporarySessionId,
           options: {
             projectPath: resolvedProjectPath,
             cwd: resolvedProjectPath,
-            sessionId: effectiveSessionId,
-            resume: Boolean(effectiveSessionId),
+            sessionId: serverSessionId,
+            resume: Boolean(serverSessionId),
             toolsSettings,
             permissionMode: effectivePermissionMode,
             model: claudeModel,

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -18,6 +18,7 @@ import { RESUMING_STATUS_TEXT } from '../types/types';
 import i18n from '../../../i18n/config';
 import type { ChatMessage, PendingPermissionRequest } from '../types/types';
 import type { Project, ProjectSession, SessionNavigationSource, SessionProvider } from '../../../types/app';
+import { useSessionTabsStore } from '../../../stores/useSessionTabsStore';
 
 type PendingViewSession = {
   sessionId: string | null;
@@ -539,10 +540,42 @@ export function useChatRealtimeHandlers({
       });
     };
 
+    // Route messages for background (non-active) sessions to the tab store
+    const updateBackgroundSessionStatus = (bgSessionId: string, msgType: string) => {
+      const store = useSessionTabsStore.getState();
+      const isTabOpen = store.tabs.some((t) => t.id === bgSessionId);
+      if (!isTabOpen) return;
+
+      const prevSeq = store.backgroundStatus[bgSessionId]?.messageSeq ?? 0;
+      const isComplete = lifecycleMessageTypes.has(msgType);
+      if (isComplete) {
+        const wasLoading = store.backgroundStatus[bgSessionId]?.isLoading ?? false;
+        store.setBackgroundStatus(bgSessionId, {
+          isLoading: false,
+          statusText: null,
+          hasUnread: wasLoading,
+          messageSeq: prevSeq + 1,
+        });
+      } else if (msgType.endsWith('-status') || msgType.endsWith('-response') || msgType.endsWith('-output')) {
+        const statusText = latestMessage.data?.status || latestMessage.data?.text || null;
+        const tokens = typeof latestMessage.data?.tokens === 'number' ? latestMessage.data.tokens : undefined;
+        store.setBackgroundStatus(bgSessionId, {
+          isLoading: true,
+          hasUnread: false,
+          ...(statusText != null && { statusText: String(statusText) }),
+          ...(tokens != null && { tokenCount: tokens }),
+          messageSeq: prevSeq + 1,
+        });
+      }
+    };
+
     if (!shouldBypassSessionFilter) {
       if (!activeViewSessionId) {
         if (latestMessage.sessionId && lifecycleMessageTypes.has(String(latestMessage.type))) {
           handleBackgroundLifecycle(latestMessage.sessionId);
+        }
+        if (latestMessage.sessionId) {
+          updateBackgroundSessionStatus(latestMessage.sessionId, String(latestMessage.type));
         }
         if (!isUnscopedError) {
           return;
@@ -554,6 +587,9 @@ export function useChatRealtimeHandlers({
       }
 
       if (latestMessage.sessionId !== activeViewSessionId) {
+        if (latestMessage.sessionId) {
+          updateBackgroundSessionStatus(latestMessage.sessionId, String(latestMessage.type));
+        }
         if (latestMessage.sessionId && lifecycleMessageTypes.has(String(latestMessage.type))) {
           handleBackgroundLifecycle(latestMessage.sessionId);
         }
@@ -588,6 +624,13 @@ export function useChatRealtimeHandlers({
             pendingViewSessionRef.current.sessionId = latestMessage.sessionId;
           }
           setIsSystemSessionChange(true);
+          if (temporarySessionId) {
+            useSessionTabsStore.getState().replaceTabSessionId(
+              temporarySessionId,
+              { id: latestMessage.sessionId, __provider: createdSessionProvider, __projectName: selectedProject?.name } as ProjectSession,
+              selectedProject?.name || '',
+            );
+          }
           onReplaceTemporarySession?.(latestMessage.sessionId);
           onNavigateToSession?.(latestMessage.sessionId, createdSessionProvider, selectedProject?.name, { source: 'system' });
           setPendingPermissionRequests((previous) =>

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -870,6 +870,10 @@ export function useChatRealtimeHandlers({
           sessionStorage.removeItem('pendingSessionId');
         }
         if (selectedProject && latestMessage.exitCode === 0) {
+          // Clear both the session-scoped and legacy project-scoped recovery keys.
+          if (completedSessionId) {
+            safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}_${completedSessionId}`);
+          }
           safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
         }
         setPendingPermissionRequests([]);
@@ -1367,7 +1371,12 @@ export function useChatRealtimeHandlers({
           }
           sessionStorage.removeItem('pendingSessionId');
         }
-        if (selectedProject) safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
+        if (selectedProject) {
+          if (codexActualSessionId) {
+            safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}_${codexActualSessionId}`);
+          }
+          safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
+        }
         break;
       }
 
@@ -1383,6 +1392,13 @@ export function useChatRealtimeHandlers({
       case 'session-aborted': {
         const pendingSessionId = typeof window !== 'undefined' ? sessionStorage.getItem('pendingSessionId') : null;
         const abortedSessionId = latestMessage.sessionId || currentSessionId;
+        // Guard: with multiple ChatInterface instances mounted (one per tab),
+        // session-aborted is a global message that reaches all of them. Only the
+        // instance that owns the aborted session should update chat state.
+        const thisInstanceId = selectedSession?.id || currentSessionId;
+        if (abortedSessionId && thisInstanceId && abortedSessionId !== thisInstanceId) {
+          break;
+        }
         if (latestMessage.success !== false) {
           clearLoadingIndicators();
           markSessionsAsCompleted(abortedSessionId, currentSessionId, selectedSession?.id, pendingSessionId);

--- a/src/components/chat/hooks/useChatRealtimeHandlers.ts
+++ b/src/components/chat/hooks/useChatRealtimeHandlers.ts
@@ -18,7 +18,7 @@ import { RESUMING_STATUS_TEXT } from '../types/types';
 import i18n from '../../../i18n/config';
 import type { ChatMessage, PendingPermissionRequest } from '../types/types';
 import type { Project, ProjectSession, SessionNavigationSource, SessionProvider } from '../../../types/app';
-import { useSessionTabsStore } from '../../../stores/useSessionTabsStore';
+import { isSessionVisibleInTabs, useSessionTabsStore } from '../../../stores/useSessionTabsStore';
 
 type PendingViewSession = {
   sessionId: string | null;
@@ -38,6 +38,7 @@ type LatestChatMessage = {
   exitCode?: number;
   isProcessing?: boolean;
   actualSessionId?: string;
+  clientSessionId?: string;
   [key: string]: any;
 };
 
@@ -80,6 +81,22 @@ type FinalizeSessionLifecycleOptions = {
   onSessionStatusResolved?: (sessionId?: string | null, isProcessing?: boolean) => void;
   invalidateSessionCache?: (projectName: string, sessionId: string) => void;
 };
+
+export function shouldHandleCreatedSession({
+  currentSessionId,
+  clientSessionId,
+  activeTabId,
+}: {
+  currentSessionId: string | null;
+  clientSessionId?: string;
+  activeTabId: string | null;
+}) {
+  return clientSessionId
+    ? currentSessionId === clientSessionId
+    : !currentSessionId || (
+        currentSessionId.startsWith('new-session-') && activeTabId === currentSessionId
+      );
+}
 
 export function finalizeSessionLifecycle(
   sessionIds: Array<string | null | undefined>,
@@ -544,7 +561,8 @@ export function useChatRealtimeHandlers({
     const updateBackgroundSessionStatus = (bgSessionId: string, msgType: string) => {
       const store = useSessionTabsStore.getState();
       const isTabOpen = store.tabs.some((t) => t.id === bgSessionId);
-      if (!isTabOpen) return;
+      const isPrimaryInstance = activeViewSessionId === store.activeTabId;
+      if (!isPrimaryInstance || !isTabOpen || isSessionVisibleInTabs(store, bgSessionId)) return;
 
       const prevSeq = store.backgroundStatus[bgSessionId]?.messageSeq ?? 0;
       const isComplete = lifecycleMessageTypes.has(msgType);
@@ -598,8 +616,14 @@ export function useChatRealtimeHandlers({
     }
 
     switch (latestMessage.type) {
-      case 'session-created':
-        if (latestMessage.sessionId && (!currentSessionId || currentSessionId.startsWith('new-session-'))) {
+      case 'session-created': {
+        const tabStore = useSessionTabsStore.getState();
+        const ownsCreatedSession = shouldHandleCreatedSession({
+          currentSessionId,
+          clientSessionId: latestMessage.clientSessionId,
+          activeTabId: tabStore.activeTabId,
+        });
+        if (latestMessage.sessionId && ownsCreatedSession) {
           const createdSessionProvider =
             (latestMessage.provider as SessionProvider | undefined) || provider;
           const pendingStartTime = pendingViewSessionRef.current?.startedAt;
@@ -631,6 +655,7 @@ export function useChatRealtimeHandlers({
               selectedProject?.name || '',
             );
           }
+          setCurrentSessionId(latestMessage.sessionId);
           onReplaceTemporarySession?.(latestMessage.sessionId);
           onNavigateToSession?.(latestMessage.sessionId, createdSessionProvider, selectedProject?.name, { source: 'system' });
           setPendingPermissionRequests((previous) =>
@@ -640,6 +665,7 @@ export function useChatRealtimeHandlers({
           );
         }
         break;
+      }
 
       case 'token-budget':
         if (latestMessage.data) {

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -13,6 +13,7 @@ import {
   createCachedDiffCalculator,
   type DiffCalculator,
 } from '../utils/messageTransforms';
+import { useSessionTabsStore } from '../../../stores/useSessionTabsStore';
 
 const MESSAGES_PER_PAGE = 20;
 const INITIAL_VISIBLE_MESSAGES = 100;
@@ -439,6 +440,41 @@ export function useChatSessionState({
     }, 200);
   }, [chatMessages.length, isLoadingSessionMessages, scrollToBottom]);
 
+  // Keep refs to latest values so snapshot save never captures stale closures
+  const chatMessagesRef = useRef(chatMessages);
+  chatMessagesRef.current = chatMessages;
+  const isLoadingRef = useRef(isLoading);
+  isLoadingRef.current = isLoading;
+  const claudeStatusRef = useRef(claudeStatus);
+  claudeStatusRef.current = claudeStatus;
+  const tokenBudgetRef = useRef(tokenBudget);
+  tokenBudgetRef.current = tokenBudget;
+  const canAbortSessionRef = useRef(canAbortSession);
+  canAbortSessionRef.current = canAbortSession;
+
+  const prevSessionIdRef = useRef<string | null>(selectedSession?.id || null);
+
+  // Save snapshot of outgoing session when selectedSession changes
+  useEffect(() => {
+    const outgoingId = prevSessionIdRef.current;
+    const incomingId = selectedSession?.id || null;
+
+    if (outgoingId && outgoingId !== incomingId && chatMessagesRef.current.length > 0) {
+      const container = scrollContainerRef.current;
+      useSessionTabsStore.getState().saveSnapshot(outgoingId, {
+        messages: chatMessagesRef.current,
+        isLoading: isLoadingRef.current,
+        statusText: claudeStatusRef.current?.text ?? null,
+        tokenCount: claudeStatusRef.current?.tokens ?? 0,
+        tokenBudget: tokenBudgetRef.current,
+        scrollTop: container?.scrollTop ?? 0,
+        canAbort: canAbortSessionRef.current,
+      });
+    }
+
+    prevSessionIdRef.current = incomingId;
+  }, [selectedSession?.id]);
+
   useEffect(() => {
     const loadMessages = async () => {
       if (selectedSession && selectedProject) {
@@ -446,6 +482,62 @@ export function useChatSessionState({
         isLoadingSessionRef.current = true;
 
         const sessionChanged = currentSessionId !== null && currentSessionId !== selectedSession.id;
+
+        // Try restoring from snapshot cache for instant tab switching
+        if (sessionChanged && !isSystemSessionChange) {
+          const snapshot = useSessionTabsStore.getState().getSnapshot(selectedSession.id);
+          if (snapshot && snapshot.messages.length > 0) {
+            useSessionTabsStore.getState().clearSnapshot(selectedSession.id);
+            resetStreamingState();
+            pendingViewSessionRef.current = null;
+            setChatMessages(snapshot.messages);
+            setSessionMessages([]);
+            setIsLoading(snapshot.isLoading);
+            setCanAbortSession(snapshot.canAbort);
+            setTokenBudget(snapshot.tokenBudget);
+            setStatusTextOverride(null);
+            setCurrentSessionId(selectedSession.id);
+            messagesOffsetRef.current = 0;
+            setHasMoreMessages(false);
+            setTotalMessages(snapshot.messages.length);
+            setVisibleMessageCount(INITIAL_VISIBLE_MESSAGES);
+            setAllMessagesLoaded(false);
+            allMessagesLoadedRef.current = false;
+
+            if (snapshot.isLoading && snapshot.statusText) {
+              setClaudeStatus({ text: snapshot.statusText, tokens: snapshot.tokenCount, can_interrupt: true });
+            } else {
+              setClaudeStatus(null);
+              // Clear persisted timer so the "Resuming..." effect doesn't kick in
+              clearSessionTimerStart(selectedSession.id);
+            }
+
+            // Clear any pending status validation to prevent spurious "Resuming..."
+            setPendingStatusValidationSessionId(null);
+
+            // Only check session status if the snapshot indicated the session was active
+            if (snapshot.isLoading && ws && selectedSession?.id) {
+              markSessionStatusCheckPending(selectedSession.id);
+              sendMessage({
+                type: 'check-session-status',
+                sessionId: selectedSession.id,
+                provider: currentProvider,
+              });
+            }
+
+            // Restore scroll position after next paint
+            const savedScrollTop = snapshot.scrollTop;
+            requestAnimationFrame(() => {
+              if (scrollContainerRef.current && savedScrollTop > 0) {
+                scrollContainerRef.current.scrollTop = savedScrollTop;
+              }
+            });
+
+            isLoadingSessionRef.current = false;
+            return;
+          }
+        }
+
         if (sessionChanged) {
           if (!isSystemSessionChange) {
             resetStreamingState();
@@ -469,7 +561,6 @@ export function useChatSessionState({
           if (loadAllFinishedTimerRef.current) clearTimeout(loadAllFinishedTimerRef.current);
           setTokenBudget(null);
           
-          // Only set isLoading to false if it's NOT in the processingSessions set
           const isProcessing =
             processingSessions?.has(selectedSession.id) ||
             pendingStatusValidationSessionIdRef.current === selectedSession.id;
@@ -478,8 +569,6 @@ export function useChatSessionState({
           }
         }
 
-        // Always check status if we have a websocket and a session, 
-        // especially on initial load or reconnect.
         if (ws && selectedSession?.id) {
           markSessionStatusCheckPending(selectedSession.id);
           sendMessage({

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -102,12 +102,21 @@ export function useChatSessionState({
 
   const [chatMessages, _setChatMessages] = useState<ChatMessage[]>(() => {
     if (typeof window !== 'undefined' && selectedProject) {
-      const saved = safeLocalStorage.getItem(`chat_messages_${selectedProject.name}`);
+      // Prefer session-scoped key to avoid collisions when multiple sessions
+      // from the same project are open simultaneously (split pane / multi-tab).
+      const sessionScopedKey =
+        selectedSession?.id && !selectedSession.id.startsWith('new-session-')
+          ? `chat_messages_${selectedProject.name}_${selectedSession.id}`
+          : null;
+      const saved =
+        (sessionScopedKey ? safeLocalStorage.getItem(sessionScopedKey) : null) ??
+        safeLocalStorage.getItem(`chat_messages_${selectedProject.name}`);
       if (saved) {
         try {
           return hydrateStoredChatMessages(JSON.parse(saved) as ChatMessage[]);
         } catch {
           console.error('Failed to parse saved chat messages, resetting');
+          if (sessionScopedKey) safeLocalStorage.removeItem(sessionScopedKey);
           safeLocalStorage.removeItem(`chat_messages_${selectedProject.name}`);
           return [];
         }
@@ -235,7 +244,6 @@ export function useChatSessionState({
         }
 
         const data = await response.json();
-        console.log('[DEBUG] Received session messages data:', data);
         if (isInitialLoad && data.tokenUsage) {
           setTokenBudget(data.tokenUsage);
         }
@@ -703,10 +711,14 @@ export function useChatSessionState({
   }, [convertedMessages, setChatMessages]);
 
   useEffect(() => {
-    if (selectedProject && chatMessages.length > 0) {
-      safeLocalStorage.setItem(`chat_messages_${selectedProject.name}`, JSON.stringify(chatMessages));
-    }
-  }, [chatMessages, selectedProject]);
+    if (!selectedProject || chatMessages.length === 0) return;
+    // Use session-scoped key when possible to avoid cross-session collisions.
+    const key =
+      selectedSession?.id && !selectedSession.id.startsWith('new-session-')
+        ? `chat_messages_${selectedProject.name}_${selectedSession.id}`
+        : `chat_messages_${selectedProject.name}`;
+    safeLocalStorage.setItem(key, JSON.stringify(chatMessages));
+  }, [chatMessages, selectedProject, selectedSession?.id]);
 
   useEffect(() => {
     if (!selectedProject || !selectedSession?.id || selectedSession.id.startsWith('new-session-')) {

--- a/src/components/chat/view/subcomponents/SessionTabBar.tsx
+++ b/src/components/chat/view/subcomponents/SessionTabBar.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useRef } from 'react';
+import { X, Columns2, Loader2, CircleDot } from 'lucide-react';
+import { cn } from '../../../../lib/utils';
+import { useSessionTabsStore } from '../../../../stores/useSessionTabsStore';
+import SessionProviderLogo from '../../../SessionProviderLogo';
+import type { SessionTab } from '../../../../types/sessionTabs';
+
+function tabDisplayName(tab: SessionTab): string {
+  return tab.session.summary || tab.session.title || tab.session.name || tab.id.slice(0, 8);
+}
+
+function TabItem({
+  tab,
+  isActive,
+  isSecondary,
+  onActivate,
+  onClose,
+  onSplitOpen,
+  dragIndex,
+  onDragStart,
+  onDragOver,
+  onDrop,
+}: {
+  tab: SessionTab;
+  isActive: boolean;
+  isSecondary: boolean;
+  onActivate: () => void;
+  onClose: (e: React.MouseEvent) => void;
+  onSplitOpen: (e: React.MouseEvent) => void;
+  dragIndex: number;
+  onDragStart: (idx: number) => void;
+  onDragOver: (e: React.DragEvent, idx: number) => void;
+  onDrop: (e: React.DragEvent, idx: number) => void;
+}) {
+  const bgStatus = useSessionTabsStore((s) => s.backgroundStatus[tab.id]);
+  const isLoading = bgStatus?.isLoading ?? false;
+  const hasUnread = bgStatus?.hasUnread ?? false;
+  const tokenCount = bgStatus?.tokenCount ?? 0;
+
+  const statusIcon = isLoading ? (
+    <Loader2 className="w-3 h-3 flex-shrink-0 animate-spin text-amber-500" />
+  ) : hasUnread ? (
+    <CircleDot className="w-3 h-3 flex-shrink-0 text-emerald-500" />
+  ) : null;
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center gap-1.5 px-3 py-1.5 text-xs cursor-pointer select-none border-b-2 transition-colors min-w-0 max-w-[200px] shrink-0',
+        isActive && 'border-primary bg-accent/60 text-accent-foreground',
+        isSecondary && !isActive && 'border-blue-400/60 bg-blue-50/30 dark:bg-blue-950/20 text-foreground/90',
+        !isActive && !isSecondary && 'border-transparent text-muted-foreground hover:text-foreground hover:bg-accent/30',
+      )}
+      draggable
+      onDragStart={() => onDragStart(dragIndex)}
+      onDragOver={(e) => onDragOver(e, dragIndex)}
+      onDrop={(e) => onDrop(e, dragIndex)}
+      onClick={onActivate}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onSplitOpen(e);
+      }}
+      title={tabDisplayName(tab)}
+    >
+      <SessionProviderLogo provider={tab.provider} className="w-3.5 h-3.5 flex-shrink-0" />
+
+      {statusIcon}
+
+      <span className={cn('truncate', hasUnread && 'font-medium')}>{tabDisplayName(tab)}</span>
+
+      {isLoading && tokenCount > 0 && (
+        <span className="text-[10px] text-muted-foreground/70 tabular-nums flex-shrink-0">
+          {tokenCount > 999 ? `${Math.round(tokenCount / 1000)}k` : tokenCount}
+        </span>
+      )}
+
+      <button
+        className="ml-auto flex-shrink-0 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-destructive/10 transition-opacity"
+        onClick={onClose}
+        aria-label="Close tab"
+      >
+        <X className="w-3 h-3" />
+      </button>
+    </div>
+  );
+}
+
+export default function SessionTabBar() {
+  const tabs = useSessionTabsStore((s) => s.tabs);
+  const activeTabId = useSessionTabsStore((s) => s.activeTabId);
+  const secondaryTabId = useSessionTabsStore((s) => s.secondaryTabId);
+  const splitMode = useSessionTabsStore((s) => s.splitMode);
+  const { setActiveTab, removeTab, reorderTab, enableSplit, disableSplit } = useSessionTabsStore();
+
+  const dragIndexRef = useRef<number | null>(null);
+
+  const handleDragStart = useCallback((idx: number) => {
+    dragIndexRef.current = idx;
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, _idx: number) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent, toIdx: number) => {
+      e.preventDefault();
+      const fromIdx = dragIndexRef.current;
+      if (fromIdx !== null && fromIdx !== toIdx) {
+        reorderTab(fromIdx, toIdx);
+      }
+      dragIndexRef.current = null;
+    },
+    [reorderTab],
+  );
+
+  if (tabs.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center border-b border-border/40 bg-background/80 backdrop-blur-sm overflow-x-auto scrollbar-none">
+      <div className="flex items-center min-w-0 flex-1">
+        {tabs.map((tab, idx) => (
+          <TabItem
+            key={tab.id}
+            tab={tab}
+            isActive={tab.id === activeTabId}
+            isSecondary={splitMode && tab.id === secondaryTabId}
+            onActivate={() => setActiveTab(tab.id)}
+            onClose={(e) => {
+              e.stopPropagation();
+              removeTab(tab.id);
+            }}
+            onSplitOpen={(e) => {
+              e.stopPropagation();
+              if (splitMode && secondaryTabId === tab.id) {
+                disableSplit();
+              } else if (tab.id !== activeTabId) {
+                enableSplit(tab.id);
+              }
+            }}
+            dragIndex={idx}
+            onDragStart={handleDragStart}
+            onDragOver={handleDragOver}
+            onDrop={handleDrop}
+          />
+        ))}
+      </div>
+
+      {tabs.length >= 2 && (
+        <button
+          className={cn(
+            'flex-shrink-0 p-1.5 mx-1 rounded hover:bg-accent/50 transition-colors',
+            splitMode && 'text-primary bg-accent/40',
+          )}
+          onClick={() => {
+            if (splitMode) {
+              disableSplit();
+            } else {
+              const other = tabs.find((t) => t.id !== activeTabId);
+              if (other) enableSplit(other.id);
+            }
+          }}
+          title={splitMode ? 'Exit split view' : 'Split view'}
+        >
+          <Columns2 className="w-3.5 h-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/view/subcomponents/SplitPaneContainer.tsx
+++ b/src/components/chat/view/subcomponents/SplitPaneContainer.tsx
@@ -6,7 +6,7 @@ import type { ProjectSession } from '../../../../types/app';
 interface SplitPaneContainerProps {
   ChatInterfaceComponent: React.ComponentType<ChatInterfaceProps>;
   baseChatProps: ChatInterfaceProps;
-  /** All projects for resolving secondary tab's project */
+  /** All projects for resolving each tab's project */
   projects: Array<{ name: string; sessions?: ProjectSession[]; [k: string]: unknown }>;
 }
 
@@ -21,14 +21,27 @@ function readStoredRatio(): number {
   return Number.isFinite(n) && n >= SPLIT_MIN_WIDTH_PCT && n <= SPLIT_MAX_WIDTH_PCT ? n : 50;
 }
 
+/**
+ * Renders one ChatInterface instance per open tab and keeps them ALL mounted.
+ * Switching tabs is a pure CSS display toggle — no unmount/remount, no API reload.
+ *
+ * Layout:
+ *  - Non-split: active tab is `position:absolute; inset:0`, all others are `display:none`.
+ *  - Split:     primary (left) and secondary (right) are positioned absolutely;
+ *               all other tabs are `display:none`.
+ *
+ * The draggable divider is rendered as a separate absolutely-positioned element
+ * so it doesn't affect the tab instances' layout.
+ */
 export default function SplitPaneContainer({
   ChatInterfaceComponent,
   baseChatProps,
   projects,
 }: SplitPaneContainerProps) {
+  const tabs = useSessionTabsStore((s) => s.tabs);
+  const activeTabId = useSessionTabsStore((s) => s.activeTabId);
   const splitMode = useSessionTabsStore((s) => s.splitMode);
   const secondaryTabId = useSessionTabsStore((s) => s.secondaryTabId);
-  const secondaryTab = useSessionTabsStore((s) => s.tabs.find((t) => t.id === secondaryTabId));
 
   const [splitRatio, setSplitRatio] = useState(readStoredRatio);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -63,32 +76,87 @@ export default function SplitPaneContainer({
     document.addEventListener('mouseup', onMouseUp);
   }, []);
 
-  if (!splitMode || !secondaryTab) {
+  // No tabs yet (initial load before any session is selected).
+  if (tabs.length === 0) {
     return <ChatInterfaceComponent {...baseChatProps} />;
   }
 
-  const secondaryProject = projects.find((p) => p.name === secondaryTab.projectName) ?? baseChatProps.selectedProject;
-
-  const secondaryProps: ChatInterfaceProps = {
-    ...baseChatProps,
-    selectedProject: secondaryProject as ChatInterfaceProps['selectedProject'],
-    selectedSession: secondaryTab.session,
-  };
-
   return (
-    <div ref={containerRef} className="flex h-full w-full min-w-0">
-      <div className="min-w-0 overflow-hidden" style={{ width: `${splitRatio}%` }}>
-        <ChatInterfaceComponent {...baseChatProps} />
-      </div>
+    <div ref={containerRef} className="relative h-full w-full min-w-0 overflow-hidden">
+      {tabs.map((tab) => {
+        const isPrimary = tab.id === activeTabId;
+        const isSecondary = splitMode && tab.id === secondaryTabId;
 
-      <div
-        className="w-1 flex-shrink-0 cursor-col-resize hover:bg-primary/20 active:bg-primary/30 bg-border/30 transition-colors"
-        onMouseDown={handleResizeStart}
-      />
+        // Resolve the project for this specific tab.
+        const tabProject =
+          (projects.find((p) => p.name === tab.projectName) as ChatInterfaceProps['selectedProject']) ??
+          baseChatProps.selectedProject;
 
-      <div className="min-w-0 overflow-hidden flex-1">
-        <ChatInterfaceComponent {...secondaryProps} />
-      </div>
+        // Compute CSS positioning for this pane.
+        let paneStyle: React.CSSProperties;
+        if (!isPrimary && !isSecondary) {
+          // Hidden: keep mounted but invisible (display:none preserves scroll & state).
+          paneStyle = { display: 'none' };
+        } else if (!splitMode) {
+          // Single-pane: fill the entire container.
+          paneStyle = { position: 'absolute', inset: 0 };
+        } else if (isPrimary) {
+          // Left pane: 0 → splitRatio%, with 2 px gap for the divider.
+          paneStyle = {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            bottom: 0,
+            right: `calc(${100 - splitRatio}% + 2px)`,
+          };
+        } else {
+          // Right pane: splitRatio% → 100%, with 2 px gap for the divider.
+          paneStyle = {
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            bottom: 0,
+            left: `calc(${splitRatio}% + 2px)`,
+          };
+        }
+
+        // Props overrides for each tab instance.
+        // Session-specific reactive props (external file changes, intake flows)
+        // only go to the active primary tab to avoid cross-instance interference.
+        const tabChatProps: ChatInterfaceProps = {
+          ...baseChatProps,
+          selectedProject: tabProject,
+          selectedSession: tab.session,
+          externalMessageUpdate: isPrimary ? baseChatProps.externalMessageUpdate : 0,
+          pendingAutoIntake: isPrimary ? baseChatProps.pendingAutoIntake : null,
+          importedProjectAnalysisPrompt: isPrimary
+            ? baseChatProps.importedProjectAnalysisPrompt
+            : null,
+        };
+
+        return (
+          <div key={tab.tabKey} style={paneStyle} className="overflow-hidden">
+            <ChatInterfaceComponent {...tabChatProps} />
+          </div>
+        );
+      })}
+
+      {/* Draggable divider — absolutely positioned, above all panes (z-10). */}
+      {splitMode && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: `${splitRatio}%`,
+            width: 4,
+            transform: 'translateX(-50%)',
+            zIndex: 10,
+          }}
+          className="cursor-col-resize hover:bg-primary/20 active:bg-primary/30 bg-border/30 transition-colors"
+          onMouseDown={handleResizeStart}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/chat/view/subcomponents/SplitPaneContainer.tsx
+++ b/src/components/chat/view/subcomponents/SplitPaneContainer.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { useSessionTabsStore } from '../../../../stores/useSessionTabsStore';
+import type { ChatInterfaceProps } from '../../types/types';
+import type { ProjectSession } from '../../../../types/app';
+
+interface SplitPaneContainerProps {
+  ChatInterfaceComponent: React.ComponentType<ChatInterfaceProps>;
+  baseChatProps: ChatInterfaceProps;
+  /** All projects for resolving secondary tab's project */
+  projects: Array<{ name: string; sessions?: ProjectSession[]; [k: string]: unknown }>;
+}
+
+const SPLIT_MIN_WIDTH_PCT = 25;
+const SPLIT_MAX_WIDTH_PCT = 75;
+const SPLIT_STORAGE_KEY = 'dr-claw-split-ratio';
+
+function readStoredRatio(): number {
+  if (typeof window === 'undefined') return 50;
+  const v = window.localStorage.getItem(SPLIT_STORAGE_KEY);
+  const n = v ? Number(v) : NaN;
+  return Number.isFinite(n) && n >= SPLIT_MIN_WIDTH_PCT && n <= SPLIT_MAX_WIDTH_PCT ? n : 50;
+}
+
+export default function SplitPaneContainer({
+  ChatInterfaceComponent,
+  baseChatProps,
+  projects,
+}: SplitPaneContainerProps) {
+  const splitMode = useSessionTabsStore((s) => s.splitMode);
+  const secondaryTabId = useSessionTabsStore((s) => s.secondaryTabId);
+  const secondaryTab = useSessionTabsStore((s) => s.tabs.find((t) => t.id === secondaryTabId));
+
+  const [splitRatio, setSplitRatio] = useState(readStoredRatio);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isResizing = useRef(false);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isResizing.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isResizing.current || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const pct = ((ev.clientX - rect.left) / rect.width) * 100;
+      setSplitRatio(Math.min(SPLIT_MAX_WIDTH_PCT, Math.max(SPLIT_MIN_WIDTH_PCT, pct)));
+    };
+
+    const onMouseUp = () => {
+      isResizing.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      setSplitRatio((r) => {
+        window.localStorage.setItem(SPLIT_STORAGE_KEY, String(Math.round(r)));
+        return r;
+      });
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, []);
+
+  if (!splitMode || !secondaryTab) {
+    return <ChatInterfaceComponent {...baseChatProps} />;
+  }
+
+  const secondaryProject = projects.find((p) => p.name === secondaryTab.projectName) ?? baseChatProps.selectedProject;
+
+  const secondaryProps: ChatInterfaceProps = {
+    ...baseChatProps,
+    selectedProject: secondaryProject as ChatInterfaceProps['selectedProject'],
+    selectedSession: secondaryTab.session,
+  };
+
+  return (
+    <div ref={containerRef} className="flex h-full w-full min-w-0">
+      <div className="min-w-0 overflow-hidden" style={{ width: `${splitRatio}%` }}>
+        <ChatInterfaceComponent {...baseChatProps} />
+      </div>
+
+      <div
+        className="w-1 flex-shrink-0 cursor-col-resize hover:bg-primary/20 active:bg-primary/30 bg-border/30 transition-colors"
+        onMouseDown={handleResizeStart}
+      />
+
+      <div className="min-w-0 overflow-hidden flex-1">
+        <ChatInterfaceComponent {...secondaryProps} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -60,9 +60,9 @@ function MainContent({
   onChatFromReference,
   newSessionMode,
   onNewSessionModeChange,
-  sessionNavigationSource,
-  onResetNavigationSource,
-  onNewSession,
+  sessionNavigationSource: _sessionNavigationSource,
+  onResetNavigationSource: _onResetNavigationSource,
+  onNewSession: _onNewSession,
 }: MainContentProps) {
   const { preferences } = useUiPreferences();
   const { autoExpandTools, showRawParameters, showThinking, autoScrollToBottom, sendByCtrlEnter } = preferences;

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 import ChatInterface from '../../chat/view/ChatInterface';
 import SkillsDashboard from '../../SkillsDashboard';
@@ -10,12 +10,11 @@ import ProjectDashboard from '../../project-dashboard/view/ProjectDashboard';
 import TrashDashboard from '../../project-dashboard/view/TrashDashboard';
 import NewsDashboard from '../../news-dashboard/view/NewsDashboard';
 
-import ChatTabBar from '../../chat/view/ChatTabBar';
-import { useChatTabs } from '../../../hooks/useChatTabs';
 import MainContentHeader from './subcomponents/MainContentHeader';
 import MainContentStateView from './subcomponents/MainContentStateView';
+import SessionTabBar from '../../chat/view/subcomponents/SessionTabBar';
+import SplitPaneContainer from '../../chat/view/subcomponents/SplitPaneContainer';
 import type { MainContentProps } from '../types/types';
-import { resolveChatTabSyncAction } from './chatTabSync';
 
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
 import { useUiPreferences } from '../../../hooks/useUiPreferences';
@@ -70,74 +69,6 @@ function MainContent({
 
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const shouldShowTasksTab = false;
-
-  const handleActivateBlankTab = useCallback(() => {
-    if (selectedProject && onNewSession) {
-      onNewSession(selectedProject, newSessionMode);
-    }
-  }, [selectedProject, onNewSession, newSessionMode]);
-
-  const chatTabs = useChatTabs(
-    selectedProject,
-    onNavigateToSession,
-    handleActivateBlankTab,
-  );
-
-  const {
-    activeTab: chatActiveTab,
-    tabs: chatTabList,
-    openNewTab,
-    openTab,
-    updateActiveTabSession,
-    switchTab,
-    closeTab,
-  } = chatTabs;
-  const chatActiveTabSessionId = chatActiveTab?.sessionId;
-  const chatTabCount = chatTabList.length;
-
-  // Sync selectedSession changes into tab state using navigation source to
-  // distinguish user sidebar clicks from system session-created events. Runs
-  // on first render too so a pre-selected session (e.g. from URL) gets a tab.
-  useEffect(() => {
-    const currId = selectedSession?.id ?? null;
-
-    const action = resolveChatTabSyncAction({
-      activeAppTab: activeTab,
-      hasSelectedProject: Boolean(selectedProject),
-      nextSessionId: currId,
-      activeChatTabSessionId: chatActiveTabSessionId,
-      tabCount: chatTabCount,
-      navigationSource: sessionNavigationSource,
-    });
-
-    if (action === 'open-new-tab') {
-      openNewTab();
-    } else if (action === 'update-active-tab-session' && currId && selectedProject) {
-      updateActiveTabSession(selectedSession!, selectedProject);
-    } else if (action === 'open-tab' && currId && selectedProject) {
-      openTab(selectedSession!, selectedProject);
-    }
-
-    if (action !== 'noop') {
-      onResetNavigationSource();
-    }
-  }, [
-    selectedSession,
-    selectedProject,
-    activeTab,
-    sessionNavigationSource,
-    chatActiveTabSessionId,
-    chatTabCount,
-    openNewTab,
-    openTab,
-    updateActiveTabSession,
-    onResetNavigationSource,
-  ]);
-
-  // When the active tab has no session (new chat via [+]), pass null to ChatInterface
-  const effectiveSession = chatActiveTabSessionId === null
-    ? null
-    : selectedSession;
 
   useEffect(() => {
     if (selectedProject && selectedProject !== currentProject) {
@@ -222,7 +153,6 @@ function MainContent({
           <SkillsDashboard
             onSendToChat={(command: string) => {
               queueSkillCommandDraft(command);
-              // Select the most recent project if available, then switch to chat
               const recentProject = projects?.[0];
               if (recentProject) {
                 onProjectSelect(recentProject);
@@ -323,49 +253,44 @@ function MainContent({
       <div className="flex-1 flex min-h-0 overflow-hidden">
         <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
           <div className={`h-full flex flex-col ${activeTab === 'chat' ? '' : 'hidden'}`}>
-            <ChatTabBar
-              tabs={chatTabList}
-              processingSessions={processingSessions}
-              onSwitchTab={switchTab}
-              onCloseTab={closeTab}
-              onNewTab={() => {
-                if (selectedProject && onNewSession) {
-                  onNewSession(selectedProject);
-                }
-                openNewTab();
-              }}
-            />
-            <ErrorBoundary showDetails>
-              <ChatInterface
-                selectedProject={selectedProject}
-                selectedSession={effectiveSession}
-                ws={ws}
-                sendMessage={sendMessage}
-                latestMessage={latestMessage}
-                onInputFocusChange={onInputFocusChange}
-                onSessionActive={onSessionActive}
-                onSessionInactive={onSessionInactive}
-                onSessionProcessing={onSessionProcessing}
-                onSessionNotProcessing={onSessionNotProcessing}
-                processingSessions={processingSessions}
-                onReplaceTemporarySession={onReplaceTemporarySession}
-                onNavigateToSession={onNavigateToSession}
-                onShowSettings={onShowSettings}
-                autoExpandTools={autoExpandTools}
-                showRawParameters={showRawParameters}
-                showThinking={showThinking}
-                autoScrollToBottom={autoScrollToBottom}
-                sendByCtrlEnter={sendByCtrlEnter}
-                externalMessageUpdate={externalMessageUpdate}
-                onStartWorkspaceQa={onStartWorkspaceQa}
-                pendingAutoIntake={pendingAutoIntake}
-                clearPendingAutoIntake={clearPendingAutoIntake}
-                importedProjectAnalysisPrompt={importedProjectAnalysisPrompt}
-                clearImportedProjectAnalysisPrompt={clearImportedProjectAnalysisPrompt}
-                newSessionMode={newSessionMode}
-                onNewSessionModeChange={onNewSessionModeChange}
-              />
-            </ErrorBoundary>
+            <SessionTabBar />
+            <div className="flex-1 min-h-0">
+              <ErrorBoundary showDetails>
+                <SplitPaneContainer
+                  ChatInterfaceComponent={ChatInterface}
+                  baseChatProps={{
+                    selectedProject,
+                    selectedSession,
+                    ws,
+                    sendMessage,
+                    latestMessage,
+                    onInputFocusChange,
+                    onSessionActive,
+                    onSessionInactive,
+                    onSessionProcessing,
+                    onSessionNotProcessing,
+                    processingSessions,
+                    onReplaceTemporarySession,
+                    onNavigateToSession,
+                    onShowSettings,
+                    autoExpandTools,
+                    showRawParameters,
+                    showThinking,
+                    autoScrollToBottom,
+                    sendByCtrlEnter,
+                    externalMessageUpdate,
+                    onStartWorkspaceQa,
+                    pendingAutoIntake,
+                    clearPendingAutoIntake,
+                    importedProjectAnalysisPrompt,
+                    clearImportedProjectAnalysisPrompt,
+                    newSessionMode,
+                    onNewSessionModeChange,
+                  }}
+                  projects={projects}
+                />
+              </ErrorBoundary>
+            </div>
           </div>
 
           {activeTab === 'survey' && (

--- a/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarSessionItem.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '../../../ui/badge';
 import { Button } from '../../../ui/button';
-import { Check, Clock, Edit2, Trash2, X } from 'lucide-react';
+import { Check, Clock, Edit2, Loader2, Trash2, X } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { cn } from '../../../../lib/utils';
 import { formatTimeAgo } from '../../../../utils/dateUtils';
@@ -8,6 +8,7 @@ import type { Project, ProjectSession, SessionProvider } from '../../../../types
 import type { SessionWithProvider, TouchHandlerFactory } from '../../types/types';
 import { createSessionViewModel } from '../../utils/utils';
 import SessionProviderLogo from '../../../SessionProviderLogo';
+import { useSessionTabsStore } from '../../../../stores/useSessionTabsStore';
 
 const STAGE_TAG_TONE_BY_KEY: Record<string, string> = {
   survey: 'border-sky-200/80 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/30 dark:text-sky-300',
@@ -59,6 +60,10 @@ export default function SidebarSessionItem({
 }: SidebarSessionItemProps) {
   const sessionView = createSessionViewModel(session, currentTime, t);
   const isSelected = selectedSession?.id === session.id;
+  const bgStatus = useSessionTabsStore((s) => s.backgroundStatus[session.id]);
+  const isBackgroundLoading = bgStatus?.isLoading ?? false;
+  const hasUnread = bgStatus?.hasUnread ?? false;
+  const bgTokenCount = bgStatus?.tokenCount ?? 0;
 
   const selectMobileSession = () => {
     onProjectSelect(project);
@@ -190,21 +195,44 @@ export default function SidebarSessionItem({
                   {formatTimeAgo(sessionView.sessionTime, currentTime, t)}
                 </span>
                 <div className={`${rightMetaClassName} group-hover:opacity-0 transition-opacity`}>
-                  <Badge
-                    variant="secondary"
-                    className="text-xs px-1 py-0 min-w-[1.5rem] justify-center"
-                  >
-                    {sessionView.messageCount}
-                  </Badge>
-                  <Badge
-                    variant="outline"
-                    className="text-[10px] px-1.5 py-0"
-                  >
-                    {modeBadgeLabel}
-                  </Badge>
-                  <span className="opacity-70">
-                    <SessionProviderLogo provider={session.__provider} className="w-3 h-3" />
-                  </span>
+                  {isBackgroundLoading ? (
+                    <>
+                      <Loader2 className="w-3 h-3 animate-spin text-amber-500" />
+                      {bgTokenCount > 0 && (
+                        <span className="text-[10px] tabular-nums text-amber-600 dark:text-amber-400">
+                          {bgTokenCount > 999 ? `${Math.round(bgTokenCount / 1000)}k` : bgTokenCount}
+                        </span>
+                      )}
+                    </>
+                  ) : hasUnread ? (
+                    <>
+                      <span className="w-2 h-2 rounded-full bg-emerald-500 flex-shrink-0" />
+                      <Badge
+                        variant="secondary"
+                        className="text-xs px-1 py-0 min-w-[1.5rem] justify-center"
+                      >
+                        {sessionView.messageCount}
+                      </Badge>
+                    </>
+                  ) : (
+                    <>
+                      <Badge
+                        variant="secondary"
+                        className="text-xs px-1 py-0 min-w-[1.5rem] justify-center"
+                      >
+                        {sessionView.messageCount}
+                      </Badge>
+                      <Badge
+                        variant="outline"
+                        className="text-[10px] px-1.5 py-0"
+                      >
+                        {modeBadgeLabel}
+                      </Badge>
+                      <span className="opacity-70">
+                        <SessionProviderLogo provider={session.__provider} className="w-3 h-3" />
+                      </span>
+                    </>
+                  )}
                 </div>
               </div>
               {stageTagBadges}

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -21,6 +21,7 @@ import type {
   SessionTag,
   TrashProject,
 } from '../types/app';
+import { useSessionTabsStore } from '../stores/useSessionTabsStore';
 
 declare global {
   interface Window {
@@ -707,6 +708,11 @@ export function useProjectsState({
       setSelectedSession(sessionToSelect);
     }
 
+    if (sessionToSelect) {
+      const pName = projectToSelect?.name || selectedProject?.name || '';
+      useSessionTabsStore.getState().addTab(sessionToSelect, pName);
+    }
+
     if (shouldSwitchTab) {
       setActiveTab('chat');
     }
@@ -745,6 +751,9 @@ export function useProjectsState({
   const handleSessionSelect = useCallback(
     (session: ProjectSession) => {
       setSelectedSession(session);
+
+      const projectName = session.__projectName || selectedProject?.name || '';
+      useSessionTabsStore.getState().addTab(session, projectName);
 
       if (session.mode) {
         persistNewSessionMode(session.mode);

--- a/src/hooks/useProjectsState.ts
+++ b/src/hooks/useProjectsState.ts
@@ -785,6 +785,7 @@ export function useProjectsState({
 
   const handleNewSession = useCallback(
     (project: Project, mode: SessionMode = 'research') => {
+      useSessionTabsStore.getState().addNewTab(project.name, mode);
       setSessionNavigationSource('user');
       setSelectedProject(project);
       setSelectedSession(null);
@@ -802,6 +803,7 @@ export function useProjectsState({
 
   const handleStartWorkspaceQa = useCallback(
     (project: Project, prompt: string) => {
+      useSessionTabsStore.getState().addNewTab(project.name, 'workspace_qa');
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab('chat');
@@ -819,6 +821,7 @@ export function useProjectsState({
 
   const handleChatFromReference = useCallback(
     (project: Project, ref: Reference) => {
+      useSessionTabsStore.getState().addNewTab(project.name, 'research');
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab('chat');
@@ -840,6 +843,7 @@ export function useProjectsState({
 
   const handleProjectCreatedWithIntake = useCallback(
     (project: Project, options?: ProjectCreationOptions) => {
+      useSessionTabsStore.getState().addNewTab(project.name, 'research');
       setSelectedProject(project);
       setSelectedSession(null);
       setActiveTab('chat');

--- a/src/stores/__tests__/useSessionTabsStore.test.ts
+++ b/src/stores/__tests__/useSessionTabsStore.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { isSessionVisibleInTabs, useSessionTabsStore } from '../useSessionTabsStore';
+
+describe('useSessionTabsStore', () => {
+  beforeEach(() => {
+    useSessionTabsStore.setState({
+      tabs: [],
+      activeTabId: null,
+      splitMode: false,
+      secondaryTabId: null,
+      snapshots: {},
+      backgroundStatus: {},
+    });
+  });
+
+  it('opens a distinct temporary tab for a new conversation', () => {
+    const store = useSessionTabsStore.getState();
+    store.addTab({ id: 'existing', __provider: 'claude' }, 'project-a');
+
+    const temporaryId = useSessionTabsStore.getState().addNewTab('project-a', 'workspace_qa');
+    const state = useSessionTabsStore.getState();
+
+    expect(temporaryId).toMatch(/^new-session-/);
+    expect(state.activeTabId).toBe(temporaryId);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(['existing', temporaryId]);
+    expect(state.tabs[1].session.mode).toBe('workspace_qa');
+  });
+
+  it('keeps the tab key stable when the server assigns the real session id', () => {
+    const temporaryId = useSessionTabsStore.getState().addNewTab('project-a');
+    const originalKey = useSessionTabsStore.getState().tabs[0].tabKey;
+
+    useSessionTabsStore.getState().replaceTabSessionId(
+      temporaryId,
+      { id: 'real-session', __provider: 'codex' },
+      'project-a',
+    );
+
+    expect(useSessionTabsStore.getState().tabs[0]).toMatchObject({
+      id: 'real-session',
+      tabKey: originalKey,
+      provider: 'codex',
+    });
+  });
+
+  it('treats both split panes as visible', () => {
+    expect(isSessionVisibleInTabs({
+      activeTabId: 'primary',
+      splitMode: true,
+      secondaryTabId: 'secondary',
+    }, 'secondary')).toBe(true);
+
+    expect(isSessionVisibleInTabs({
+      activeTabId: 'primary',
+      splitMode: false,
+      secondaryTabId: 'secondary',
+    }, 'secondary')).toBe(false);
+  });
+
+  it('clears unread without discarding a background loading state', () => {
+    const store = useSessionTabsStore.getState();
+    store.addTab({ id: 'one' }, 'project-a');
+    store.addTab({ id: 'two' }, 'project-a');
+    useSessionTabsStore.getState().setBackgroundStatus('one', {
+      isLoading: true,
+      hasUnread: true,
+      statusText: 'Working',
+    });
+
+    useSessionTabsStore.getState().setActiveTab('one');
+
+    expect(useSessionTabsStore.getState().backgroundStatus.one).toMatchObject({
+      isLoading: true,
+      hasUnread: false,
+      statusText: 'Working',
+    });
+  });
+});

--- a/src/stores/useSessionTabsStore.ts
+++ b/src/stores/useSessionTabsStore.ts
@@ -63,6 +63,9 @@ export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
       return;
     }
     const newTab: SessionTab = {
+      tabKey: (typeof crypto !== 'undefined' && crypto.randomUUID)
+        ? crypto.randomUUID()
+        : `tab-${Date.now()}-${Math.random().toString(36).slice(2)}`,
       id: session.id,
       session,
       projectName,
@@ -106,14 +109,11 @@ export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
   },
 
   setActiveTab: (sessionId) => {
-    const { backgroundStatus } = get();
-    const bg = backgroundStatus[sessionId];
-    if (bg && (bg.hasUnread || bg.isLoading === false)) {
-      const { [sessionId]: _, ...rest } = backgroundStatus;
-      set({ activeTabId: sessionId, backgroundStatus: rest });
-    } else {
-      set({ activeTabId: sessionId });
-    }
+    // Always clear background tracking when the tab becomes active.
+    // If the session was loading in the background, the foreground loading
+    // spinner will take over; there's no need to keep a background entry.
+    const { [sessionId]: _, ...rest } = get().backgroundStatus;
+    set({ activeTabId: sessionId, backgroundStatus: rest });
   },
 
   reorderTab: (fromIndex, toIndex) => {

--- a/src/stores/useSessionTabsStore.ts
+++ b/src/stores/useSessionTabsStore.ts
@@ -1,0 +1,205 @@
+import { create } from 'zustand';
+import type { ProjectSession, SessionProvider } from '../types/app';
+import type {
+  BackgroundSessionStatus,
+  SessionSnapshot,
+  SessionTab,
+} from '../types/sessionTabs';
+
+interface SessionTabsState {
+  /** Ordered list of open tabs */
+  tabs: SessionTab[];
+  /** ID of the currently active (visible) tab */
+  activeTabId: string | null;
+  /** Whether split-pane mode is on */
+  splitMode: boolean;
+  /** ID of the tab shown in the secondary (right) pane */
+  secondaryTabId: string | null;
+  /** Cached state snapshots keyed by session ID */
+  snapshots: Record<string, SessionSnapshot>;
+  /** Live status for background (non-visible) sessions */
+  backgroundStatus: Record<string, BackgroundSessionStatus>;
+
+  // --- Tab CRUD ---
+  addTab: (session: ProjectSession, projectName: string) => void;
+  removeTab: (sessionId: string) => void;
+  setActiveTab: (sessionId: string) => void;
+  reorderTab: (fromIndex: number, toIndex: number) => void;
+
+  // --- Split pane ---
+  enableSplit: (secondarySessionId: string) => void;
+  disableSplit: () => void;
+
+  // --- Snapshot cache ---
+  saveSnapshot: (sessionId: string, snapshot: SessionSnapshot) => void;
+  getSnapshot: (sessionId: string) => SessionSnapshot | undefined;
+  clearSnapshot: (sessionId: string) => void;
+
+  // --- Background status ---
+  setBackgroundStatus: (sessionId: string, patch: Partial<BackgroundSessionStatus>) => void;
+  clearBackgroundStatus: (sessionId: string) => void;
+  /** Mark a tab as read (clear hasUnread and loading indicators) */
+  markTabRead: (sessionId: string) => void;
+
+  /** Replace the temporary new-session-* tab id with the real session id from the server */
+  replaceTabSessionId: (oldId: string, realSession: ProjectSession, projectName: string) => void;
+}
+
+const MAX_OPEN_TABS = 20;
+
+export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
+  tabs: [],
+  activeTabId: null,
+  splitMode: false,
+  secondaryTabId: null,
+  snapshots: {},
+  backgroundStatus: {},
+
+  addTab: (session, projectName) => {
+    const { tabs } = get();
+    const existing = tabs.find((t) => t.id === session.id);
+    if (existing) {
+      set({ activeTabId: session.id });
+      return;
+    }
+    const newTab: SessionTab = {
+      id: session.id,
+      session,
+      projectName,
+      provider: session.__provider || 'claude',
+      openedAt: Date.now(),
+    };
+    const next = [...tabs, newTab];
+    if (next.length > MAX_OPEN_TABS) {
+      const oldest = next.find((t) => t.id !== get().activeTabId && t.id !== get().secondaryTabId);
+      if (oldest) {
+        const idx = next.indexOf(oldest);
+        next.splice(idx, 1);
+        const { snapshots, backgroundStatus } = get();
+        const { [oldest.id]: _s, ...restSnap } = snapshots;
+        const { [oldest.id]: _b, ...restBg } = backgroundStatus;
+        set({ tabs: next, activeTabId: session.id, snapshots: restSnap, backgroundStatus: restBg });
+        return;
+      }
+    }
+    set({ tabs: next, activeTabId: session.id });
+  },
+
+  removeTab: (sessionId) => {
+    const { tabs, activeTabId, secondaryTabId, snapshots, backgroundStatus } = get();
+    const idx = tabs.findIndex((t) => t.id === sessionId);
+    if (idx === -1) return;
+    const next = tabs.filter((t) => t.id !== sessionId);
+    const { [sessionId]: _s, ...restSnap } = snapshots;
+    const { [sessionId]: _b, ...restBg } = backgroundStatus;
+    const updates: Partial<SessionTabsState> = { tabs: next, snapshots: restSnap, backgroundStatus: restBg };
+
+    if (activeTabId === sessionId) {
+      const neighbor = next[Math.min(idx, next.length - 1)] ?? null;
+      updates.activeTabId = neighbor?.id ?? null;
+    }
+    if (secondaryTabId === sessionId) {
+      updates.secondaryTabId = null;
+      updates.splitMode = false;
+    }
+    set(updates);
+  },
+
+  setActiveTab: (sessionId) => {
+    const { backgroundStatus } = get();
+    const bg = backgroundStatus[sessionId];
+    if (bg && (bg.hasUnread || bg.isLoading === false)) {
+      const { [sessionId]: _, ...rest } = backgroundStatus;
+      set({ activeTabId: sessionId, backgroundStatus: rest });
+    } else {
+      set({ activeTabId: sessionId });
+    }
+  },
+
+  reorderTab: (fromIndex, toIndex) => {
+    const { tabs } = get();
+    if (fromIndex < 0 || fromIndex >= tabs.length || toIndex < 0 || toIndex >= tabs.length) return;
+    const next = [...tabs];
+    const [moved] = next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, moved);
+    set({ tabs: next });
+  },
+
+  enableSplit: (secondarySessionId) => {
+    const { tabs, activeTabId } = get();
+    if (!tabs.find((t) => t.id === secondarySessionId)) return;
+    if (secondarySessionId === activeTabId) return;
+    set({ splitMode: true, secondaryTabId: secondarySessionId });
+  },
+
+  disableSplit: () => {
+    set({ splitMode: false, secondaryTabId: null });
+  },
+
+  saveSnapshot: (sessionId, snapshot) => {
+    set((state) => ({
+      snapshots: { ...state.snapshots, [sessionId]: snapshot },
+    }));
+  },
+
+  getSnapshot: (sessionId) => {
+    return get().snapshots[sessionId];
+  },
+
+  clearSnapshot: (sessionId) => {
+    const { [sessionId]: _, ...rest } = get().snapshots;
+    set({ snapshots: rest });
+  },
+
+  setBackgroundStatus: (sessionId, patch) => {
+    set((state) => {
+      const prev = state.backgroundStatus[sessionId] || {
+        isLoading: false,
+        statusText: null,
+        tokenCount: 0,
+        hasUnread: false,
+        messageSeq: 0,
+      };
+      return {
+        backgroundStatus: {
+          ...state.backgroundStatus,
+          [sessionId]: { ...prev, ...patch },
+        },
+      };
+    });
+  },
+
+  clearBackgroundStatus: (sessionId) => {
+    const { [sessionId]: _, ...rest } = get().backgroundStatus;
+    set({ backgroundStatus: rest });
+  },
+
+  markTabRead: (sessionId) => {
+    const { [sessionId]: _, ...rest } = get().backgroundStatus;
+    set({ backgroundStatus: rest });
+  },
+
+  replaceTabSessionId: (oldId, realSession, projectName) => {
+    set((state) => {
+      const tabs = state.tabs.map((t) =>
+        t.id === oldId
+          ? { ...t, id: realSession.id, session: realSession, projectName, provider: realSession.__provider || t.provider }
+          : t,
+      );
+      const activeTabId = state.activeTabId === oldId ? realSession.id : state.activeTabId;
+      const secondaryTabId = state.secondaryTabId === oldId ? realSession.id : state.secondaryTabId;
+
+      const snapshots = { ...state.snapshots };
+      if (snapshots[oldId]) {
+        snapshots[realSession.id] = snapshots[oldId];
+        delete snapshots[oldId];
+      }
+      const backgroundStatus = { ...state.backgroundStatus };
+      if (backgroundStatus[oldId]) {
+        backgroundStatus[realSession.id] = backgroundStatus[oldId];
+        delete backgroundStatus[oldId];
+      }
+      return { tabs, activeTabId, secondaryTabId, snapshots, backgroundStatus };
+    });
+  },
+}));

--- a/src/stores/useSessionTabsStore.ts
+++ b/src/stores/useSessionTabsStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { ProjectSession, SessionProvider } from '../types/app';
+import type { ProjectSession, SessionMode } from '../types/app';
 import type {
   BackgroundSessionStatus,
   SessionSnapshot,
@@ -22,6 +22,7 @@ interface SessionTabsState {
 
   // --- Tab CRUD ---
   addTab: (session: ProjectSession, projectName: string) => void;
+  addNewTab: (projectName: string, mode?: SessionMode) => string;
   removeTab: (sessionId: string) => void;
   setActiveTab: (sessionId: string) => void;
   reorderTab: (fromIndex: number, toIndex: number) => void;
@@ -46,6 +47,13 @@ interface SessionTabsState {
 }
 
 const MAX_OPEN_TABS = 20;
+
+export function isSessionVisibleInTabs(
+  state: Pick<SessionTabsState, 'activeTabId' | 'splitMode' | 'secondaryTabId'>,
+  sessionId: string,
+) {
+  return state.activeTabId === sessionId || (state.splitMode && state.secondaryTabId === sessionId);
+}
 
 export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
   tabs: [],
@@ -88,6 +96,14 @@ export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
     set({ tabs: next, activeTabId: session.id });
   },
 
+  addNewTab: (projectName, mode = 'research') => {
+    const id = `new-session-${typeof crypto !== 'undefined' && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`}`;
+    get().addTab({ id, mode, __projectName: projectName }, projectName);
+    return id;
+  },
+
   removeTab: (sessionId) => {
     const { tabs, activeTabId, secondaryTabId, snapshots, backgroundStatus } = get();
     const idx = tabs.findIndex((t) => t.id === sessionId);
@@ -109,11 +125,18 @@ export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
   },
 
   setActiveTab: (sessionId) => {
-    // Always clear background tracking when the tab becomes active.
-    // If the session was loading in the background, the foreground loading
-    // spinner will take over; there's no need to keep a background entry.
-    const { [sessionId]: _, ...rest } = get().backgroundStatus;
-    set({ activeTabId: sessionId, backgroundStatus: rest });
+    const currentStatus = get().backgroundStatus[sessionId];
+    if (!currentStatus) {
+      set({ activeTabId: sessionId });
+      return;
+    }
+    set({
+      activeTabId: sessionId,
+      backgroundStatus: {
+        ...get().backgroundStatus,
+        [sessionId]: { ...currentStatus, hasUnread: false },
+      },
+    });
   },
 
   reorderTab: (fromIndex, toIndex) => {
@@ -175,8 +198,14 @@ export const useSessionTabsStore = create<SessionTabsState>((set, get) => ({
   },
 
   markTabRead: (sessionId) => {
-    const { [sessionId]: _, ...rest } = get().backgroundStatus;
-    set({ backgroundStatus: rest });
+    const currentStatus = get().backgroundStatus[sessionId];
+    if (!currentStatus) return;
+    set({
+      backgroundStatus: {
+        ...get().backgroundStatus,
+        [sessionId]: { ...currentStatus, hasUnread: false },
+      },
+    });
   },
 
   replaceTabSessionId: (oldId, realSession, projectName) => {

--- a/src/types/sessionTabs.ts
+++ b/src/types/sessionTabs.ts
@@ -1,0 +1,30 @@
+import type { ChatMessage, TokenBudget } from '../components/chat/types/types';
+import type { ProjectSession, SessionProvider } from './app';
+
+export interface SessionTab {
+  id: string;
+  session: ProjectSession;
+  projectName: string;
+  provider: SessionProvider;
+  openedAt: number;
+}
+
+export interface SessionSnapshot {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  statusText: string | null;
+  tokenCount: number;
+  tokenBudget: TokenBudget | null;
+  scrollTop: number;
+  canAbort: boolean;
+}
+
+export interface BackgroundSessionStatus {
+  isLoading: boolean;
+  statusText: string | null;
+  tokenCount: number;
+  /** True when the session completed in the background and hasn't been viewed yet */
+  hasUnread: boolean;
+  /** Incremented every time a background message arrives so UI can react */
+  messageSeq: number;
+}

--- a/src/types/sessionTabs.ts
+++ b/src/types/sessionTabs.ts
@@ -2,6 +2,10 @@ import type { ChatMessage, TokenBudget } from '../components/chat/types/types';
 import type { ProjectSession, SessionProvider } from './app';
 
 export interface SessionTab {
+  /** Stable identity for this tab slot — never changes, even when the real session
+   *  ID is assigned (replacing the initial `new-session-*` placeholder). Use this
+   *  as the React `key` so the ChatInterface instance stays mounted through ID swaps. */
+  tabKey: string;
   id: string;
   session: ProjectSession;
   projectName: string;


### PR DESCRIPTION
## Summary

- **Instant tab switching** — all `ChatInterface` instances stay mounted simultaneously via CSS `display:none`/`position:absolute` toggling; no unmount/remount/API reload on every tab switch
- **Multi-session tab bar** (`SessionTabBar`) with drag-to-reorder, close button, background loading indicator, and unread dot; hides when only one tab is open
- **Split pane** — right-click a tab or click the split icon to view two sessions side-by-side with a draggable divider (ratio persisted to localStorage)
- **Session isolation** — localStorage keys are scoped per session (`chat_messages_${project}_${sessionId}`) to prevent cross-tab message bleed
- **Stable tab identity** — each tab slot gets a `tabKey` UUID assigned once; used as React `key` so the `ChatInterface` instance survives the `new-session-*` → real-ID replacement without remounting
- **`session-aborted` guard** — only the `ChatInterface` that owns the aborted session handles the event (prevents all mounted instances from each appending an "interrupted" message)
- **Background session status** — Zustand tracks loading/unread state for non-visible tabs; shown in the tab bar

## Architecture

```
AppContent
├── useSessionTabsStore (Zustand) ← addTab called on every session navigation
│   ├── tabs[]  activeTabId  splitMode  secondaryTabId
│   └── backgroundStatus{}  snapshots{}
└── MainContent
    ├── SessionTabBar        (reads store, renders tab chips)
    └── SplitPaneContainer   (renders ONE ChatInterface per tab, all mounted)
        ├── tab[0]: display:none
        ├── tab[1]: position:absolute; inset:0   ← active
        └── tab[2]: display:none
```

## Test plan

- [ ] Open multiple sessions — verify tab bar appears and switching is instant (no loading spinner)
- [ ] Navigate to a session from the sidebar — verify it opens as a new tab
- [ ] Close a tab — verify adjacent tab activates
- [ ] Right-click a tab → split view opens; drag divider resizes; click split icon to exit
- [ ] Send a message in a background tab — verify loading indicator and unread dot appear in tab bar
- [ ] Create a new session — verify `new-session-*` tab is replaced with real session ID without remounting
- [ ] Reload the page — verify split ratio is restored from localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)