### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #210)

### DIFF
--- a/skills/aris-ablation-planner/SKILL.md
+++ b/skills/aris-ablation-planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-ablation-planner
 description: Use when main results pass result-to-claim (claim_supported=yes or partial) and ablation studies are needed for paper submission. Codex designs ablations from a reviewer's perspective, CC reviews feasibility and implements.
-argument-hint: [method-description-or-claim]
+argument-hint: "[method-description-or-claim]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-analyze-results/SKILL.md
+++ b/skills/aris-analyze-results/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-analyze-results
 description: Analyze ML experiment results, compute statistics, generate comparison tables and insights. Use when user says "analyze results", "compare", or needs to interpret experimental data.
-argument-hint: [results-path-or-description]
+argument-hint: "[results-path-or-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
 license: MIT
 metadata:

--- a/skills/aris-arxiv/SKILL.md
+++ b/skills/aris-arxiv/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-arxiv
 description: Search, download, and summarize academic papers from arXiv. Use when user says "search arxiv", "download paper", "fetch arxiv", "arxiv search", "get paper pdf", or wants to find and save papers from arXiv to the local paper library.
-argument-hint: [query-or-arxiv-id]
+argument-hint: "[query-or-arxiv-id]"
 allowed-tools: Bash(*), Read, Write
 license: MIT
 metadata:

--- a/skills/aris-auto-paper-improvement-loop/SKILL.md
+++ b/skills/aris-auto-paper-improvement-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-auto-paper-improvement-loop
 description: "Autonomously improve a generated paper via GPT-5.4 xhigh review → implement fixes → recompile, for 2 rounds. Use when user says \"改论文\", \"improve paper\", \"论文润色循环\", \"auto improve\", or wants to iteratively polish a generated paper."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-auto-review-loop/SKILL.md
+++ b/skills/aris-auto-review-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-auto-review-loop
 description: Autonomous multi-round research review loop. Repeatedly reviews via Codex MCP, implements fixes, and re-reviews until positive assessment or max rounds reached. Use when user says "auto review loop", "review until it passes", or wants autonomous iterative improvement.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-compute-guard/SKILL.md
+++ b/skills/aris-compute-guard/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-compute-guard
 description: "Mandatory pre-flight compute resource check before running experiments. Detects whether local/remote GPU or compute resources are actually available. If resources are unavailable, STOPS the experiment pipeline immediately and reports to the user — preventing the model from hallucinating fake experiment results. Use when: about to run experiments, deploy training, or any GPU-intensive task."
-argument-hint: [environment-type]
+argument-hint: "[environment-type]"
 allowed-tools: Bash(nvidia-smi*), Bash(python*), Bash(ssh*), Bash(echo*), Bash(which*), Bash(command*), Read, Grep, Glob
 license: MIT
 metadata:

--- a/skills/aris-dse-loop/SKILL.md
+++ b/skills/aris-dse-loop/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-dse-loop
 description: "Autonomous design space exploration loop for computer architecture and EDA. Runs a program, analyzes results, tunes parameters, and iterates until objective is met or timeout. Use when user says \"DSE\", \"design space exploration\", \"sweep parameters\", \"optimize\", \"find best config\", or wants iterative parameter tuning."
-argument-hint: [task-description — include program, parameters, objective, and timeout]
+argument-hint: "[task-description — include program, parameters, objective, and timeout]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent
 license: MIT
 metadata:

--- a/skills/aris-experiment-bridge/SKILL.md
+++ b/skills/aris-experiment-bridge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-experiment-bridge
 description: "Workflow 1.5: Bridge between idea discovery and auto review. Reads EXPERIMENT_PLAN.md, implements experiment code, deploys to GPU, collects initial results. Use when user says \"实现实验\", \"implement experiments\", \"bridge\", \"从计划到跑实验\", \"deploy the plan\", or has an experiment plan ready to execute."
-argument-hint: [experiment-plan-path-or-topic]
+argument-hint: "[experiment-plan-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-feishu-notify/SKILL.md
+++ b/skills/aris-feishu-notify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-feishu-notify
 description: "Send notifications to Feishu/Lark. Internal utility used by other skills, or manually via /feishu-notify. Supports push-only (webhook) and interactive (bidirectional) modes. Use when user says \"发飞书\", \"notify feishu\", or other skills need to send status updates."
