### PR TITLE
Fix inno figure provider key handling

### DIFF
--- a/skills/inno-figure-gen/SKILL.md
+++ b/skills/inno-figure-gen/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: inno-figure-gen
 description: >
-  Generate/edit images with Gemini image models (default:
-  gemini-3.1-flash-image-preview). Use for image create/modify requests incl.
-  edits. Supports text-to-image + image-to-image; 1K/2K/4K; use --input-image.
-  Use --model to select a different model.
+  Generate/edit images with OpenAI gpt-image-2 by default, falling back to
+  Gemini (gemini-3.1-flash-image-preview) when OPENAI_API_KEY is unset.
+  Supports text-to-image + image-to-image; 1K/2K/4K; use --input-image for
+  editing, --provider to force a provider, --model to override the model.
 ---
 
-# Gemini Image Generation & Editing
+# Image Generation & Editing (GPT Image default, Gemini fallback)
 
-Generate new images or edit existing ones using Google's Gemini image generation API (default model: `gemini-3.1-flash-image-preview`).
+Generate new images or edit existing ones. The script picks a provider based on which API keys are available:
+
+1. **OpenAI** `gpt-image-2` — used when `OPENAI_API_KEY` is set (default).
+2. **Gemini** `gemini-3.1-flash-image-preview` — used when only `GEMINI_API_KEY` is set.
+
+When both keys are set, OpenAI is picked by default; force Gemini with `--provider gemini`. If an auto-selected OpenAI call fails at runtime (quota, moderation, network), the script transparently falls back to Gemini when a Gemini key is available.
 
 ## Usage
 
@@ -22,12 +27,12 @@ Keep the distinction clear:
 
 **Generate new image:**
 ```bash
-uv run <this-skill-directory>/scripts/generate_image.py --prompt "your image description" --filename "output-name.png" [--resolution 1K|2K|4K] [--model MODEL] [--api-key KEY]
+uv run <this-skill-directory>/scripts/generate_image.py --prompt "your image description" --filename "output-name.png" [--resolution 1K|2K|4K] [--provider auto|openai|gemini] [--model MODEL] [--openai-api-key KEY | --gemini-api-key KEY]
 ```
 
 **Edit existing image:**
 ```bash
-uv run <this-skill-directory>/scripts/generate_image.py --prompt "editing instructions" --filename "output-name.png" --input-image "path/to/input.png" [--resolution 1K|2K|4K] [--model MODEL] [--api-key KEY]
+uv run <this-skill-directory>/scripts/generate_image.py --prompt "editing instructions" --filename "output-name.png" --input-image "path/to/input.png" [--resolution 1K|2K|4K] [--provider auto|openai|gemini] [--model MODEL] [--openai-api-key KEY | --gemini-api-key KEY]
 ```
 
 **Important:** Always run from the user's current working directory so images are saved where the user is working, not in the skill directory.
@@ -45,11 +50,11 @@ Goal: fast iteration without burning time on 4K until the prompt is correct.
 
 ## Resolution Options
 
-The Gemini 3 Pro Image API supports three resolutions (uppercase K required):
+The script accepts three resolution tiers (uppercase K required):
 
-- **1K** (default) - ~1024px resolution
-- **2K** - ~2048px resolution
-- **4K** - ~4096px resolution
+- **1K** (default) - ~1024px
+- **2K** - ~2048px
+- **4K** - ~4096px (Gemini) / **3840×2160 landscape** under OpenAI
 
 Map user requests to API parameters:
 - No mention of resolution → `1K`
@@ -57,37 +62,47 @@ Map user requests to API parameters:
 - "2K", "2048", "normal", "medium resolution" → `2K`
 - "high resolution", "high-res", "hi-res", "4K", "ultra" → `4K`
 
-## Model Selection
+**OpenAI 4K note:** `gpt-image-2` supports non-square 4K outputs within its size limits. `--resolution 4K` with OpenAI maps to `3840×2160`.
 
-The default model is `gemini-3.1-flash-image-preview`. You can override it with the `--model` flag:
+## Provider & Model Selection
 
-```bash
-uv run <this-skill-directory>/scripts/generate_image.py --prompt "..." --filename "..." --model gemini-3.1-flash-image-preview
-```
+Two providers are available:
 
