### PR TITLE
feat(telemetry): add autoresearch usage tracking

### DIFF
--- a/server/routes/auto-research.js
+++ b/server/routes/auto-research.js
@@ -12,6 +12,7 @@ import { spawnGemini, abortGeminiSession, isGeminiSessionActive } from '../gemin
 import { queryOpenRouter, abortOpenRouterSession, isOpenRouterSessionActive } from '../openrouter.js';
 import { sendAutoResearchCompletionEmail } from '../utils/auto-research-mailer.js';
 import { getGeminiApiKeyForUser, withGeminiApiKeyEnv } from '../utils/geminiApiKey.js';
+import { enqueueTelemetryEvent } from '../telemetry.js';
 
 const router = express.Router();
 
@@ -47,6 +48,34 @@ function normalizePermissionMode(permissionMode) {
     return permissionMode;
   }
   return AUTO_RESEARCH_DEFAULT_PERMISSION_MODE;
+}
+
+function hashProjectPath(projectPath) {
+  if (!projectPath) return null;
+  return crypto.createHash('sha256').update(String(projectPath)).digest('hex').slice(0, 16);
+}
+
+function emitRunTelemetry(name, run, extra = {}) {
+  if (!run) return;
+  try {
+    enqueueTelemetryEvent({
+      name,
+      source: 'auto-research-backend',
+      data: {
+        run_id: run.id,
+        user_id: run.user_id ?? null,
+        project_name: run.project_name ?? null,
+        project_path_hash: hashProjectPath(run.project_path),
+        provider: run.provider ?? null,
+        status: run.status ?? null,
+        total_tasks: run.total_tasks ?? null,
+        completed_tasks: run.completed_tasks ?? null,
+        ...extra,
+      },
+    });
+  } catch (error) {
+    console.error('[AutoResearch] telemetry emit failed:', error?.message || error);
+  }
 }
 
 function abortActiveSession(provider, sessionId) {
@@ -380,27 +409,43 @@ async function runAutoResearch(runId, userId, projectName, projectPath) {
         throw new Error(`Task ${task.id} did not transition to done after execution`);
       }
 
-      autoResearchDb.updateRun(runId, {
+      const afterTaskRun = autoResearchDb.updateRun(runId, {
         completedTasks: pipelineState.completedTaskCount,
         totalTasks: pipelineState.tasks.length,
         currentTaskId: null,
       });
+
+      emitRunTelemetry('autoresearch_run_task_completed', afterTaskRun, {
+        task_id_hash: task.id ? hashProjectPath(String(task.id)) : null,
+        task_stage: task.stage ?? null,
+      });
     }
 
-    autoResearchDb.updateRun(runId, {
+    const completedRun = autoResearchDb.updateRun(runId, {
       status: 'completed',
       currentTaskId: null,
       completedTasks: pipelineState.completedTaskCount,
       totalTasks: pipelineState.tasks.length,
       finishedAt: new Date().toISOString(),
     });
+
+    emitRunTelemetry('autoresearch_run_finished', completedRun, {
+      outcome: 'completed',
+      duration_ms: runState.startedAt ? Date.now() - runState.startedAt : null,
+    });
   } catch (error) {
     const isCancelled = runState.cancelRequested || /cancelled by user/i.test(String(error?.message || ''));
-    autoResearchDb.updateRun(runId, {
+    const finishedRun = autoResearchDb.updateRun(runId, {
       status: isCancelled ? 'cancelled' : 'failed',
       error: error.message,
       currentTaskId: null,
       finishedAt: new Date().toISOString(),
+    });
+
+    emitRunTelemetry('autoresearch_run_finished', finishedRun, {
+      outcome: isCancelled ? 'cancelled' : 'failed',
+      duration_ms: runState.startedAt ? Date.now() - runState.startedAt : null,
+      error_type: error?.name || 'Error',
     });
   } finally {
     activeRuns.delete(runId);
@@ -498,6 +543,13 @@ router.post('/:projectName/start', async (req, res) => {
       provider,
       model,
       permissionMode,
+      startedAt: Date.now(),
+    });
+
+    emitRunTelemetry('autoresearch_run_started', run, {
+      model,
+      permission_mode: permissionMode,
+      actionable_task_count: pipelineState.actionableTaskCount,
     });
 
     void runAutoResearch(runId, userId, projectName, projectPath);
@@ -524,6 +576,12 @@ router.post('/:projectName/cancel', async (req, res) => {
 
     const runtime = activeRuns.get(activeRun.id);
     const sessionStillActive = isRunSessionStillActive(activeRun);
+
+    emitRunTelemetry('autoresearch_run_cancel_requested', activeRun, {
+      had_active_runtime: Boolean(runtime),
+      session_still_active: sessionStillActive,
+    });
+
     if (runtime) {
       runtime.cancelRequested = true;
       if (runtime.sessionId || activeRun.session_id) {

--- a/src/components/AutoResearchHub.tsx
+++ b/src/components/AutoResearchHub.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../utils/api';
+import { emitAutoresearchEvent } from '../utils/autoresearchTelemetry';
 import { AUTO_RESEARCH_PACKS, type LocaleKey, type PackDef } from '../constants/autoResearchPacks';
 import useLocalStorage from '../hooks/useLocalStorage';
 
@@ -170,6 +171,13 @@ export default function AutoResearchHub() {
 
   const [expandedWorkflows, setExpandedWorkflows] = useState<Set<string>>(new Set());
 
+  useEffect(() => {
+    emitAutoresearchEvent('autoresearch_hub_viewed', {
+      pack_count: PACKS.length,
+      workflow_count: PACKS.reduce((sum, p) => sum + p.workflows.length, 0),
+    });
+  }, []);
+
   const copyToClipboard = useCallback((text: string) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedCommand(text);
@@ -182,11 +190,22 @@ export default function AutoResearchHub() {
     const mcpOpt = pack.mcp.find(m => m.key === mcpKey) || pack.mcp[0];
 
     const apiKeys: Record<string, string> = {};
+    let envVarsFilled = 0;
     if (mcpOpt) {
       for (const ev of mcpOpt.envVars) {
-        if (apiKeyInputs[ev.name]) apiKeys[ev.name] = apiKeyInputs[ev.name];
+        if (apiKeyInputs[ev.name]) {
+          apiKeys[ev.name] = apiKeyInputs[ev.name];
+          envVarsFilled += 1;
+        }
       }
     }
+
+    emitAutoresearchEvent('autoresearch_configure_clicked', {
+      pack: pack.name,
+      mcp_key: mcpKey || null,
+      env_vars_required: mcpOpt?.envVars.length ?? 0,
+      env_vars_filled: envVarsFilled,
+    });
 
     setConfiguring(true);
     setConfigResult(null);
@@ -194,16 +213,36 @@ export default function AutoResearchHub() {
       const resp = await api.communityTools.configure(null, mcpKey, apiKeys, null);
       if (!resp.ok) {
         const text = await resp.text();
+        emitAutoresearchEvent('autoresearch_configure_result', {
+          pack: pack.name,
+          mcp_key: mcpKey || null,
+          success: false,
+          error_type: 'http_error',
+          http_status: resp.status,
+        });
         setConfigResult({ success: false, message: `Server error (${resp.status}): ${text}` });
         return;
       }
       const data = await resp.json();
+      emitAutoresearchEvent('autoresearch_configure_result', {
+        pack: pack.name,
+        mcp_key: mcpKey || null,
+        success: Boolean(data.success),
+        error_type: data.success ? null : 'server_reported_error',
+        error_count: Array.isArray(data.errors) ? data.errors.length : 0,
+      });
       setConfigResult({
         success: data.success,
         message: data.success ? t.configSuccess : (data.errors || []).map((e: { error: string }) => e.error).join('; '),
       });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      emitAutoresearchEvent('autoresearch_configure_result', {
+        pack: pack.name,
+        mcp_key: mcpKey || null,
+        success: false,
+        error_type: 'exception',
+      });
       setConfigResult({ success: false, message: msg });
     } finally {
       setConfiguring(false);
@@ -285,7 +324,11 @@ export default function AutoResearchHub() {
                 <button
                   type="button"
                   className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium text-slate-700 hover:bg-sky-100/60 hover:text-slate-900 dark:text-sky-100/80 dark:hover:bg-sky-900/30 dark:hover:text-sky-100"
-                  onClick={() => setGuideCollapsed(!guideCollapsed)}
+                  onClick={() => {
+                    emitAutoresearchEvent('autoresearch_guide_toggled', { collapsed: !guideCollapsed });
+                    setGuideCollapsed(!guideCollapsed);
+                  }}
+                  data-telemetry-id="autoresearch-hub-guide-toggle"
                 >
                   {guideCollapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
                   {guideCollapsed ? t.guideExpand : t.guideCollapse}
@@ -293,7 +336,11 @@ export default function AutoResearchHub() {
                 <button
                   type="button"
                   className="inline-flex h-8 items-center gap-1.5 rounded-full px-3 text-xs font-medium text-slate-700 hover:bg-sky-100/60 hover:text-slate-900 dark:text-sky-100/80 dark:hover:bg-sky-900/30 dark:hover:text-sky-100"
-                  onClick={() => setGuideDismissed(true)}
+                  onClick={() => {
+                    emitAutoresearchEvent('autoresearch_guide_dismissed', {});
+                    setGuideDismissed(true);
+                  }}
+                  data-telemetry-id="autoresearch-hub-guide-dismiss"
                 >
                   <X className="h-4 w-4" />
                   {t.guideDismiss}
@@ -352,7 +399,18 @@ export default function AutoResearchHub() {
                   {/* Collapsible workflows list */}
                   <button
                     type="button"
-                    onClick={() => setExpandedWorkflows(prev => { const n = new Set(prev); n.has(pack.name) ? n.delete(pack.name) : n.add(pack.name); return n; })}
+                    onClick={() => setExpandedWorkflows(prev => {
+                      const n = new Set(prev);
+                      const willExpand = !n.has(pack.name);
+                      emitAutoresearchEvent('autoresearch_pack_expanded', {
+                        pack: pack.name,
+                        expanded: willExpand,
+                        source: 'hub',
+                      });
+                      if (n.has(pack.name)) n.delete(pack.name); else n.add(pack.name);
+                      return n;
+                    })}
+                    data-telemetry-id={`autoresearch-hub-pack-workflows-${pack.name}`}
                     className="mt-3 flex w-full items-center justify-between rounded-lg border border-border/40 bg-muted/30 px-3 py-2 text-left transition-colors hover:bg-muted/60"
                   >
                     <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
@@ -381,7 +439,17 @@ export default function AutoResearchHub() {
                   <div className="border-t border-border/40">
                     <button
                       type="button"
-                      onClick={() => setExpandedConfig(prev => { const n = new Set(prev); n.has(pack.name) ? n.delete(pack.name) : n.add(pack.name); return n; })}
+                      onClick={() => setExpandedConfig(prev => {
+                        const n = new Set(prev);
+                        const willExpand = !n.has(pack.name);
+                        emitAutoresearchEvent('autoresearch_config_section_opened', {
+                          pack: pack.name,
+                          expanded: willExpand,
+                        });
+                        if (n.has(pack.name)) n.delete(pack.name); else n.add(pack.name);
+                        return n;
+                      })}
+                      data-telemetry-id={`autoresearch-hub-config-${pack.name}`}
                       className="flex w-full items-center justify-between px-5 py-3 transition-colors hover:bg-muted/30"
                     >
                       <span className="flex items-center gap-2 text-sm font-semibold text-foreground">
@@ -400,8 +468,19 @@ export default function AutoResearchHub() {
                           {pack.mcp.length > 1 && (
                           <div className="mb-2 flex flex-wrap gap-1.5">
                             {pack.mcp.map(opt => (
-                              <button key={opt.key} type="button" onClick={() => setSelectedMcp(p => ({ ...p, [pack.name]: opt.key }))}
-                                className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all ${mcpKey === opt.key ? 'border-sky-400 bg-sky-100 text-sky-700 shadow-sm dark:border-sky-600 dark:bg-sky-900/40 dark:text-sky-200' : 'border-border/60 bg-background text-muted-foreground hover:bg-muted/60'}`}>
+                              <button
+                                key={opt.key}
+                                type="button"
+                                onClick={() => {
+                                  emitAutoresearchEvent('autoresearch_mcp_selected', {
+                                    pack: pack.name,
+                                    mcp_key: opt.key,
+                                  });
+                                  setSelectedMcp(p => ({ ...p, [pack.name]: opt.key }));
+                                }}
+                                data-telemetry-id={`autoresearch-hub-mcp-${pack.name}-${opt.key}`}
+                                className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-all ${mcpKey === opt.key ? 'border-sky-400 bg-sky-100 text-sky-700 shadow-sm dark:border-sky-600 dark:bg-sky-900/40 dark:text-sky-200' : 'border-border/60 bg-background text-muted-foreground hover:bg-muted/60'}`}
+                              >
                                 {opt.label}
                               </button>
                             ))}
@@ -460,8 +539,13 @@ export default function AutoResearchHub() {
                         )}
 
                         {/* Configure button */}
-                        <button type="button" disabled={configuring} onClick={() => handleConfigure(pack)}
-                          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-sky-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-sky-700 active:scale-[0.98] disabled:opacity-60 dark:bg-sky-500 dark:hover:bg-sky-600">
+                        <button
+                          type="button"
+                          disabled={configuring}
+                          onClick={() => handleConfigure(pack)}
+                          data-telemetry-id={`autoresearch-hub-configure-${pack.name}`}
+                          className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-sky-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-all hover:bg-sky-700 active:scale-[0.98] disabled:opacity-60 dark:bg-sky-500 dark:hover:bg-sky-600"
+                        >
                           {configuring ? <><Loader2 className="h-4 w-4 animate-spin" />{t.configApplying}</> : <><Settings className="h-4 w-4" />{t.configApply}</>}
                         </button>
                         {configResult && (

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -43,6 +43,7 @@ import { type SlashCommand, useSlashCommands } from './useSlashCommands';
 import type { Project, ProjectSession, SessionProvider } from '../../../types/app';
 import { escapeRegExp } from '../utils/chatFormatting';
 import { isAutoResearchScenario } from '../utils/autoResearch';
+import { emitAutoresearchEvent } from '../../../utils/autoresearchTelemetry';
 import type { SessionMode } from '../../../types/app';
 import type { BtwOverlayState } from '../view/subcomponents/BtwOverlay';
 
@@ -1132,9 +1133,25 @@ export function useChatComposerState({
       }
 
       // Auto-bypass permissions for autoresearch workflows
-      const effectivePermissionMode = isAutoResearchScenario(attachedPrompt?.scenarioId)
+      const isAutoresearchMessage = isAutoResearchScenario(attachedPrompt?.scenarioId);
+      const effectivePermissionMode = isAutoresearchMessage
         ? 'bypassPermissions'
         : permissionMode;
+
+      if (isAutoresearchMessage) {
+        const scenarioId = attachedPrompt?.scenarioId ?? null;
+        const commandFromScenario = scenarioId?.startsWith('autoresearch-')
+          ? scenarioId.slice('autoresearch-'.length)
+          : null;
+        emitAutoresearchEvent('autoresearch_message_sent', {
+          scenario_id: scenarioId,
+          command: commandFromScenario,
+          input_length: currentInput.trim().length,
+          has_attachments: currentAttachedFiles.length > 0,
+          attachment_count: currentAttachedFiles.length,
+          provider,
+        });
+      }
 
       const selectedThinkingMode = thinkingModes.find((mode: { id: string; prefix?: string }) => mode.id === thinkingMode);
       if (selectedThinkingMode && selectedThinkingMode.prefix) {

--- a/src/components/chat/view/subcomponents/AutoResearchDropdown.tsx
+++ b/src/components/chat/view/subcomponents/AutoResearchDropdown.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { ChevronDown, ChevronRight, FlaskConical, Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AUTO_RESEARCH_PACKS, type LocaleKey } from '../../../../constants/autoResearchPacks';
+import { emitAutoresearchEvent } from '../../../../utils/autoresearchTelemetry';
 import type { AttachedPrompt } from '../../types/types';
 
 function resolveLocaleKey(lang: string): LocaleKey {
@@ -49,6 +50,12 @@ export default function AutoResearchDropdown({
   }, [open]);
 
   const select = (command: string, packName: string, wfName: string) => {
+    emitAutoresearchEvent('autoresearch_workflow_selected', {
+      pack: packName,
+      workflow_name: wfName,
+      command,
+      source: 'chat-dropdown',
+    });
     if (setAttachedPrompt) {
       setAttachedPrompt({
         scenarioId: `autoresearch-${command}`,
@@ -64,11 +71,31 @@ export default function AutoResearchDropdown({
     setExpandedPack(null);
   };
 
+  const togglePackExpanded = (packName: string, isExpanded: boolean) => {
+    emitAutoresearchEvent('autoresearch_pack_expanded', {
+      pack: packName,
+      expanded: !isExpanded,
+      source: 'chat-dropdown',
+    });
+    setExpandedPack(isExpanded ? null : packName);
+  };
+
+  const toggleDropdown = () => {
+    const willOpen = !open;
+    emitAutoresearchEvent('autoresearch_dropdown_toggled', {
+      open: willOpen,
+      source: 'chat-dropdown',
+    });
+    setOpen(willOpen);
+    if (!willOpen) setExpandedPack(null);
+  };
+
   return (
     <div ref={containerRef} className="relative">
       <button
         type="button"
-        onClick={() => { setOpen(!open); if (open) setExpandedPack(null); }}
+        onClick={toggleDropdown}
+        data-telemetry-id="autoresearch-dropdown-toggle"
         className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg border border-purple-300/50 text-[11px] font-medium text-purple-600 hover:text-purple-700 hover:bg-purple-50/60 dark:border-purple-700/40 dark:text-purple-400 dark:hover:text-purple-300 dark:hover:bg-purple-950/30 transition-all duration-150"
       >
         <FlaskConical className="w-3 h-3" />
@@ -98,7 +125,8 @@ export default function AutoResearchDropdown({
                 {/* Pack header — click to expand/collapse */}
                 <button
                   type="button"
-                  onClick={() => setExpandedPack(isExpanded ? null : pack.name)}
+                  onClick={() => togglePackExpanded(pack.name, isExpanded)}
+                  data-telemetry-id={`autoresearch-dropdown-pack-${pack.name}`}
                   className={`w-full flex items-center gap-2.5 px-3 py-2.5 text-left transition-colors ${color.hoverBg}`}
                 >
                   <span className={`h-2 w-2 rounded-full shrink-0 ${color.dot}`} />
@@ -131,6 +159,7 @@ export default function AutoResearchDropdown({
                         key={wf.command}
                         type="button"
                         onClick={() => select(wf.command, pack.name, wf.name)}
+                        data-telemetry-id={`autoresearch-dropdown-workflow-${pack.name}-${wf.command}`}
                         className={`w-full flex items-center gap-2 px-4 py-2 text-left transition-colors ${color.hoverBg}`}
                       >
                         <span className={`h-1 w-1 rounded-full shrink-0 ${color.dot} opacity-50`} />
@@ -150,7 +179,13 @@ export default function AutoResearchDropdown({
           {onNavigateToHub && (
             <button
               type="button"
-              onClick={() => { setOpen(false); setExpandedPack(null); onNavigateToHub(); }}
+              onClick={() => {
+                emitAutoresearchEvent('autoresearch_hub_opened', { source: 'chat-dropdown-configure' });
+                setOpen(false);
+                setExpandedPack(null);
+                onNavigateToHub();
+              }}
+              data-telemetry-id="autoresearch-dropdown-goto-hub"
               className="w-full flex items-center gap-2 px-3 py-2.5 border-t border-border/50 text-[11px] font-medium text-purple-600 hover:bg-purple-50/40 dark:text-purple-400 dark:hover:bg-purple-950/20 transition-colors"
             >
               <Settings className="w-3 h-3" />

--- a/src/components/chat/view/subcomponents/GuidedPromptStarter.tsx
+++ b/src/components/chat/view/subcomponents/GuidedPromptStarter.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../constants/guidedPromptScenarios';
 import { AUTO_RESEARCH_PACKS, type LocaleKey } from '../../../../constants/autoResearchPacks';
 import { api } from '../../../../utils/api';
+import { emitAutoresearchEvent } from '../../../../utils/autoresearchTelemetry';
 import type { AttachedPrompt } from '../../types/types';
 
 function resolveLocaleKey(lang: string): LocaleKey {
@@ -138,6 +139,14 @@ export default function GuidedPromptStarter({
     setSelectedScenarioId(scenario.id);
     setAutoResearchOpen(false);
 
+    if (scenario.slashCommand) {
+      emitAutoresearchEvent('autoresearch_scenario_clicked', {
+        scenario_id: scenario.id,
+        slash_command: scenario.slashCommand,
+        source: 'guided-starter',
+      });
+    }
+
     // Auto Research scenarios inject slash command as AttachedPrompt
     if (scenario.slashCommand) {
       if (setAttachedPrompt) {
@@ -201,7 +210,15 @@ export default function GuidedPromptStarter({
                   <div key={pack.name} className={isExp ? c.bg : ''}>
                     <button
                       type="button"
-                      onClick={() => setExpandedGuidedPack(isExp ? null : pack.name)}
+                      onClick={() => {
+                        emitAutoresearchEvent('autoresearch_pack_expanded', {
+                          pack: pack.name,
+                          expanded: !isExp,
+                          source: 'guided-starter',
+                        });
+                        setExpandedGuidedPack(isExp ? null : pack.name);
+                      }}
+                      data-telemetry-id={`autoresearch-guided-pack-${pack.name}`}
                       className={`w-full flex items-center gap-2.5 px-3 py-2.5 text-left transition-colors ${c.hover}`}
                     >
                       <span className={`h-2 w-2 rounded-full shrink-0 ${c.dot}`} />
@@ -218,6 +235,12 @@ export default function GuidedPromptStarter({
                             key={wf.command}
                             type="button"
                             onClick={() => {
+                              emitAutoresearchEvent('autoresearch_workflow_selected', {
+                                pack: pack.name,
+                                workflow_name: wf.name,
+                                command: wf.command,
+                                source: 'guided-starter',
+                              });
                               setAutoResearchOpen(false);
                               setExpandedGuidedPack(null);
                               setSelectedScenarioId(wf.command);
@@ -234,6 +257,7 @@ export default function GuidedPromptStarter({
                                 setTimeout(() => textareaRef.current?.focus(), 100);
                               }
                             }}
+                            data-telemetry-id={`autoresearch-guided-workflow-${pack.name}-${wf.command}`}
                             className={`w-full flex items-center gap-2 px-4 py-2 text-left transition-colors ${c.hover}`}
                           >
                             <span className={`h-1 w-1 rounded-full shrink-0 ${c.dot} opacity-50`} />

--- a/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarHeader.tsx
@@ -4,6 +4,7 @@ import type { AppTab } from '../../../../types/app';
 import { Button } from '../../../ui/button';
 import { Input } from '../../../ui/input';
 import { IS_PLATFORM } from '../../../../constants/config';
+import { emitAutoresearchEvent } from '../../../../utils/autoresearchTelemetry';
 
 type SidebarHeaderProps = {
   isPWA: boolean;
@@ -48,6 +49,11 @@ export default function SidebarHeader({
   onCollapseSidebar,
   t,
 }: SidebarHeaderProps) {
+  const handleOpenAutoResearch = (source: 'sidebar-desktop' | 'sidebar-mobile') => {
+    emitAutoresearchEvent('autoresearch_hub_opened', { source });
+    onOpenAutoResearch();
+  };
+
   const LogoBlock = () => (
     <div className="flex items-center gap-2.5 min-w-0">
       <img src="/icons/file.svg" alt="Dr. Claw" className="w-7 h-7 rounded-lg shadow-sm flex-shrink-0" />
@@ -163,7 +169,8 @@ export default function SidebarHeader({
               variant={activeTab === 'autoresearch' ? 'secondary' : 'outline'}
               size="sm"
               className="h-9 w-full justify-start rounded-xl"
-              onClick={onOpenAutoResearch}
+              onClick={() => handleOpenAutoResearch('sidebar-desktop')}
+              data-telemetry-id="autoresearch-sidebar-open-desktop"
             >
               <FlaskConical className="h-4 w-4" />
               {t('common:tabs.autoResearch', { defaultValue: 'Auto Research' })}
@@ -294,7 +301,8 @@ export default function SidebarHeader({
               type="button"
               variant={activeTab === 'autoresearch' ? 'secondary' : 'outline'}
               className="h-10 w-full justify-start rounded-xl"
-              onClick={onOpenAutoResearch}
+              onClick={() => handleOpenAutoResearch('sidebar-mobile')}
+              data-telemetry-id="autoresearch-sidebar-open-mobile"
             >
               <FlaskConical className="h-4 w-4" />
               {t('common:tabs.autoResearch', { defaultValue: 'Auto Research' })}

--- a/src/utils/autoresearchTelemetry.ts
+++ b/src/utils/autoresearchTelemetry.ts
@@ -1,0 +1,81 @@
+import { authenticatedFetch } from './api';
+import { isTelemetryEnabled } from './telemetry';
+
+type AutoresearchEvent = {
+  name: string;
+  source: string;
+  data: Record<string, unknown>;
+  clientAt: string;
+};
+
+const FLUSH_DELAY_MS = 500;
+const MAX_BATCH_SIZE = 10;
+const MAX_QUEUE_SIZE = 200;
+
+let queue: AutoresearchEvent[] = [];
+let flushTimer: number | null = null;
+let isFlushing = false;
+
+const scheduleFlush = () => {
+  if (flushTimer !== null || typeof window === 'undefined') {
+    return;
+  }
+  flushTimer = window.setTimeout(() => {
+    flushTimer = null;
+    void flush();
+  }, FLUSH_DELAY_MS);
+};
+
+const flush = async () => {
+  if (isFlushing || queue.length === 0) {
+    return;
+  }
+  if (!isTelemetryEnabled()) {
+    queue = [];
+    return;
+  }
+
+  isFlushing = true;
+  const batch = queue.splice(0, MAX_BATCH_SIZE);
+  try {
+    await authenticatedFetch('/api/telemetry/events', {
+      method: 'POST',
+      body: JSON.stringify({ events: batch }),
+    });
+  } catch {
+    queue = [...batch, ...queue].slice(0, MAX_QUEUE_SIZE);
+  } finally {
+    isFlushing = false;
+    if (queue.length > 0) {
+      scheduleFlush();
+    }
+  }
+};
+
+export function emitAutoresearchEvent(
+  name: string,
+  data: Record<string, unknown> = {},
+  source: string = 'autoresearch-ui',
+): void {
+  if (typeof window === 'undefined' || !isTelemetryEnabled()) {
+    return;
+  }
+
+  queue.push({
+    name,
+    source,
+    data,
+    clientAt: new Date().toISOString(),
+  });
+
+  if (queue.length > MAX_QUEUE_SIZE) {
+    queue = queue.slice(queue.length - MAX_QUEUE_SIZE);
+  }
+
+  if (queue.length >= MAX_BATCH_SIZE) {
+    void flush();
+    return;
+  }
+
+  scheduleFlush();
+}


### PR DESCRIPTION
## Summary

- Adds dedicated `autoresearch_*` telemetry events covering the full usage funnel: hub discovery → pack/workflow selection → configuration → message submission → backend run lifecycle
- New helper `src/utils/autoresearchTelemetry.ts` with micro-batched queue (reuses existing `/api/telemetry/events` pipeline and `isTelemetryEnabled()` opt-out)
- Backend `server/routes/auto-research.js` emits `autoresearch_run_started`, `_task_completed`, `_finished` (with outcome + duration), and `_cancel_requested` via `enqueueTelemetryEvent`
- Backfills `data-telemetry-id` on autoresearch buttons so existing `ui_click` events gain semantic identifiers as a backup data lane

## Why

Existing telemetry only captures generic DOM events (`ui_click`, `ui_change`, `ui_submit`) plus `agent_dialogue_meta`. It cannot answer core product questions: which pack are users picking? Which workflow is most used? Does the config flow convert? Are autoresearch runs finishing or failing? This PR closes that gap with a focused event set.

## Privacy

- User input content is **never sent** — only `input_length`, `command` (from scenario_id), and `attachment_count`
- `project_path` is SHA256-hashed (first 16 chars) before emission
- API keys / env var values are dropped; only key names and filled-count are reported
- Server-side sanitizer (`server/routes/telemetry.js` `BLOCKED_EVENT_KEYS`) continues to strip `content / prompt / output / message / context` as a second line of defense

## Events added

**Frontend** (source: `autoresearch-ui`): `autoresearch_hub_opened`, `_hub_viewed`, `_dropdown_toggled`, `_pack_expanded`, `_workflow_selected`, `_scenario_clicked`, `_config_section_opened`, `_mcp_selected`, `_configure_clicked`, `_configure_result`, `_guide_toggled`, `_guide_dismissed`, `_message_sent`

**Backend** (source: `auto-research-backend`): `autoresearch_run_started`, `_run_task_completed`, `_run_finished` (outcome: completed/failed/cancelled + duration_ms), `_run_cancel_requested`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Backend module imports without errors
- [ ] Manual: start dev server, open Auto Research hub via sidebar, expand a pack, select a workflow in chat dropdown, verify POSTs to `/api/telemetry/events` contain the new event names and no user content
- [ ] Manual: toggle Settings → Data Transfer off, repeat above, verify no requests are sent
- [ ] Manual: trigger a full autoresearch run (start → task completes → finish), verify backend emits `autoresearch_run_started` and `_run_finished` with correct outcome
- [ ] Manual: cancel an active run, verify `autoresearch_run_cancel_requested` is emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)