-argument-hint: [message-text]
+argument-hint: "[message-text]"
 allowed-tools: Bash(curl *), Bash(cat *), Read, Glob
 license: MIT
 metadata:

--- a/skills/aris-formula-derivation/SKILL.md
+++ b/skills/aris-formula-derivation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-formula-derivation
 description: Structures and derives research formulas when the user wants to 推导公式, build a theory line, organize assumptions, turn scattered equations into a coherent derivation, or rewrite theory notes into a paper-ready formula document. Use when the derivation target is not yet fully fixed, the main object still needs to be chosen, or the user needs a coherent derivation package rather than a finished theorem proof.
-argument-hint: [problem-goal-current-formulas-or-notes]
+argument-hint: "[problem-goal-current-formulas-or-notes]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 license: MIT
 metadata:

--- a/skills/aris-grant-proposal/SKILL.md
+++ b/skills/aris-grant-proposal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-grant-proposal
 description: "Draft a structured grant proposal from research ideas and literature. Supports KAKENHI (Japan), NSF (US), NSFC (China, including 面上/青年/优青/杰青/海外优青/重点), ERC (EU), DFG (Germany), SNSF (Switzerland), ARC (Australia), NWO (Netherlands), and generic formats. Use when user says \"write grant\", \"grant proposal\", \"申請書\", \"write KAKENHI\", \"科研費\", \"基金申请\", \"写基金\", \"NSF proposal\", or wants to turn research ideas into a funding application."
-argument-hint: [research-direction — grant-type]
+argument-hint: "[research-direction — grant-type]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-idea-creator/SKILL.md
+++ b/skills/aris-idea-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-idea-creator
 description: Generate and rank research ideas given a broad direction. Use when user says "找idea", "brainstorm ideas", "generate research ideas", "what can we work on", or wants to explore a research area for publishable directions.
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Grep, Glob, WebSearch, WebFetch, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-idea-discovery/SKILL.md
+++ b/skills/aris-idea-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-idea-discovery
 description: "Workflow 1: Full idea discovery pipeline. Orchestrates research-lit → idea-creator → novelty-check → research-review to go from a broad research direction to validated, pilot-tested ideas. Use when user says \"找idea全流程\", \"idea discovery pipeline\", \"从零开始找方向\", or wants the complete idea exploration workflow."
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-mermaid-diagram/SKILL.md
+++ b/skills/aris-mermaid-diagram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-mermaid-diagram
 description: Generate Mermaid diagrams from user requirements. Saves .mmd and .md files to figures/ directory with syntax verification. Supports flowcharts, sequence diagrams, class diagrams, ER diagrams, Gantt charts, and 18 more diagram types.
-argument-hint: [diagram description or requirements]
+argument-hint: "[diagram description or requirements]"
 allowed-tools: Bash(*), Read, Write, Edit, Glob, Grep
 license: MIT
 metadata:

--- a/skills/aris-meta-optimize/SKILL.md
+++ b/skills/aris-meta-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-meta-optimize
 description: "Analyze ARIS usage logs and propose optimizations to SKILL.md files, reviewer prompts, and workflow defaults. Outer-loop harness optimization inspired by Meta-Harness (Lee et al., 2026). Use when user says \"优化技能\", \"meta optimize\", \"improve skills\", \"分析使用记录\", or wants to optimize ARIS's own harness components based on accumulated experience."
-argument-hint: [target-skill-or-all]
+argument-hint: "[target-skill-or-all]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-monitor-experiment/SKILL.md
+++ b/skills/aris-monitor-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-monitor-experiment
 description: Monitor running experiments, check progress, collect results. Use when user says "check results", "is it done", "monitor", or wants experiment output.
-argument-hint: [server-alias or screen-name]
+argument-hint: "[server-alias or screen-name]"
 allowed-tools: Bash(ssh *), Bash(echo *), Read, Write, Edit
 license: MIT
 metadata:

--- a/skills/aris-novelty-check/SKILL.md
+++ b/skills/aris-novelty-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-novelty-check
 description: Verify research idea novelty against recent literature. Use when user says "查新", "novelty check", "有没有人做过", "check novelty", or wants to verify a research idea is novel before implementing.