-Available models depend on your Gemini API access. Common options:
-- `gemini-3.1-flash-image-preview` (default) - Fast image generation
-- `gemini-3-pro-image-preview` - Higher quality, slower
+| Provider | Default model                        | When chosen                                                  |
+| -------- | ------------------------------------ | ------------------------------------------------------------ |
+| OpenAI   | `gpt-image-2`                        | `--provider auto` (default) when `OPENAI_API_KEY` is set, or `--provider openai` |
+| Gemini   | `gemini-3.1-flash-image-preview`     | `--provider auto` when only `GEMINI_API_KEY` is set, or `--provider gemini`, or as runtime fallback from a failed auto-OpenAI call |
 
-## API Key
+Override either default with `--model`. Note: the model name is provider-specific; passing a Gemini model name while the script falls back to Gemini automatically will not preserve a user-specified OpenAI model (each provider uses its own default during fallback).
 
-The script checks for API key in this order:
-1. `--api-key` argument (use if user provided key in chat)
-2. `GEMINI_API_KEY` environment variable
+Common model options:
+- **OpenAI:** `gpt-image-2` (default)
+- **Gemini:** `gemini-3.1-flash-image-preview` (default, fast), `gemini-3-pro-image-preview` (higher quality, slower)
 
-If neither is available, the script exits with an error message.
+## API Keys
+
+The script resolves provider-specific keys first, while preserving the original Gemini-only `--api-key` behavior:
+
+1. Explicit, provider-specific flags: `--openai-api-key KEY`, `--gemini-api-key KEY`
+2. Generic `--api-key KEY` — kept for backward compatibility with the original Gemini-only script. Under `auto`, it is treated as a Gemini key unless an OpenAI key is provided by `--openai-api-key` or `OPENAI_API_KEY`. Under explicit `--provider openai`, it is treated as an OpenAI key; under explicit `--provider gemini`, it is treated as a Gemini key.
+3. Environment variables: `OPENAI_API_KEY`, `GEMINI_API_KEY`
+
+When `--provider auto` is selected and OpenAI fails at runtime, fallback to Gemini requires `--gemini-api-key`, `--api-key`, or the `GEMINI_API_KEY` env var.
+
+If no key is resolvable for the chosen provider, the script exits with a clear error message listing both ways to fix it.
 
 ## Preflight + Common Failures (fast fixes)
 
 - Preflight:
   - `command -v uv` (must exist)
-  - `test -n \"$GEMINI_API_KEY\"` (or pass `--api-key`)
-  - If editing: `test -f \"path/to/input.png\"`
+  - At least one of: `test -n "$OPENAI_API_KEY" -o -n "$GEMINI_API_KEY"` (or pass `--openai-api-key`, `--gemini-api-key`, or backward-compatible `--api-key`)
+  - If editing: `test -f "path/to/input.png"`
 
 - Common failures:
-  - `Error: No API key provided.` → set `GEMINI_API_KEY` or pass `--api-key`
+  - `Error: No API key found...` → set `OPENAI_API_KEY` or `GEMINI_API_KEY`, or pass an explicit `--*-api-key` flag
   - `Error loading input image:` → wrong path / unreadable file; verify `--input-image` points to a real image
-  - “quota/permission/403” style API errors → wrong key, no access, or quota exceeded; try a different key/account
+  - `[warn] OpenAI call failed (...); falling back to Gemini.` → informational; a Gemini key was available and produced the image. Investigate the OpenAI error separately (quota, moderation, network)
+  - "quota/permission/403" style errors with no fallback → no Gemini key available, or user used `--provider openai` (explicit provider disables fallback). Try a different key, or drop the explicit provider to enable fallback
 
 ## Filename Generation
 
@@ -140,12 +155,17 @@ Use templates when the user is vague or when edits must be precise.
 
 ## Examples
 
-**Generate new image:**
+**Generate new image (auto provider):**
 ```bash
-uv run <this-skill-directory>/scripts/generate_image.py --prompt "A serene Japanese garden with cherry blossoms" --filename "2025-11-23-14-23-05-japanese-garden.png" --resolution 4K
+uv run <this-skill-directory>/scripts/generate_image.py --prompt "A serene Japanese garden with cherry blossoms" --filename "2025-11-23-14-23-05-japanese-garden.png" --resolution 2K
 ```
 
