### PR TITLE
feat(markdown): render Mermaid across chat + preview surfaces (#50)

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -12,14 +12,11 @@ import { EditorView, showPanel, ViewPlugin } from '@codemirror/view';
 import { unifiedMergeView, getChunks } from '@codemirror/merge';
 import { showMinimap } from '@replit/codemirror-minimap';
 import { X, Save, Download, Maximize2, Minimize2, Settings as SettingsIcon, FileText, MessageSquarePlus } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import rehypeRaw from 'rehype-raw';
-import { normalizeLatexDelimiters } from '../utils/latexNormalizer';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark as prismOneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import MarkdownRenderer from './shared/MarkdownRenderer';
 import { api } from '../utils/api';
 import { useTranslation } from 'react-i18next';
 import { Eye, Code2 } from 'lucide-react';
@@ -50,97 +47,18 @@ const envLanguage = StreamLanguage.define({
   },
 });
 
-function MarkdownCodeBlock({ inline, className, children, ...props }) {
-  const [copied, setCopied] = useState(false);
-  const raw = Array.isArray(children) ? children.join('') : String(children ?? '');
-  const looksMultiline = /[\r\n]/.test(raw);
-  const shouldInline = inline || !looksMultiline;
-
-  if (shouldInline) {
-    return (
-      <code
-        className={`font-mono text-[0.9em] px-1.5 py-0.5 rounded-md bg-gray-100 text-gray-900 border border-gray-200 dark:bg-gray-800/60 dark:text-gray-100 dark:border-gray-700 whitespace-pre-wrap break-words ${className || ''}`}
-        {...props}
-      >
-        {children}
-      </code>
-    );
-  }
-
-  const match = /language-(\w+)/.exec(className || '');
-  const language = match ? match[1] : 'text';
-
-  return (
-    <div className="relative group my-2">
-      {language && language !== 'text' && (
-        <div className="absolute top-2 left-3 z-10 text-xs text-gray-400 font-medium uppercase">{language}</div>
-      )}
-      <button
-        type="button"
-        onClick={() => {
-          navigator.clipboard?.writeText(raw).then(() => {
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1500);
-          });
-        }}
-        className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 transition-opacity text-xs px-2 py-1 rounded-md bg-gray-700/80 hover:bg-gray-700 text-white border border-gray-600"
-      >
-        {copied ? 'Copied!' : 'Copy'}
-      </button>
-      <SyntaxHighlighter
-        language={language}
-        style={prismOneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: '0.5rem',
-          fontSize: '0.875rem',
-          padding: language && language !== 'text' ? '2rem 1rem 1rem 1rem' : '1rem',
-        }}
-      >
-        {raw}
-      </SyntaxHighlighter>
-    </div>
-  );
-}
-
-const markdownPreviewComponents = {
-  code: MarkdownCodeBlock,
-  blockquote: ({ children }) => (
-    <blockquote className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic text-gray-600 dark:text-gray-400 my-2">
-      {children}
-    </blockquote>
-  ),
-  a: ({ href, children }) => (
-    <a href={href} className="text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">
-      {children}
-    </a>
-  ),
-  table: ({ children }) => (
-    <div className="overflow-x-auto my-2">
-      <table className="min-w-full border-collapse border border-gray-200 dark:border-gray-700">{children}</table>
-    </div>
-  ),
-  thead: ({ children }) => <thead className="bg-gray-50 dark:bg-gray-800">{children}</thead>,
-  th: ({ children }) => (
-    <th className="px-3 py-2 text-left text-sm font-semibold border border-gray-200 dark:border-gray-700">{children}</th>
-  ),
-  td: ({ children }) => (
-    <td className="px-3 py-2 align-top text-sm border border-gray-200 dark:border-gray-700">{children}</td>
-  ),
-};
+const PREVIEW_REMARK_PLUGINS = [remarkGfm, remarkMath];
+const PREVIEW_REHYPE_PLUGINS = [rehypeRaw, rehypeKatex];
 
 function MarkdownPreview({ content }) {
-  const remarkPlugins = useMemo(() => [remarkGfm, remarkMath], []);
-  const rehypePlugins = useMemo(() => [rehypeRaw, rehypeKatex], []);
-
   return (
-    <ReactMarkdown
-      remarkPlugins={remarkPlugins}
-      rehypePlugins={rehypePlugins}
-      components={markdownPreviewComponents}
+    <MarkdownRenderer
+      remarkPlugins={PREVIEW_REMARK_PLUGINS}
+      rehypePlugins={PREVIEW_REHYPE_PLUGINS}
+      codeBlockStyle="syntax"
     >
-      {normalizeLatexDelimiters(content ?? '')}
-    </ReactMarkdown>
+      {content ?? ''}
+    </MarkdownRenderer>
   );
 }
 