-argument-hint: [method-or-idea-description]
+argument-hint: "[method-or-idea-description]"
 allowed-tools: WebSearch, WebFetch, Grep, Read, Glob, mcp__codex__codex
 license: MIT
 metadata:

--- a/skills/aris-paper-compile/SKILL.md
+++ b/skills/aris-paper-compile/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-compile
 description: "Compile LaTeX paper to PDF, fix errors, and verify output. Use when user says \"编译论文\", \"compile paper\", \"build PDF\", \"生成PDF\", or wants to compile LaTeX into a submission-ready PDF."
-argument-hint: [paper-directory]
+argument-hint: "[paper-directory]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob
 license: MIT
 metadata:

--- a/skills/aris-paper-figure/SKILL.md
+++ b/skills/aris-paper-figure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-figure
 description: "Generate publication-quality figures and tables from experiment results. Use when user says \"画图\", \"作图\", \"generate figures\", \"paper figures\", or needs plots for a paper."
-argument-hint: [figure-plan-or-data-path]
+argument-hint: "[figure-plan-or-data-path]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-paper-illustration/SKILL.md
+++ b/skills/aris-paper-illustration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-illustration
 description: "Generate publication-quality AI illustrations for academic papers using Gemini image generation. Creates architecture diagrams, method illustrations with Claude-supervised iterative refinement loop. Use when user says \"生成图表\", \"画架构图\", \"AI绘图\", \"paper illustration\", \"generate diagram\", or needs visual figures for papers."
-argument-hint: [description-or-method-file]
+argument-hint: "[description-or-method-file]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply, WebSearch
 license: MIT
 metadata:

--- a/skills/aris-paper-plan/SKILL.md
+++ b/skills/aris-paper-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-plan
 description: "Generate a structured paper outline from review conclusions and experiment results. Use when user says \"写大纲\", \"paper outline\", \"plan the paper\", \"论文规划\", or wants to create a paper plan before writing."
-argument-hint: [topic-or-narrative-doc]
+argument-hint: "[topic-or-narrative-doc]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-paper-poster/SKILL.md
+++ b/skills/aris-paper-poster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-poster
 description: "Generate a conference poster (article + tcbposter LaTeX → A0/A1 PDF + editable PPTX + SVG) from a compiled paper. Use when user says \"做海报\", \"制作海报\", \"conference poster\", \"make poster\", \"生成poster\", \"poster session\", or wants to create a poster for a conference presentation."
-argument-hint: [paper-directory-or-venue]
+argument-hint: "[paper-directory-or-venue]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-paper-slides/SKILL.md
+++ b/skills/aris-paper-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-slides
 description: "Generate conference presentation slides (beamer LaTeX → PDF + editable PPTX) from a compiled paper, with speaker notes and full talk script. Use when user says \"做PPT\", \"做幻灯片\", \"make slides\", \"conference talk\", \"presentation slides\", \"生成slides\", \"写演讲稿\", or wants beamer slides for a conference talk."
-argument-hint: [paper-directory-or-talk-length]
+argument-hint: "[paper-directory-or-talk-length]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-paper-write/SKILL.md
+++ b/skills/aris-paper-write/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-write
 description: "Draft LaTeX paper section by section from an outline. Use when user says \"写论文\", \"write paper\", \"draft LaTeX\", \"开始写\", or wants to generate LaTeX content from a paper plan."
-argument-hint: [venue-or-section]
+argument-hint: "[venue-or-section]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-paper-writing/SKILL.md
+++ b/skills/aris-paper-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-paper-writing
 description: "Workflow 3: Full paper writing pipeline. Orchestrates paper-plan → paper-figure → paper-write → paper-compile → auto-paper-improvement-loop to go from a narrative report to a polished, submission-ready PDF. Use when user says \"写论文全流程\", \"write paper pipeline\", \"从报告到PDF\", \"paper writing\", or wants the complete paper generation workflow."
-argument-hint: [narrative-report-path-or-topic]
+argument-hint: "[narrative-report-path-or-topic]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-pixel-art/SKILL.md
+++ b/skills/aris-pixel-art/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-pixel-art
 description: Generate pixel art SVG illustrations for READMEs, docs, or slides. Use when user says "画像素图", "pixel art", "make an SVG illustration", "README hero image", or wants a cute visual.