-**Edit existing image:**
+**Force Gemini:**
+```bash
+uv run <this-skill-directory>/scripts/generate_image.py --prompt "A serene Japanese garden with cherry blossoms" --filename "2025-11-23-14-23-05-japanese-garden-4k.png" --resolution 4K --provider gemini
+```
+
+**Edit existing image (auto provider):**
 ```bash
 uv run <this-skill-directory>/scripts/generate_image.py --prompt "make the sky more dramatic with storm clouds" --filename "2025-11-23-14-25-30-dramatic-sky.png" --input-image "original-photo.jpg" --resolution 2K
 ```

--- a/skills/inno-figure-gen/scripts/generate_image.py
+++ b/skills/inno-figure-gen/scripts/generate_image.py
@@ -3,169 +3,314 @@
 # requires-python = ">=3.10"
 # dependencies = [
 #     "google-genai>=1.0.0",
+#     "openai>=1.40.0",
 #     "pillow>=10.0.0",
 # ]
 # ///
 """
-Generate images using Google's Gemini image generation API.
+Generate images using OpenAI gpt-image-2 (default) or Google Gemini (fallback).
+
+Provider selection (auto, the default):
+  1. If OPENAI_API_KEY is available -> OpenAI (gpt-image-2)
+  2. Else if --api-key or GEMINI_API_KEY is available -> Gemini (gemini-3.1-flash-image-preview)
+  3. Else -> error listing both fix options
+
+If auto picks OpenAI and the call itself fails (quota, moderation, network),
+the script transparently falls back to Gemini when a Gemini key is available.
+Use --provider to force a specific provider (no fallback is performed when the
+provider is set explicitly).
 
 Usage:
-    uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--model MODEL] [--api-key KEY]
+    uv run generate_image.py --prompt "..." --filename "out.png"
+        [--resolution 1K|2K|4K]
+        [--provider auto|openai|gemini]
+        [--model MODEL]
+        [--openai-api-key KEY | --gemini-api-key KEY | --api-key KEY]
 """
 
 import argparse
+import base64
 import os
 import sys
+from io import BytesIO
 from pathlib import Path
 
 
-def get_api_key(provided_key: str | None) -> str | None:
-    """Get API key from argument first, then environment."""
-    if provided_key:
-        return provided_key
-    return os.environ.get("GEMINI_API_KEY")
+DEFAULT_MODELS = {
+    "openai": "gpt-image-2",
+    "gemini": "gemini-3.1-flash-image-preview",
+}
+
+# OpenAI gpt-image-2 supports larger non-square sizes within its limits.
+OPENAI_SIZE_MAP = {
+    "1K": "1024x1024",
+    "2K": "2048x2048",
+    "4K": "3840x2160",
+}
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Generate images using Gemini image generation API"
-    )
-    parser.add_argument(
-        "--prompt", "-p",
-        required=True,
-        help="Image description/prompt"
-    )
-    parser.add_argument(
-        "--filename", "-f",
-        required=True,
-        help="Output filename (e.g., sunset-mountains.png)"
-    )
-    parser.add_argument(
-        "--input-image", "-i",
-        help="Optional input image path for editing/modification"
-    )
-    parser.add_argument(
-        "--resolution", "-r",
-        choices=["1K", "2K", "4K"],
-        default="1K",
-        help="Output resolution: 1K (default), 2K, or 4K"
-    )
-    parser.add_argument(
-        "--api-key", "-k",
-        help="Gemini API key (overrides GEMINI_API_KEY env var)"
-    )
-    parser.add_argument(
-        "--model", "-m",
-        default="gemini-3.1-flash-image-preview",
-        help="Model to use for image generation (default: gemini-3.1-flash-image-preview)"
-    )
+def get_openai_key(provided: str | None) -> str | None:
+    return provided or os.environ.get("OPENAI_API_KEY")
 
-    args = parser.parse_args()
 