--- a/src/components/ResearchLab.jsx
+++ b/src/components/ResearchLab.jsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { normalizeLatexDelimiters } from '../utils/latexNormalizer';
+import MarkdownRenderer from './shared/MarkdownRenderer';
 import {
   FlaskConical, RefreshCw, FileText, BookOpen, Settings2, Lightbulb,
   GitBranch, FolderOpen, ChevronDown, ChevronRight, ExternalLink,
@@ -1670,10 +1671,7 @@ function ArtifactsCard({ artifacts, onSelect, selectedPath, compact = false }) {
   );
 }
 
-/* ------------------------------------------------------------------ */
-/*  Markdown components for IdeaCard                                   */
-/* ------------------------------------------------------------------ */
-const ideaMarkdownComponents = {
+const ideaMarkdownOverrides = {
   h1: ({ children }) => <h1 className="text-xl font-bold text-foreground mt-5 mb-2 first:mt-0">{children}</h1>,
   h2: ({ children }) => <h2 className="text-lg font-semibold text-foreground mt-4 mb-2 border-b border-border pb-1">{children}</h2>,
   h3: ({ children }) => <h3 className="text-base font-semibold text-foreground mt-3 mb-1">{children}</h3>,
@@ -1688,46 +1686,17 @@ const ideaMarkdownComponents = {
   a: ({ href, children }) => (
     <a href={href} className="text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">{children}</a>
   ),
-  code: ({ inline, className, children, ...props }) => {
-    if (inline) {
-      return <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono text-foreground">{children}</code>;
-    }
-    const lang = (className || '').replace('language-', '');
-    return (
-      <div className="my-2 rounded-lg overflow-hidden border border-border">
-        {lang && <div className="bg-muted/60 px-3 py-1 text-xs text-muted-foreground font-mono border-b border-border">{lang}</div>}
-        <pre className="bg-muted/30 p-3 overflow-x-auto text-xs">
-          <code className="font-mono text-foreground/90">{children}</code>
-        </pre>
-      </div>
-    );
-  },
   strong: ({ children }) => <strong className="font-semibold text-foreground">{children}</strong>,
   em: ({ children }) => <em className="italic">{children}</em>,
 };
 
-/** Markdown component overrides */
-const markdownComponents = {
+const previewMarkdownOverrides = {
   blockquote: ({ children }) => (
     <blockquote className="border-l-4 border-blue-300 dark:border-blue-600 pl-3 italic text-foreground/70 my-2 text-sm">{children}</blockquote>
   ),
   a: ({ href, children }) => (
     <a href={href} className="text-blue-600 dark:text-blue-400 hover:underline" target="_blank" rel="noopener noreferrer">{children}</a>
   ),
-  code: ({ inline, className, children, ...props }) => {
-    if (inline) {
-      return <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono text-foreground">{children}</code>;
-    }
-    const lang = (className || '').replace('language-', '');
-    return (
-      <div className="my-2 rounded-lg overflow-hidden border border-border">
-        {lang && <div className="bg-muted/60 px-3 py-1 text-xs text-muted-foreground font-mono border-b border-border">{lang}</div>}
-        <pre className="bg-muted/30 p-3 overflow-x-auto text-xs">
-          <code className="font-mono text-foreground/90">{children}</code>
-        </pre>
-      </div>
-    );
-  },
   table: ({ children }) => (
     <div className="overflow-x-auto my-2">
       <table className="min-w-full border-collapse border border-border text-sm">{children}</table>
@@ -1766,9 +1735,6 @@ function IdeaCard({ projectName, config, projectFileSet, compact = false }) {
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState(!compact);
   const [copied, setCopied] = useState(false);
-
-  const remarkPlugins = useMemo(() => [remarkGfm, remarkMath], []);
-  const rehypePlugins = useMemo(() => [rehypeKatex], []);
 
   useEffect(() => {
     if (!projectName) { setLoading(false); return; }
@@ -1911,13 +1877,9 @@ function IdeaCard({ projectName, config, projectFileSet, compact = false }) {
       {/* Body — markdown rendered */}
       {expanded && (
         <div className={`overflow-y-auto ${compact ? 'max-h-[300px] px-3 py-3' : 'max-h-[600px] px-5 py-4'}`}>
-          <ReactMarkdown
-            remarkPlugins={remarkPlugins}
-            rehypePlugins={rehypePlugins}
-            components={ideaMarkdownComponents}
-          >
-            {normalizeLatexDelimiters(ideaText)}
-          </ReactMarkdown>
+          <MarkdownRenderer codeBlockStyle="plain" components={ideaMarkdownOverrides}>
+            {ideaText ?? ''}
+          </MarkdownRenderer>
         </div>
       )}
     </div>
@@ -2240,13 +2202,9 @@ function FileViewer({ projectName, file, onClose }) {
       return (
         <div className="flex-1 min-h-0 overflow-auto bg-muted/10 p-4">
           <div className={`prose max-w-none rounded-2xl border border-border/60 bg-background/80 shadow-sm dark:prose-invert ${expanded ? 'prose-base p-8' : 'prose-sm p-6'}`}>
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm, remarkMath]}
-              rehypePlugins={[rehypeKatex]}
-              components={markdownComponents}
-            >
-              {normalizeLatexDelimiters(content ?? '')}
-            </ReactMarkdown>
+            <MarkdownRenderer codeBlockStyle="plain" components={previewMarkdownOverrides}>
+              {content ?? ''}
+            </MarkdownRenderer>
           </div>
         </div>
       );

--- a/src/components/chat/utils/chatFormatting.ts
+++ b/src/components/chat/utils/chatFormatting.ts
@@ -56,27 +56,39 @@ export function escapeRegExp(value: string) {
 export function formatFileTreeInContent(text: string): string {
   if (!text || typeof text !== 'string') return text;
 
-  // Pattern to detect file tree structures
-  // Matches lines starting with ├──, └──, │, or multiple spaces followed by these symbols
-  // Also matches the root directory line which often precedes the tree
+  // Auto-wrap ASCII file trees in a `text` fence so monospace alignment is preserved.
+  // Two guardrails prevent mis-wrapping non-tree content (Mermaid-ish diagrams, ASCII
+  // pipelines, content already inside a fence):
+  //   1. `insideFence` — skip detection while walking through a fenced block
+  //   2. `hasStrongTreeSignal` — require at least one `├──` or `└──` line before
+  //      committing the wrap; a lone `│` run is not enough evidence of a file tree.
   const lines = text.split('\n');
   const result: string[] = [];
   let isInTree = false;
   let treeLines: string[] = [];
+  let hasStrongSignal = false;
+  let insideFence = false;
 
-  const isTreeLine = (line: string) => {
+  const isFenceToggleLine = (line: string) => /^\s*```/.test(line);
+
+  const isStrongTreeLine = (line: string) => {
     const trimmed = line.trim();
     return (
       trimmed.startsWith('├──') ||
       trimmed.startsWith('└──') ||
-      trimmed.startsWith('│') ||
       (trimmed.includes('──') && (trimmed.includes('├') || trimmed.includes('└')))
     );
   };
 
+  const isWeakTreeLine = (line: string) => {
+    const trimmed = line.trim();
+    return trimmed.startsWith('│');
+  };
+
+  const isTreeLine = (line: string) => isStrongTreeLine(line) || isWeakTreeLine(line);
+
   const isPossibleRootLine = (line: string) => {
     const trimmed = line.trim();
-    // Common root patterns: "dir/", "./dir", "/path/to/dir"
     return (
       trimmed.endsWith('/') ||
       trimmed.startsWith('./') ||
@@ -85,43 +97,63 @@ export function formatFileTreeInContent(text: string): string {
     );
   };
 
+  const flushTreeLines = () => {
+    if (!treeLines.length) return;
+    if (hasStrongSignal) {
+      result.push('```text\n' + treeLines.join('\n') + '\n```');
+    } else {
+      // Weak-only collection (e.g. lone `│` pipeline art) — emit unchanged so we
+      // don't fence real diagrams into a text code block.
+      result.push(...treeLines);
+    }
+    treeLines = [];
+    hasStrongSignal = false;
+    isInTree = false;
+  };
+
+  const pushTreeLine = (line: string) => {
+    treeLines.push(line);
+    if (!hasStrongSignal && isStrongTreeLine(line)) hasStrongSignal = true;
+  };
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
-    const nextLine = lines[i + 1];
+
+    if (isFenceToggleLine(line)) {
+      if (isInTree) flushTreeLines();
+      insideFence = !insideFence;
+      result.push(line);
+      continue;
+    }
+
+    if (insideFence) {
+      result.push(line);
+      continue;
+    }
 
     if (isTreeLine(line)) {
       if (!isInTree) {
-        // Look back one line to see if it's the root directory
+        isInTree = true;
         if (result.length > 0 && isPossibleRootLine(result[result.length - 1])) {
           const rootLine = result.pop()!;
-          isInTree = true;
-          treeLines = [rootLine, line];
-        } else {
-          isInTree = true;
-          treeLines = [line];
+          pushTreeLine(rootLine);
         }
-      } else {
-        treeLines.push(line);
       }
+      pushTreeLine(line);
     } else if (isInTree) {
-      // Sometimes there are empty lines or lines with just vertical bars in a tree
       if (line.trim() === '' || line.trim() === '│') {
-        treeLines.push(line);
+        pushTreeLine(line);
       } else {
-        // End of tree
-        result.push('```text\n' + treeLines.join('\n') + '\n```');
+        flushTreeLines();
         result.push(line);
-        isInTree = false;
-        treeLines = [];
       }
     } else {
       result.push(line);
     }
   }
 
-  // Handle case where tree ends at the last line
   if (isInTree) {
-    result.push('```text\n' + treeLines.join('\n') + '\n```');
+    flushTreeLines();
   }
 
   return result.join('\n');

--- a/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
+++ b/src/components/chat/view/subcomponents/ChatContextFilePreview.tsx
@@ -1,12 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import ReactMarkdown from 'react-markdown';
-import { normalizeLatexDelimiters } from '../../../../utils/latexNormalizer';
-import remarkGfm from 'remark-gfm';
-import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
 import { ExternalLink, FileText, X } from 'lucide-react';
 
+import MarkdownRenderer from '../../../shared/MarkdownRenderer';
 import { Button } from '../../../ui/button';
 import { api } from '../../../../utils/api';
 import { IMAGE_EXTENSIONS, AUDIO_EXTENSIONS, VIDEO_EXTENSIONS, MARKDOWN_EXTENSIONS, HTML_EXTENSIONS } from '../../utils/fileExtensions';
@@ -307,9 +303,7 @@ export default function ChatContextFilePreview({
       {!loading && !loadError && previewKind === 'markdown' && (
         <div className={`${previewHeightClass} flex-1 overflow-auto bg-muted/10 ${compact ? 'p-3' : 'p-4'}`}>
           <div className={`prose prose-sm max-w-none rounded-2xl border border-border/60 bg-background/90 shadow-sm dark:prose-invert ${compact ? 'p-4' : 'p-5'}`}>
-            <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]}>
-              {normalizeLatexDelimiters(content)}
-            </ReactMarkdown>
+            <MarkdownRenderer codeBlockStyle="syntax">{content}</MarkdownRenderer>
           </div>
         </div>
       )}

--- a/src/components/chat/view/subcomponents/Markdown.tsx
+++ b/src/components/chat/view/subcomponents/Markdown.tsx
@@ -7,6 +7,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
 import { normalizeInlineCodeFences } from '../../utils/chatFormatting';
+import MermaidBlock from './MermaidBlock';
 
 type MarkdownProps = {
   children: React.ReactNode;
@@ -44,6 +45,11 @@ const CodeBlock = ({ node, inline, className, children, ...props }: CodeBlockPro
 
   const match = /language-(\w+)/.exec(className || '');
   const language = match ? match[1] : 'text';
+
+  if (language === 'mermaid') {
+    return <MermaidBlock source={raw} />;
+  }
+
   const textToCopy = raw;
 
   const handleCopy = () => {

--- a/src/components/chat/view/subcomponents/MermaidBlock.tsx
+++ b/src/components/chat/view/subcomponents/MermaidBlock.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '../../../../contexts/ThemeContext';
+
+type MermaidBlockProps = {
+  source: string;
+};
+
+type MermaidModule = typeof import('mermaid')['default'];
+
+let mermaidPromise: Promise<MermaidModule> | null = null;
+const loadMermaid = (): Promise<MermaidModule> => {
+  if (!mermaidPromise) {
+    mermaidPromise = import('mermaid').then((mod) => mod.default);
+  }
+  return mermaidPromise;
+};
+
+const MermaidBlock = ({ source }: MermaidBlockProps) => {
+  const { t } = useTranslation('chat');
+  const { isDarkMode } = useTheme();
+  const theme = isDarkMode ? 'dark' : 'default';
+  const domId = 'mmd-' + useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    loadMermaid().then((mermaid) => {
+      if (cancelled) return;
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: 'strict',
+        theme,
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [theme]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      try {
+        const mermaid = await loadMermaid();
+        const result = await mermaid.render(domId, source);
+        if (!cancelled) {
+          setSvg(result.svg);
+          setFailed(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          // eslint-disable-next-line no-console
+          console.error('[MermaidBlock] render failed', { source, err });
+          setFailed(true);
+          setSvg(null);
+        }
+      }
+    }, 150);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [source, domId, theme]);
+
+  const handleCopy = () => {
+    const doSet = () => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    };
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(source).then(doSet).catch(() => {
+        const ta = document.createElement('textarea');
+        ta.value = source;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+          document.execCommand('copy');
+        } catch {
+          /* legacy fallback best-effort */
+        }
+        document.body.removeChild(ta);
+        doSet();
+      });
+    }
+  };
+
+  const copyButton = (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus:opacity-100 active:opacity-100 transition-opacity text-xs px-2 py-1 rounded-md bg-gray-700/80 hover:bg-gray-700 text-white border border-gray-600"
+      title={copied ? t('codeBlock.copied') : t('codeBlock.copy')}
+      aria-label={copied ? t('codeBlock.copied') : t('codeBlock.copy')}
+    >
+      {copied ? t('codeBlock.copied') : t('codeBlock.copy')}
+    </button>
+  );
+
+  if (failed) {
+    return (
+      <div className="relative group my-2">
+        {copyButton}
+        <pre className="rounded-lg bg-gray-900 text-gray-100 p-4 text-xs font-mono overflow-auto whitespace-pre">
+          {source}
+        </pre>
+        <div className="mt-1 text-xs text-amber-500/90">{t('codeBlock.renderError')}</div>
+      </div>
+    );
+  }
+
+  if (!svg) {
+    return (
+      <div className="my-2 rounded-lg border border-border/50 bg-background/40 p-4 text-xs text-muted-foreground">
+        {t('codeBlock.rendering')}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative group my-2">
+      {copyButton}
+      <div
+        className="rounded-lg border border-border/40 bg-white dark:bg-neutral-900 p-4 overflow-auto [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full"
+        dangerouslySetInnerHTML={{ __html: svg }}
+      />
+    </div>
+  );
+};
+
+export default MermaidBlock;

--- a/src/components/shared/MarkdownRenderer.tsx
+++ b/src/components/shared/MarkdownRenderer.tsx
@@ -186,6 +186,7 @@ const buildCodeRenderer = (
 };
 
 const defaultMarkdownComponents: Components = {
+  pre: ({ children }) => <>{children}</>,
   blockquote: ({ children }) => (
     <blockquote className="border-l-4 border-border/70 pl-4 italic text-foreground/80 my-2">
       {children}

--- a/src/components/shared/MarkdownRenderer.tsx
+++ b/src/components/shared/MarkdownRenderer.tsx
@@ -160,9 +160,11 @@ const buildCodeRenderer = (
 ) => {
   const CodeRenderer: React.FC<CodeBlockProps> = ({ node, inline, className, children, ...rest }) => {
     const raw = childrenToString(children);
+    // react-markdown@10 drops `inline` and passes HAST nodes; inline code has no newlines.
     const inlineDetected = inline || (node && node.type === 'inlineCode');
+    const shouldInline = inlineDetected || !/[\r\n]/.test(raw);
 
-    if (inlineDetected) {
+    if (shouldInline) {
       return (
         <InlineCode className={className} {...rest}>
           {children}

--- a/src/components/shared/MarkdownRenderer.tsx
+++ b/src/components/shared/MarkdownRenderer.tsx
@@ -1,0 +1,249 @@
+import React, { Suspense, lazy, useMemo, useState } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
+import type { PluggableList } from 'unified';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
+import { useTranslation } from 'react-i18next';
+
+import MermaidBlock from '../chat/view/subcomponents/MermaidBlock';
+import { normalizeLatexDelimiters } from '../../utils/latexNormalizer';
+import { cn } from '../../lib/utils';
+
+export type MarkdownCodeBlockStyle = 'syntax' | 'plain';
+
+export type MarkdownRendererProps = {
+  children: string;
+  remarkPlugins?: PluggableList;
+  rehypePlugins?: PluggableList;
+  components?: Components;
+  codeBlockStyle?: MarkdownCodeBlockStyle;
+};
+
+type CodeBlockProps = {
+  node?: any;
+  inline?: boolean;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+const DEFAULT_REMARK_PLUGINS: PluggableList = [remarkGfm, remarkMath];
+const DEFAULT_REHYPE_PLUGINS: PluggableList = [rehypeKatex];
+
+const LazyPrism = lazy(async () => {
+  const [{ Prism }, { oneDark }] = await Promise.all([
+    import('react-syntax-highlighter'),
+    import('react-syntax-highlighter/dist/esm/styles/prism'),
+  ]);
+  const Wrapped = (props: any) => <Prism style={oneDark} {...props} />;
+  return { default: Wrapped };
+});
+
+const childrenToString = (children: React.ReactNode): string =>
+  Array.isArray(children) ? children.join('') : String(children ?? '');
+
+const InlineCode: React.FC<CodeBlockProps> = ({ className, children, ...props }) => (
+  <code
+    className={cn(
+      'font-mono text-[0.9em] px-1.5 py-0.5 rounded-md bg-gray-100 text-gray-900 border border-gray-200',
+      'dark:bg-gray-800/60 dark:text-gray-100 dark:border-gray-700 whitespace-pre-wrap break-words',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </code>
+);
+
+type CopyButtonProps = { text: string; copyLabel: string; copiedLabel: string };
+
+const CopyButton: React.FC<CopyButtonProps> = ({ text, copyLabel, copiedLabel }) => {
+  const [copied, setCopied] = useState(false);
+  const onClick = () => {
+    const settle = () => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    };
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(text).then(settle).catch(() => fallbackCopy(text, settle));
+    } else {
+      fallbackCopy(text, settle);
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="absolute top-2 right-2 z-10 opacity-0 group-hover:opacity-100 focus:opacity-100 active:opacity-100 transition-opacity text-xs px-2 py-1 rounded-md bg-gray-700/80 hover:bg-gray-700 text-white border border-gray-600"
+      title={copied ? copiedLabel : copyLabel}
+      aria-label={copied ? copiedLabel : copyLabel}
+    >
+      {copied ? copiedLabel : copyLabel}
+    </button>
+  );
+};
+
+const fallbackCopy = (text: string, onDone: () => void) => {
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    document.execCommand('copy');
+  } catch {
+    /* legacy fallback best-effort */
+  }
+  document.body.removeChild(ta);
+  onDone();
+};
+
+type SyntaxBlockProps = { language: string; raw: string; copyLabel: string; copiedLabel: string };
+
+const SyntaxCodeBlock: React.FC<SyntaxBlockProps> = ({ language, raw, copyLabel, copiedLabel }) => {
+  const showLangChip = language && language !== 'text';
+  return (
+    <div className="relative group my-2">
+      {showLangChip && (
+        <div className="absolute top-2 left-3 z-10 text-xs text-gray-400 font-medium uppercase">{language}</div>
+      )}
+      <CopyButton text={raw} copyLabel={copyLabel} copiedLabel={copiedLabel} />
+      <Suspense
+        fallback={
+          <pre className="rounded-lg bg-gray-900 text-gray-100 p-4 text-sm font-mono overflow-auto whitespace-pre">
+            {raw}
+          </pre>
+        }
+      >
+        <LazyPrism
+          language={language}
+          customStyle={{
+            margin: 0,
+            borderRadius: '0.5rem',
+            fontSize: '0.875rem',
+            padding: showLangChip ? '2rem 1rem 1rem 1rem' : '1rem',
+          }}
+          codeTagProps={{
+            style: {
+              fontFamily:
+                'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+            },
+          }}
+        >
+          {raw}
+        </LazyPrism>
+      </Suspense>
+    </div>
+  );
+};
+
+type PlainBlockProps = { language: string; children?: React.ReactNode };
+
+const PlainCodeBlock: React.FC<PlainBlockProps> = ({ language, children }) => (
+  <div className="my-2 rounded-lg overflow-hidden border border-border">
+    {language && (
+      <div className="bg-muted/60 px-3 py-1 text-xs text-muted-foreground font-mono border-b border-border">
+        {language}
+      </div>
+    )}
+    <pre className="bg-muted/30 p-3 overflow-x-auto text-xs">
+      <code className="font-mono text-foreground/90">{children}</code>
+    </pre>
+  </div>
+);
+
+const buildCodeRenderer = (
+  codeBlockStyle: MarkdownCodeBlockStyle,
+  copyLabel: string,
+  copiedLabel: string,
+) => {
+  const CodeRenderer: React.FC<CodeBlockProps> = ({ node, inline, className, children, ...rest }) => {
+    const raw = childrenToString(children);
+    const inlineDetected = inline || (node && node.type === 'inlineCode');
+
+    if (inlineDetected) {
+      return (
+        <InlineCode className={className} {...rest}>
+          {children}
+        </InlineCode>
+      );
+    }
+
+    const langMatch = /language-(\w+)/.exec(className || '');
+    const language = langMatch ? langMatch[1] : 'text';
+
+    if (language === 'mermaid') {
+      return <MermaidBlock source={raw} />;
+    }
+
+    if (codeBlockStyle === 'plain') {
+      return <PlainCodeBlock language={language}>{children}</PlainCodeBlock>;
+    }
+    return <SyntaxCodeBlock language={language} raw={raw} copyLabel={copyLabel} copiedLabel={copiedLabel} />;
+  };
+  return CodeRenderer;
+};
+
+const defaultMarkdownComponents: Components = {
+  blockquote: ({ children }) => (
+    <blockquote className="border-l-4 border-border/70 pl-4 italic text-foreground/80 my-2">
+      {children}
+    </blockquote>
+  ),
+  a: ({ href, children }) => (
+    <a
+      href={href}
+      className="text-blue-600 dark:text-blue-400 hover:underline"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {children}
+    </a>
+  ),
+  table: ({ children }) => (
+    <div className="overflow-x-auto my-2">
+      <table className="min-w-full border-collapse border border-border text-sm">{children}</table>
+    </div>
+  ),
+  thead: ({ children }) => <thead className="bg-muted/50">{children}</thead>,
+  th: ({ children }) => (
+    <th className="px-3 py-1.5 text-left text-xs font-semibold border border-border">{children}</th>
+  ),
+  td: ({ children }) => (
+    <td className="px-3 py-1.5 align-top text-xs border border-border">{children}</td>
+  ),
+};
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+  children,
+  remarkPlugins,
+  rehypePlugins,
+  components,
+  codeBlockStyle = 'syntax',
+}) => {
+  const { t } = useTranslation('chat');
+  const copyLabel = t('codeBlock.copy');
+  const copiedLabel = t('codeBlock.copied');
+
+  const mergedComponents = useMemo<Components>(
+    () => ({
+      ...defaultMarkdownComponents,
+      ...(components ?? {}),
+      code: buildCodeRenderer(codeBlockStyle, copyLabel, copiedLabel),
+    }),
+    [codeBlockStyle, copyLabel, copiedLabel, components],
+  );
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={remarkPlugins ?? DEFAULT_REMARK_PLUGINS}
+      rehypePlugins={rehypePlugins ?? DEFAULT_REHYPE_PLUGINS}
+      components={mergedComponents}
+    >
+      {normalizeLatexDelimiters(children ?? '')}
+    </ReactMarkdown>
+  );
+};
+
+export default MarkdownRenderer;

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -6,7 +6,9 @@
   "codeBlock": {
     "copy": "Copy",
     "copied": "Copied",
-    "copyCode": "Copy code"
+    "copyCode": "Copy code",
+    "rendering": "Rendering diagram…",
+    "renderError": "Diagram render failed — showing source"
   },
   "messageTypes": {
     "user": "U",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -6,7 +6,9 @@
   "codeBlock": {
     "copy": "복사",
     "copied": "복사됨",
-    "copyCode": "코드 복사"
+    "copyCode": "코드 복사",
+    "rendering": "다이어그램 렌더링 중…",
+    "renderError": "다이어그램 렌더링 실패 — 소스 표시"
   },
   "messageTypes": {
     "user": "U",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -6,7 +6,9 @@
   "codeBlock": {
     "copy": "复制",
     "copied": "已复制",
-    "copyCode": "复制代码"
+    "copyCode": "复制代码",
+    "rendering": "正在渲染图表…",
+    "renderError": "图表渲染失败 — 显示源码"
   },
   "messageTypes": {
     "user": "U",


### PR DESCRIPTION
## Summary

Fixes Issue #50: render ` ```mermaid ` fences as SVG diagrams in **every** markdown surface, not just chat. Stacked on #191 (LaTeX bracket delimiters); base will auto-retarget to `main` once #191 merges.

## Changes

### Chat surface — `7794e44`

- New `MermaidBlock` component — lazy-loads `mermaid@11` via dynamic import, 150 ms debounce so streaming partials don't flash a parse error, graceful `<pre>` fallback on invalid syntax, copy-source button. `useTheme()` drives the diagram theme so dark-mode toggles repaint live.
- Hooks into chat's existing `CodeBlock` via a 3-line short-circuit when `language === 'mermaid'`.
- Tightens `formatFileTreeInContent`: skip detection inside fenced code blocks; only wrap when the block contains at least one `├──` or `└──`. Lone-`│` clusters (ASCII pipelines, Mermaid-ish art) now pass through unwrapped.

### Preview surfaces — `c06f69a`

- New shared `src/components/shared/MarkdownRenderer.tsx` — owns mermaid routing, `normalizeLatexDelimiters`, plugin defaults (`remarkGfm`, `remarkMath`, `rehypeKatex`), and code-block rendering. Two code-block variants:
  - `codeBlockStyle="syntax"` — lazy-loaded `react-syntax-highlighter` + copy button (used by CodeEditor + ChatContextFilePreview).
  - `codeBlockStyle="plain"` — language banner + `<pre>`, matching ResearchLab's pre-existing look.
- Migrated three surfaces:
  - `CodeEditor.jsx` markdown preview tab — the bug in the screenshot.
  - `chat/view/subcomponents/ChatContextFilePreview.tsx` — was bare `<ReactMarkdown>` with no `components` prop.
  - `ResearchLab.jsx` IdeaCard body + FileViewer markdown preview.
- Net diff: −150 / +20 in the migrated files; ~250 lines added in the new shared component.

## Scope decisions

- **`chat/view/subcomponents/Markdown.tsx` intentionally deferred.** It already renders mermaid correctly (per `7794e44`) and has streaming highlighting + `onFileOpen` link rewriting + insight callouts that need to be lifted into props before consolidation. Migrating it in this PR would add regression risk without fixing any user-visible bug. Tracked as a follow-up.
- **ResearchLab's `OVERVIEW_MARKDOWN_COMPONENTS` unchanged** — small inline blurbs with intentionally minimal styling. Mermaid is unlikely to appear there.

## i18n

No new keys. Reuses `chat:codeBlock.{copy,copied,rendering,renderError}` (already present in en/zh-CN/ko from `7794e44`).

## Bundle

- Mermaid stays code-split (`mermaid.core-*.js` + per-diagram chunks).
- `react-syntax-highlighter` is now `React.lazy()`-loaded inside `MarkdownRenderer`, so surfaces using `codeBlockStyle="plain"` (ResearchLab) don't pull it.

## Test plan

`npm run typecheck` and `npm run build` must pass. Then `npm run dev` and exercise the fixture below in each surface.

Fixture (any `.md` file):

````markdown
# Mermaid test

```mermaid
flowchart TD
  A[Start] --> B{Decision}
  B -->|yes| C[Render]
  B -->|no| D[Fallback]
```

```python
def hello(): print("hi")
```

Inline `code` and $E = mc^2$.

| a | b |
|---|---|
| 1 | 2 |

```mermaid
broken syntax
```
````

Per surface:

- [ ] **Chat** (regression) — paste in a chat message; SVG renders; toggle dark mode → diagram repaints; broken block falls back to `<pre>` with amber error.
- [ ] **CodeEditor preview** — open as `.md`, click preview toggle; SVG renders; python keeps syntax highlighting; KaTeX renders; broken block → fallback.
- [ ] **ChatContextFilePreview** — attach the `.md` as chat context, expand preview; same checks as CodeEditor.
- [ ] **ResearchLab** — open an idea card containing mermaid; open the FileViewer markdown preview; SVG renders; python uses plain `<pre>` (no syntax highlighter — verifies the `codeBlockStyle="plain"` opt-out path).
- [ ] **File-tree wrap regression** — ASCII pipeline (only `│`) is no longer auto-wrapped in ` ```text `; a real file tree (`├──`, `└──`) still wraps.
- [ ] **LaTeX regression** — `\[ r_t(\theta) = ... \]` still renders via KaTeX; no `\theta` corruption.