-argument-hint: [description of what to draw]
+argument-hint: "[description of what to draw]"
 allowed-tools: Write, Edit, Read, Bash(open *)
 license: MIT
 metadata:

--- a/skills/aris-proof-writer/SKILL.md
+++ b/skills/aris-proof-writer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-proof-writer
 description: Writes rigorous mathematical proofs for ML/AI theory. Use when asked to prove a theorem, lemma, proposition, or corollary, fill in missing proof steps, formalize a proof sketch, 补全证明, 写证明, 证明某个命题, or determine whether a claimed proof can actually be completed under the stated assumptions.
-argument-hint: [theorem-statement-and-assumptions]
+argument-hint: "[theorem-statement-and-assumptions]"
 allowed-tools: Read, Write, Edit, Grep, Glob
 license: MIT
 metadata:

--- a/skills/aris-rebuttal/SKILL.md
+++ b/skills/aris-rebuttal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-rebuttal
 description: "Workflow 4: Submission rebuttal pipeline. Parses external reviews, enforces coverage and grounding, drafts a safe text-only rebuttal under venue limits, and manages follow-up rounds. Use when user says \"rebuttal\", \"reply to reviewers\", \"ICML rebuttal\", \"OpenReview response\", or wants to answer external reviews safely."
-argument-hint: [paper-path-or-review-bundle]
+argument-hint: "[paper-path-or-review-bundle]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-research-lit/SKILL.md
+++ b/skills/aris-research-lit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-research-lit
 description: Search and analyze research papers, find related work, summarize key ideas. Use when user says "find papers", "related work", "literature review", "what does this paper say", or needs to understand academic papers.
-argument-hint: [paper-topic-or-url]
+argument-hint: "[paper-topic-or-url]"
 allowed-tools: Bash(*), Read, Glob, Grep, WebSearch, WebFetch, Write, Agent, mcp__zotero__*, mcp__obsidian-vault__*
 license: MIT
 metadata:

--- a/skills/aris-research-pipeline/SKILL.md
+++ b/skills/aris-research-pipeline/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-research-pipeline
 description: "Full research pipeline: Workflow 1 (idea discovery) → implementation → Workflow 2 (auto review loop). Goes from a broad research direction all the way to a submission-ready paper. Use when user says \"全流程\", \"full pipeline\", \"从找idea到投稿\", \"end-to-end research\", or wants the complete autonomous research lifecycle."
-argument-hint: [research-direction]
+argument-hint: "[research-direction]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Agent, Skill, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-research-review/SKILL.md
+++ b/skills/aris-research-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-research-review
 description: Get a deep critical review of research from GPT via Codex MCP. Use when user says "review my research", "help me review", "get external review", or wants critical feedback on research ideas, papers, or experimental results.
-argument-hint: [topic-or-scope]
+argument-hint: "[topic-or-scope]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, Agent, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-research-wiki/SKILL.md
+++ b/skills/aris-research-wiki/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-research-wiki
 description: "Persistent research knowledge base that accumulates papers, ideas, experiments, claims, and their relationships across the entire research lifecycle. Inspired by Karpathy's LLM Wiki pattern. Use when user says \"知识库\", \"research wiki\", \"add paper\", \"wiki query\", \"查知识库\", or wants to build/query a persistent field map."
-argument-hint: [subcommand: ingest|query|update|lint|stats|init]
+argument-hint: "[subcommand: ingest|query|update|lint|stats|init]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent, WebSearch, WebFetch, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-result-to-claim/SKILL.md
+++ b/skills/aris-result-to-claim/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-result-to-claim
 description: Use when experiments complete to judge what claims the results support, what they don't, and what evidence is still missing. Codex MCP evaluates results against intended claims and routes to next action (pivot, supplement, or confirm). Use after experiments finish — before writing the paper or running ablations.
-argument-hint: [experiment-description-or-wandb-run]
+argument-hint: "[experiment-description-or-wandb-run]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-run-experiment/SKILL.md
+++ b/skills/aris-run-experiment/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-run-experiment
 description: Deploy and run ML experiments on local, remote, Vast.ai, or Modal serverless GPU. Use when user says "run experiment", "deploy to server", "跑实验", or needs to launch training jobs.