-    # Get API key
-    api_key = get_api_key(args.api_key)
-    if not api_key:
-        print("Error: No API key provided.", file=sys.stderr)
+def get_gemini_key(provided: str | None) -> str | None:
+    return provided or os.environ.get("GEMINI_API_KEY")
+
+
+def _fatal_missing_key(which: str | None) -> None:
+    if which == "openai":
+        print("Error: --provider openai requires an OpenAI API key.", file=sys.stderr)
+        print("  Set OPENAI_API_KEY or pass --openai-api-key KEY.", file=sys.stderr)
+    elif which == "gemini":
+        print("Error: --provider gemini requires a Gemini API key.", file=sys.stderr)
+        print("  Set GEMINI_API_KEY or pass --gemini-api-key KEY.", file=sys.stderr)
+    else:
+        print("Error: No API key found for image generation.", file=sys.stderr)
         print("Please either:", file=sys.stderr)
-        print("  1. Provide --api-key argument", file=sys.stderr)
-        print("  2. Set GEMINI_API_KEY environment variable", file=sys.stderr)
-        sys.exit(1)
+        print("  1. Set OPENAI_API_KEY (default provider: gpt-image-2)", file=sys.stderr)
+        print("  2. Set GEMINI_API_KEY (fallback provider: gemini-3.1-flash-image-preview)", file=sys.stderr)
+        print("  3. Pass --openai-api-key KEY, --gemini-api-key KEY, or --api-key KEY", file=sys.stderr)
+    sys.exit(1)
 
-    # Import here after checking API key to avoid slow import on error
+
+def resolve_provider(args) -> tuple[str, str]:
+    """Pick a provider and API key from flags + env vars.
+
+    The generic --api-key flag remains backward-compatible with the original
+    Gemini-only script: under auto it is used as a Gemini key unless an OpenAI
+    key is provided explicitly or via OPENAI_API_KEY.
+    """
+    if args.provider == "openai":
+        key = get_openai_key(args.openai_api_key or args.api_key)
+        if not key:
+            _fatal_missing_key("openai")
+        return "openai", key
+
+    if args.provider == "gemini":
+        key = get_gemini_key(args.gemini_api_key or args.api_key)
+        if not key:
+            _fatal_missing_key("gemini")
+        return "gemini", key
+
+    # auto
+    openai_key = get_openai_key(args.openai_api_key)
+    if openai_key:
+        return "openai", openai_key
+    gemini_key = get_gemini_key(args.gemini_api_key or args.api_key)
+    if gemini_key:
+        return "gemini", gemini_key
+    _fatal_missing_key(None)
+    raise SystemExit(1)  # unreachable; for type-checkers
+
+
+def save_pil_as_png(image, output_path: Path) -> None:
+    """Normalize a PIL image to RGB and save as PNG, flattening alpha over white."""
+    from PIL import Image as PILImage
+
+    if image.mode == "RGBA":
+        rgb = PILImage.new("RGB", image.size, (255, 255, 255))
+        rgb.paste(image, mask=image.split()[3])
+        rgb.save(str(output_path), "PNG")
+    elif image.mode == "RGB":
+        image.save(str(output_path), "PNG")
+    else:
+        image.convert("RGB").save(str(output_path), "PNG")
+
+
+def generate_with_openai(
+    api_key: str,
+    model: str,
+    prompt: str,
+    input_image_path: str | None,
+    resolution: str,
+    output_path: Path,
+) -> None:
+    from openai import OpenAI
+    from PIL import Image as PILImage
+
+    size = OPENAI_SIZE_MAP.get(resolution, "1024x1024")
+
+    client = OpenAI(api_key=api_key)
+
+    if input_image_path:
+        print(f"Editing image via OpenAI ({model}, size={size})...")
+        with open(input_image_path, "rb") as fh:
+            result = client.images.edit(
+                model=model,
+                image=fh,
+                prompt=prompt,
+                size=size,
+            )
+    else:
+        print(f"Generating image via OpenAI ({model}, size={size})...")
+        result = client.images.generate(
+            model=model,
+            prompt=prompt,
+            size=size,
+        )
+
+    if not result.data:
+        raise RuntimeError("OpenAI returned no image data")
+    b64 = result.data[0].b64_json
+    if not b64:
+        raise RuntimeError("OpenAI response missing b64_json payload")
+    image_bytes = base64.b64decode(b64)
+    image = PILImage.open(BytesIO(image_bytes))
+    save_pil_as_png(image, output_path)
+
+
+def generate_with_gemini(
+    api_key: str,
+    model: str,
+    prompt: str,
+    input_image_pil,
+    resolution: str,
+    output_path: Path,
+) -> None:
     from google import genai
     from google.genai import types
     from PIL import Image as PILImage
 
