### PR TITLE
feat: add GPT-5.5 and Opus 4.7 chat models

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -241,6 +241,7 @@ function getContextWindowForModel(modelName) {
     'opusplan':            200000,
     'sonnet[1m]':          1000000,
     // API format names
+    'claude-opus-4-7':             200000,
     'claude-opus-4-6':             200000,
     'claude-opus-4-20250918':      200000,
     'claude-sonnet-4-6':           200000,

--- a/server/index.js
+++ b/server/index.js
@@ -2888,6 +2888,7 @@ app.get('/api/projects/:projectName/sessions/:sessionId/token-usage', authentica
 
     // Determine context window from model name
     const MODEL_CONTEXT_WINDOWS = {
+      'claude-opus-4-7':     200000,
       'claude-opus-4-6':     200000,
       'claude-opus-4-20250918': 200000,
       'claude-sonnet-4-6':   200000,

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -18,6 +18,7 @@ export const CLAUDE_MODELS = {
     { value: 'haiku', label: 'Haiku' },
     { value: 'opusplan', label: 'Opus (Plan Mode Only)' },
     { value: 'sonnet[1m]', label: 'Sonnet [1M]' },
+    { value: 'claude-opus-4-7', label: 'Opus 4.7' },
     { value: 'claude-opus-4-6', label: 'Opus 4.6' }
   ],
 
@@ -56,6 +57,7 @@ export const CURSOR_MODELS = {
  */
 export const CODEX_MODELS = {
   OPTIONS: [
+    { value: 'gpt-5.5', label: 'GPT-5.5' },
     { value: 'gpt-5.4', label: 'GPT-5.4' },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
     { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },

--- a/src/components/chat/constants/codexReasoningSupport.ts
+++ b/src/components/chat/constants/codexReasoningSupport.ts
@@ -4,6 +4,7 @@ const DEFAULT_ONLY: CodexReasoningEffortId[] = ['default'];
 const LOW_TO_XHIGH: CodexReasoningEffortId[] = ['default', 'low', 'medium', 'high', 'xhigh'];
 
 const MODEL_REASONING_SUPPORT: Record<string, CodexReasoningEffortId[]> = {
+  'gpt-5.5': LOW_TO_XHIGH,
   'gpt-5.4': LOW_TO_XHIGH,
   'gpt-5.3-codex': LOW_TO_XHIGH,
   'gpt-5.2-codex': LOW_TO_XHIGH,


### PR DESCRIPTION
## Summary
- add GPT-5.5 to the Codex chat model selector
- add Opus 4.7 to the Claude chat model selector
- wire GPT-5.5 reasoning effort support and Opus 4.7 token budget context window

## Tests
- npm run typecheck