-argument-hint: [experiment-description]
+argument-hint: "[experiment-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent, Skill(serverless-modal)
 license: MIT
 metadata:

--- a/skills/aris-serverless-modal/SKILL.md
+++ b/skills/aris-serverless-modal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-serverless-modal
 description: "Run GPU workloads on Modal — training, fine-tuning, inference, batch processing. Zero-config serverless: no SSH, no Docker, auto scale-to-zero. Use when user says \"modal run\", \"modal training\", \"modal inference\", \"deploy to modal\", \"need a GPU\", \"run on modal\", \"serverless GPU\", or needs remote GPU compute."
-argument-hint: [task-description]
+argument-hint: "[task-description]"
 allowed-tools: Bash(*), Read, Grep, Glob, Edit, Write, Agent
 license: MIT
 metadata:

--- a/skills/aris-training-check/SKILL.md
+++ b/skills/aris-training-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-training-check
 description: Periodically check WandB metrics during training to catch problems early (NaN, loss divergence, idle GPUs). Avoids wasting GPU hours on broken runs. Use when training is running and you want automated health checks.
-argument-hint: [wandb-run-path]
+argument-hint: "[wandb-run-path]"
 allowed-tools: Bash(*), Read, Grep, Glob, Write, Edit, mcp__codex__codex, mcp__codex__codex-reply
 license: MIT
 metadata:

--- a/skills/aris-vast-gpu/SKILL.md
+++ b/skills/aris-vast-gpu/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: aris-vast-gpu
 description: "Rent, manage, and destroy GPU instances on vast.ai. Use when user says \"rent gpu\", \"vast.ai\", \"rent a server\", \"cloud gpu\", or needs on-demand GPU without owning hardware."
-argument-hint: [task-description or action]
+argument-hint: "[task-description or action]"
 allowed-tools: Bash(*), Read, Write, Edit, Grep, Glob, Agent
 license: MIT
 metadata:


### PR DESCRIPTION
Closes #210.

## Summary

Purely mechanical single-character transform to 37 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (37)

- `skills/aris-analyze-results/SKILL.md`
- `skills/aris-novelty-check/SKILL.md`
- `skills/aris-arxiv/SKILL.md`
- `skills/aris-pixel-art/SKILL.md`
- `skills/aris-research-review/SKILL.md`
- `skills/aris-training-check/SKILL.md`
- `skills/aris-monitor-experiment/SKILL.md`
- `skills/aris-ablation-planner/SKILL.md`
- `skills/aris-feishu-notify/SKILL.md`
- `skills/aris-proof-writer/SKILL.md`
- `skills/aris-rebuttal/SKILL.md`
- `skills/aris-compute-guard/SKILL.md`
- `skills/aris-result-to-claim/SKILL.md`
- `skills/aris-dse-loop/SKILL.md`
- `skills/aris-vast-gpu/SKILL.md`
- `skills/aris-paper-plan/SKILL.md`
- `skills/aris-paper-compile/SKILL.md`
- `skills/aris-meta-optimize/SKILL.md`
- `skills/aris-paper-figure/SKILL.md`
- `skills/aris-paper-writing/SKILL.md`
- `skills/aris-research-wiki/SKILL.md`
- `skills/aris-idea-creator/SKILL.md`
- `skills/aris-research-lit/SKILL.md`
- `skills/aris-research-pipeline/SKILL.md`
- `skills/aris-paper-write/SKILL.md`
- `skills/aris-run-experiment/SKILL.md`
- `skills/aris-idea-discovery/SKILL.md`
- `skills/aris-paper-slides/SKILL.md`
- `skills/aris-formula-derivation/SKILL.md`
- `skills/aris-serverless-modal/SKILL.md`
- `skills/aris-mermaid-diagram/SKILL.md`
- `skills/aris-paper-poster/SKILL.md`
- `skills/aris-experiment-bridge/SKILL.md`
- `skills/aris-auto-review-loop/SKILL.md`
- `skills/aris-grant-proposal/SKILL.md`
- `skills/aris-paper-illustration/SKILL.md`
- `skills/aris-auto-paper-improvement-loop/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