-    # Initialise client
     client = genai.Client(api_key=api_key)
 
-    # Set up output path
+    if input_image_pil is not None:
+        contents = [input_image_pil, prompt]
+        print(f"Editing image via Gemini ({model}, resolution={resolution})...")
+    else:
+        contents = prompt
+        print(f"Generating image via Gemini ({model}, resolution={resolution})...")
+
+    response = client.models.generate_content(
+        model=model,
+        contents=contents,
+        config=types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"],
+            image_config=types.ImageConfig(image_size=resolution),
+        ),
+    )
+
+    image_saved = False
+    for part in response.parts:
+        if part.text is not None:
+            print(f"Model response: {part.text}")
+        elif part.inline_data is not None:
+            image_data = part.inline_data.data
+            if isinstance(image_data, str):
+                image_data = base64.b64decode(image_data)
+            image = PILImage.open(BytesIO(image_data))
+            save_pil_as_png(image, output_path)
+            image_saved = True
+
+    if not image_saved:
+        raise RuntimeError("No image was generated in the Gemini response")
+
+
+def load_input_image_if_any(args) -> tuple[object, str]:
+    """Open the input image (if any) and derive an effective resolution.
+
+    Returns (pil_image_or_None, resolution). When the user left the resolution
+    at the default of 1K, we scale the request up to match the input image.
+    """
+    if not args.input_image:
+        return None, args.resolution
+
+    from PIL import Image as PILImage
+
+    try:
+        pil = PILImage.open(args.input_image)
+    except Exception as e:
+        print(f"Error loading input image: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loaded input image: {args.input_image}")
+    resolution = args.resolution
+    if resolution == "1K":  # default value — auto-detect from input dims
+        width, height = pil.size
+        max_dim = max(width, height)
+        if max_dim >= 3000:
+            resolution = "4K"
+        elif max_dim >= 1500:
+            resolution = "2K"
+        print(f"Auto-detected resolution: {resolution} (from input {width}x{height})")
+    return pil, resolution
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate/edit images with OpenAI gpt-image-2 (default) or Gemini (fallback)."
+    )
+    parser.add_argument("--prompt", "-p", required=True, help="Image description/prompt")
+    parser.add_argument("--filename", "-f", required=True, help="Output filename")
+    parser.add_argument("--input-image", "-i", help="Optional input image path for editing")
+    parser.add_argument(
+        "--resolution", "-r",
+        choices=["1K", "2K", "4K"],
+        default="1K",
+        help="Output resolution: 1K (default), 2K, or 4K",
+    )
+    parser.add_argument(
+        "--provider",
+        choices=["auto", "openai", "gemini"],
+        default="auto",
+        help="Provider to use. auto (default): OpenAI if OPENAI_API_KEY is set, else Gemini.",
+    )
+    parser.add_argument(
+        "--api-key", "-k",
+        help="Backward-compatible generic key: Gemini under auto/gemini, OpenAI under openai",
+    )
+    parser.add_argument("--openai-api-key", help="Explicit OpenAI API key (overrides --api-key for OpenAI)")
+    parser.add_argument("--gemini-api-key", help="Explicit Gemini API key (overrides --api-key for Gemini)")
+    parser.add_argument(
+        "--model", "-m",
+        default=None,
+        help="Model override (default: gpt-image-2 for OpenAI, gemini-3.1-flash-image-preview for Gemini)",
+    )
+
+    args = parser.parse_args()
+
+    provider, api_key = resolve_provider(args)
+    model = args.model or DEFAULT_MODELS[provider]
+
     output_path = Path(args.filename)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Load input image if provided
-    input_image = None
-    output_resolution = args.resolution
-    if args.input_image:
-        try:
-            input_image = PILImage.open(args.input_image)
-            print(f"Loaded input image: {args.input_image}")
+    input_pil, effective_resolution = load_input_image_if_any(args)
 
-            # Auto-detect resolution if not explicitly set by user
-            if args.resolution == "1K":  # Default value
-                # Map input image size to resolution
-                width, height = input_image.size
-                max_dim = max(width, height)
-                if max_dim >= 3000:
-                    output_resolution = "4K"
-                elif max_dim >= 1500:
-                    output_resolution = "2K"
-                else:
-                    output_resolution = "1K"
-                print(f"Auto-detected resolution: {output_resolution} (from input {width}x{height})")
-        except Exception as e:
-            print(f"Error loading input image: {e}", file=sys.stderr)
-            sys.exit(1)
-
-    # Build contents (image first if editing, prompt only if generating)
-    if input_image:
-        contents = [input_image, args.prompt]
-        print(f"Editing image with resolution {output_resolution}...")
-    else:
-        contents = args.prompt
-        print(f"Generating image with resolution {output_resolution}...")
+    def _dispatch(prov: str, key: str, mdl: str) -> None:
+        if prov == "openai":
+            generate_with_openai(
+                key, mdl, args.prompt, args.input_image, effective_resolution, output_path
+            )
+        else:
+            generate_with_gemini(
+                key, mdl, args.prompt, input_pil, effective_resolution, output_path
+            )
 
     try:
-        response = client.models.generate_content(
-            model=args.model,
-            contents=contents,
-            config=types.GenerateContentConfig(
-                response_modalities=["TEXT", "IMAGE"],
-                image_config=types.ImageConfig(
-                    image_size=output_resolution
+        _dispatch(provider, api_key, model)
+    except Exception as e:
+        # Transparent fallback only when provider was auto-selected to OpenAI.
+        # Explicit --provider openai respects the user's intent and does not fall back.
+        if provider == "openai" and args.provider == "auto":
+            gemini_key = get_gemini_key(args.gemini_api_key or args.api_key)
+            if gemini_key:
+                print(
+                    f"[warn] OpenAI call failed ({e}); falling back to Gemini.",
+                    file=sys.stderr,
                 )
-            )
-        )
-
-        # Process response and convert to PNG
-        image_saved = False
-        for part in response.parts:
-            if part.text is not None:
-                print(f"Model response: {part.text}")
-            elif part.inline_data is not None:
-                # Convert inline data to PIL Image and save as PNG
-                from io import BytesIO
-
-                # inline_data.data is already bytes, not base64
-                image_data = part.inline_data.data
-                if isinstance(image_data, str):
-                    # If it's a string, it might be base64
-                    import base64
-                    image_data = base64.b64decode(image_data)
-
-                image = PILImage.open(BytesIO(image_data))
-
-                # Ensure RGB mode for PNG (convert RGBA to RGB with white background if needed)
-                if image.mode == 'RGBA':
-                    rgb_image = PILImage.new('RGB', image.size, (255, 255, 255))
-                    rgb_image.paste(image, mask=image.split()[3])
-                    rgb_image.save(str(output_path), 'PNG')
-                elif image.mode == 'RGB':
-                    image.save(str(output_path), 'PNG')
-                else:
-                    image.convert('RGB').save(str(output_path), 'PNG')
-                image_saved = True
-
-        if image_saved:
-            full_path = output_path.resolve()
-            print(f"\nImage saved: {full_path}")
+                try:
+                    _dispatch("gemini", gemini_key, DEFAULT_MODELS["gemini"])
+                except Exception as ge:
+                    print(f"Error generating image (Gemini fallback): {ge}", file=sys.stderr)
+                    sys.exit(1)
+            else:
+                print(f"Error generating image: {e}", file=sys.stderr)
+                sys.exit(1)
         else:
-            print("Error: No image was generated in the response.", file=sys.stderr)
+            print(f"Error generating image: {e}", file=sys.stderr)
             sys.exit(1)
 
-    except Exception as e:
-        print(f"Error generating image: {e}", file=sys.stderr)
-        sys.exit(1)
+    print(f"\nImage saved: {output_path.resolve()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve backward-compatible --api-key behavior for Gemini under auto provider selection
- map OpenAI 4K image generation to 3840x2160 instead of downgrading to 2048x2048
- update inno-figure-gen docs for provider selection, key precedence, and OpenAI 4K behavior

## Tests
- PYTHONPYCACHEPREFIX=/tmp/dr-claw-pycache /Users/sdj/.local/bin/python3.10 -m py_compile skills/inno-figure-gen/scripts/generate_image.py
- git diff --check
- provider resolution and fallback checks passed