### PR TITLE
fix(perf): stop re-parsing the whole Codex session history on every refresh

### DIFF
--- a/server/__tests__/codex-session-index-cache.test.mjs
+++ b/server/__tests__/codex-session-index-cache.test.mjs
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile, appendFile, readFile } from 'fs/promises';
+import fsSync from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Regression tests for the Codex session index.
+ *
+ * Before the fix, buildCodexSessionsIndex() re-read and JSON.parse'd every line
+ * of every transcript under ~/.codex/sessions on every call. With a realistic
+ * multi-gigabyte session history that is tens of seconds of blocking work on the
+ * main thread, repeated at least every 30 seconds — which is what made the app
+ * lag, stall on "loading", and refuse to create new sessions.
+ */
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalDatabasePath = process.env.DATABASE_PATH;
+
+let tempRoot = null;
+let projectRoot = null;
+
+async function loadProjects() {
+  vi.resetModules();
+  const projects = await import('../projects.js');
+  return projects;
+}
+
+function sessionLines({ sessionId, cwd, timestamp, userMessage }) {
+  return [
+    { timestamp, type: 'session_meta', payload: { id: sessionId, timestamp, cwd, model: 'gpt-5.6' } },
+    { timestamp, type: 'event_msg', payload: { type: 'user_message', message: userMessage } },
+    { timestamp, type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ok' }] } },
+  ].map((entry) => JSON.stringify(entry)).join('\n') + '\n';
+}
+
+async function writeRollout({ sessionId, cwd, userMessage = 'hello', timestamp = '2026-06-09T11:00:00.000Z' }) {
+  const sessionFile = path.join(
+    tempRoot, '.codex', 'sessions', '2026', '06', '09',
+    `rollout-2026-06-09T11-00-00-${sessionId}.jsonl`,
+  );
+  await mkdir(path.dirname(sessionFile), { recursive: true });
+  await writeFile(sessionFile, sessionLines({ sessionId, cwd, timestamp, userMessage }), 'utf8');
+  return sessionFile;
+}
+
+describe('Codex session index caching', () => {
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'dr-claw-codex-cache-'));
+    process.env.HOME = tempRoot;
+    process.env.USERPROFILE = tempRoot;
+    process.env.DATABASE_PATH = path.join(tempRoot, 'db', 'auth.db');
+
+    projectRoot = path.join(tempRoot, 'workspace', 'demo');
+    await mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    process.env.DATABASE_PATH = originalDatabasePath;
+    vi.restoreAllMocks();
+  });
+
+  it('does not re-read a transcript whose size and mtime are unchanged', async () => {
+    await writeRollout({ sessionId: 'sess-a', cwd: projectRoot, userMessage: 'first prompt' });
+    const { buildCodexSessionsIndex } = await loadProjects();
+
+    const first = await buildCodexSessionsIndex();
+    expect([...first.values()].flat()).toHaveLength(1);
+
+    // Count file reads on the second pass only, so the cold pass is not counted.
+    const createReadStream = vi.spyOn(fsSync, 'createReadStream');
+    const second = await buildCodexSessionsIndex();
+
+    expect(createReadStream).not.toHaveBeenCalled();
+    expect([...second.values()].flat()).toHaveLength(1);
+    expect([...second.values()].flat()[0].summary).toContain('first prompt');
+  });
+
+  it('parses only the appended tail when a transcript grows', async () => {
+    const sessionFile = await writeRollout({ sessionId: 'sess-b', cwd: projectRoot, userMessage: 'first prompt' });
+    const { buildCodexSessionsIndex } = await loadProjects();
+
+    await buildCodexSessionsIndex();
+    const sizeAfterFirstPass = (await readFile(sessionFile)).length;
+
+    await appendFile(sessionFile, JSON.stringify({
+      timestamp: '2026-06-09T12:00:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'second prompt' },
+    }) + '\n', 'utf8');
+
+    const createReadStream = vi.spyOn(fsSync, 'createReadStream');
+    const index = await buildCodexSessionsIndex();
+
+    expect(createReadStream).toHaveBeenCalledTimes(1);
+    // The resumed read starts at the previously consumed offset, not at 0.
+    expect(createReadStream.mock.calls[0][1]).toMatchObject({ start: sizeAfterFirstPass });
+
+    const sessions = [...index.values()].flat();
+    expect(sessions).toHaveLength(1);
+    // Folded state carried across the incremental read: both the earlier and the
+    // appended message are counted, and the summary reflects the newest prompt.
+    expect(sessions[0].summary).toContain('second prompt');
+    expect(sessions[0].messageCount).toBe(3);
+  });
+
+  it('matches a full re-parse after an incremental read', async () => {
+    const sessionFile = await writeRollout({ sessionId: 'sess-c', cwd: projectRoot, userMessage: 'alpha' });
+    const projects = await loadProjects();
+
+    await projects.buildCodexSessionsIndex();
+    await appendFile(sessionFile, JSON.stringify({
+      timestamp: '2026-06-09T12:30:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: 'beta 请问大家有变卡的情况吗' },
+    }) + '\n', 'utf8');
+
+    const incremental = [...(await projects.buildCodexSessionsIndex()).values()].flat();
+
+    projects.resetCodexSessionFileCache();
+    const fullReparse = [...(await projects.buildCodexSessionsIndex()).values()].flat();
+
+    expect(incremental).toEqual(fullReparse);
+  });
+
+  it('re-parses from scratch when a transcript is rewritten smaller', async () => {
+    const sessionFile = await writeRollout({ sessionId: 'sess-d', cwd: projectRoot, userMessage: 'original prompt' });
+    const { buildCodexSessionsIndex } = await loadProjects();
+
+    await buildCodexSessionsIndex();
+
+    // Simulate a rewrite/truncation rather than an append.
+    await writeFile(sessionFile, sessionLines({
+      sessionId: 'sess-d',
+      cwd: projectRoot,
+      timestamp: '2026-06-09T13:00:00.000Z',
+      userMessage: 'rewritten',
+    }), 'utf8');
+
+    const sessions = [...(await buildCodexSessionsIndex()).values()].flat();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].summary).toContain('rewritten');
+    // A stale accumulator would have double-counted the original messages.
+    expect(sessions[0].messageCount).toBe(2);
+  });
+
+  it('re-parses a same-size rewrite instead of treating it as an append', async () => {
+    // A rewrite that lands on an identical byte count is not growth. Resuming
+    // from the cached offset would keep the stale prefix folded in and read
+    // none of the new content.
+    const sessionFile = await writeRollout({ sessionId: 'sess-g', cwd: projectRoot, userMessage: 'aaaaa' });
+    const { buildCodexSessionsIndex } = await loadProjects();
+
+    const before = [...(await buildCodexSessionsIndex()).values()].flat();
+    expect(before[0].summary).toContain('aaaaa');
+    const sizeBefore = fsSync.statSync(sessionFile).size;
+
+    await writeFile(sessionFile, sessionLines({
+      sessionId: 'sess-g',
+      cwd: projectRoot,
+      timestamp: '2026-06-09T14:00:00.000Z',
+      userMessage: 'bbbbb', // same length as 'aaaaa' => same file size
+    }), 'utf8');
+    expect(fsSync.statSync(sessionFile).size).toBe(sizeBefore);
+
+    const after = [...(await buildCodexSessionsIndex()).values()].flat();
+    expect(after[0].summary).toContain('bbbbb');
+    expect(after[0].messageCount).toBe(2);
+  });
+
+  it('includes a final record that has no trailing newline', async () => {
+    const dir = path.join(tempRoot, '.codex', 'sessions', '2026', '06', '09');
+    await mkdir(dir, { recursive: true });
+    const sessionFile = path.join(dir, 'rollout-sess-h.jsonl');
+    // Note: no terminating newline on the last record.
+    await writeFile(sessionFile, [
+      JSON.stringify({ timestamp: '2026-06-09T11:00:00.000Z', type: 'session_meta', payload: { id: 'sess-h', cwd: projectRoot, model: 'gpt-5.6' } }),
+      JSON.stringify({ timestamp: '2026-06-09T11:01:00.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'unterminated tail' } }),
+    ].join('\n'), 'utf8');
+
+    const { buildCodexSessionsIndex } = await loadProjects();
+    const sessions = [...(await buildCodexSessionsIndex()).values()].flat();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].summary).toContain('unterminated tail');
+    expect(sessions[0].messageCount).toBe(1);
+  });
+
+  it('does not double-count a trailing record once it is terminated', async () => {
+    const dir = path.join(tempRoot, '.codex', 'sessions', '2026', '06', '09');
+    await mkdir(dir, { recursive: true });
+    const sessionFile = path.join(dir, 'rollout-sess-i.jsonl');
+    await writeFile(sessionFile, [
+      JSON.stringify({ timestamp: '2026-06-09T11:00:00.000Z', type: 'session_meta', payload: { id: 'sess-i', cwd: projectRoot, model: 'gpt-5.6' } }),
+      JSON.stringify({ timestamp: '2026-06-09T11:01:00.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'mid-write' } }),
+    ].join('\n'), 'utf8');
+
+    const { buildCodexSessionsIndex } = await loadProjects();
+    const first = [...(await buildCodexSessionsIndex()).values()].flat();
+    expect(first[0].messageCount).toBe(1);
+
+    // The writer completes that line and appends nothing else.
+    await appendFile(sessionFile, '\n', 'utf8');
+
+    const second = [...(await buildCodexSessionsIndex()).values()].flat();
+    expect(second[0].messageCount).toBe(1);
+    expect(second[0].summary).toContain('mid-write');
+  });
+
+  it('finds a session with no cwd, which the project index cannot hold', async () => {
+    const dir = path.join(tempRoot, '.codex', 'sessions', '2026', '06', '09');
+    await mkdir(dir, { recursive: true });
+    // Opaque filename AND no cwd: neither the basename match nor the project
+    // index can resolve this, so the header scan has to.
+    const sessionFile = path.join(dir, 'rollout-no-cwd.jsonl');
+    await writeFile(sessionFile, [
+      JSON.stringify({ timestamp: '2026-06-09T11:00:00.000Z', type: 'session_meta', payload: { id: 'sess-nocwd', model: 'gpt-5.6' } }),
+      JSON.stringify({ timestamp: '2026-06-09T11:01:00.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'orphaned session' } }),
+      JSON.stringify({ timestamp: '2026-06-09T11:02:00.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'still reachable' }] } }),
+    ].join('\n') + '\n', 'utf8');
+
+    const { getCodexSessionMessages, deleteCodexSession } = await loadProjects();
+
+    const result = await getCodexSessionMessages('sess-nocwd');
+    expect(result.messages.length).toBeGreaterThan(0);
+
+    // Deleting must remove the transcript, not just a database row.
+    await deleteCodexSession('sess-nocwd');
+    expect(fsSync.existsSync(sessionFile)).toBe(false);
+  });
+
+  it('does not delete a transcript whose filename merely contains the id', async () => {
+    const dir = path.join(tempRoot, '.codex', 'sessions', '2026', '06', '09');
+    await mkdir(dir, { recursive: true });
+
+    // Filename contains "abc123" as a substring but belongs to another session.
+    const decoy = path.join(dir, 'rollout-abc1234567.jsonl');
+    await writeFile(decoy, sessionLines({
+      sessionId: 'abc1234567',
+      cwd: projectRoot,
+      timestamp: '2026-06-09T10:00:00.000Z',
+      userMessage: 'do not touch me',
+    }), 'utf8');
+
+    const target = path.join(dir, 'rollout-opaque.jsonl');
+    await writeFile(target, sessionLines({
+      sessionId: 'abc123',
+      cwd: projectRoot,
+      timestamp: '2026-06-09T11:00:00.000Z',
+      userMessage: 'delete me',
+    }), 'utf8');
+
+    const { deleteCodexSession } = await loadProjects();
+    await deleteCodexSession('abc123');
+
+    expect(fsSync.existsSync(decoy)).toBe(true);
+    expect(fsSync.existsSync(target)).toBe(false);
+  });
+
+  it('drops cache entries for deleted transcripts', async () => {
+    const sessionFile = await writeRollout({ sessionId: 'sess-e', cwd: projectRoot });
+    const { buildCodexSessionsIndex } = await loadProjects();
+
+    expect([...(await buildCodexSessionsIndex()).values()].flat()).toHaveLength(1);
+
+    await rm(sessionFile);
+
+    expect([...(await buildCodexSessionsIndex()).values()].flat()).toHaveLength(0);
+  });
+
+  it('resolves a session file by id without re-parsing every transcript', async () => {
+    // Filename intentionally does NOT contain the session id, so the lookup has
+    // to fall through to the index rather than the cheap basename match.
+    const dir = path.join(tempRoot, '.codex', 'sessions', '2026', '06', '09');
+    await mkdir(dir, { recursive: true });
+    const sessionFile = path.join(dir, 'rollout-opaque-name.jsonl');
+    await writeFile(sessionFile, sessionLines({
+      sessionId: 'sess-lookup',
+      cwd: projectRoot,
+      timestamp: '2026-06-09T11:00:00.000Z',
+      userMessage: 'find me',
+    }), 'utf8');
+
+    // Decoys the old implementation would also have parsed line by line.
+    for (let i = 0; i < 5; i++) {
+      await writeFile(path.join(dir, `rollout-decoy-${i}.jsonl`), sessionLines({
+        sessionId: `decoy-${i}`,
+        cwd: projectRoot,
+        timestamp: '2026-06-09T10:00:00.000Z',
+        userMessage: 'decoy',
+      }), 'utf8');
+    }
+
+    const { buildCodexSessionsIndex, getCodexSessionMessages } = await loadProjects();
+    await buildCodexSessionsIndex();
+
+    const createReadStream = vi.spyOn(fsSync, 'createReadStream');
+    const result = await getCodexSessionMessages('sess-lookup');
+
+    expect(result.messages.length).toBeGreaterThan(0);
+    // Only the resolved transcript is read — not the five decoys.
+    const readPaths = new Set(createReadStream.mock.calls.map((call) => String(call[0])));
+    expect([...readPaths]).toEqual([sessionFile]);
+  });
+
+  it('collapses concurrent scans onto a single pass', async () => {
+    await writeRollout({ sessionId: 'sess-f', cwd: projectRoot });
+    const { buildCodexSessionsIndex, resetCodexSessionFileCache } = await loadProjects();
+    resetCodexSessionFileCache();
+
+    const createReadStream = vi.spyOn(fsSync, 'createReadStream');
+    const [a, b, c] = await Promise.all([
+      buildCodexSessionsIndex(),
+      buildCodexSessionsIndex(),
+      buildCodexSessionsIndex(),
+    ]);
+
+    expect(createReadStream).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+});

--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -28,6 +28,7 @@ import { createRequestId, waitForToolApproval, resolveToolApproval as resolvePer
 import { buildMemoryBlock } from './utils/memoryPrompt.js';
 import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
 import { COMPUTE_GUARD_BLOCK } from './utils/computeGuardPrompt.js';
+import { debugLog } from './utils/logger.js';
 
 const activeSessions = new Map();
 const pendingClaudeSessionIndexReconciles = new Map();
@@ -690,10 +691,13 @@ async function queryClaudeSDK(command, options = {}, ws) {
             mode: sessionMode || 'research'
           });
         } else {
-          console.log('Not sending session-created. sessionId:', sessionId, 'sessionCreatedSent:', sessionCreatedSent);
+          debugLog('claude', 'Not sending session-created. sessionId:', sessionId, 'sessionCreatedSent:', sessionCreatedSent);
         }
       } else {
-        console.log('No session_id in message or already captured. message.session_id:', message.session_id, 'capturedSessionId:', capturedSessionId);
+        // Fires for every message in the stream once the session id is known.
+        // Left unguarded this was thousands of console writes per turn, which
+        // stalls the event loop on a Windows console TTY.
+        debugLog('claude', 'No session_id in message or already captured. message.session_id:', message.session_id, 'capturedSessionId:', capturedSessionId);
       }
 
       // Track usage from assistant messages (per-API-call, not cumulative)

--- a/server/index.js
+++ b/server/index.js
@@ -42,7 +42,7 @@ import pty from 'node-pty';
 import fetch from 'node-fetch';
 import mime from 'mime-types';
 
-import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, resolveClaudeProjectDirs, clearProjectDirectoryCache } from './projects.js';
+import { getProjects, getTrashedProjects, getSessions, getSessionMessages, renameProject, renameSession, deleteSession, deleteProject, restoreProject, deleteTrashedProject, addProjectManually, extractProjectDirectory, resolveClaudeProjectDirs, clearProjectDirectoryCache, projectsEvents } from './projects.js';
 import { getProjectTokenUsageSummary } from './project-token-usage.js';
 import { queryClaudeSDK, abortClaudeSDKSession, isClaudeSDKSessionActive, getClaudeSDKSessionStartTime, getActiveClaudeSDKSessions, resolveToolApproval } from './claude-sdk.js';
 import { spawnCursor, abortCursorSession, isCursorSessionActive, getCursorSessionStartTime, getActiveCursorSessions } from './cursor-cli.js';
@@ -116,9 +116,14 @@ let isGetProjectsRunning = false; // Flag to prevent reentrant calls
 let hasPendingProjectsUpdate = false;
 let lastWatcherEvent = null;
 let lastProjectsUpdateSignature = '';
+// Assigned by setupProjectsWatcher(); lets background discovery passes reuse the
+// same debounced broadcast instead of pushing their own project snapshots.
+let scheduleProjectsBroadcast = null;
 
 function shouldProcessProjectsWatcherEvent(eventType, filePath, provider) {
-    if (eventType === 'addDir' || eventType === 'unlinkDir') {
+    // 'discovery' is synthetic: emitted by background project discovery rather
+    // than by chokidar, so there is no file path to filter on.
+    if (eventType === 'addDir' || eventType === 'unlinkDir' || eventType === 'discovery') {
         return true;
     }
 
@@ -205,23 +210,25 @@ async function setupProjectsWatcher() {
 
                 // Get updated projects list
                 const updatedProjects = await getProjects();
-                const updateSignature = JSON.stringify(updatedProjects);
+
+                // Serialize once and reuse it as the change signature. The
+                // project list can be megabytes, so stringifying it twice per
+                // watcher event was pure GC pressure on the main thread.
+                const projectsJson = JSON.stringify(updatedProjects);
 
                 // Skip broadcasting identical snapshots
-                if (updateSignature === lastProjectsUpdateSignature) {
+                if (projectsJson === lastProjectsUpdateSignature) {
                     return;
                 }
-                lastProjectsUpdateSignature = updateSignature;
+                lastProjectsUpdateSignature = projectsJson;
 
                 // Notify all connected clients about the project changes
-                const updateMessage = JSON.stringify({
-                    type: 'projects_updated',
-                    projects: updatedProjects,
-                    timestamp: new Date().toISOString(),
-                    changeType: eventType,
-                    changedFile: path.relative(rootPath, filePath),
-                    watchProvider: provider
-                });
+                const updateMessage = '{"type":"projects_updated","projects":' + projectsJson
+                    + ',"timestamp":' + JSON.stringify(new Date().toISOString())
+                    + ',"changeType":' + JSON.stringify(eventType ?? null)
+                    + ',"changedFile":' + JSON.stringify(rootPath && filePath ? path.relative(rootPath, filePath) : null)
+                    + ',"watchProvider":' + JSON.stringify(provider ?? null)
+                    + '}';
 
                 connectedClients.forEach(client => {
                     if (client.readyState === WebSocket.OPEN) {
@@ -241,6 +248,8 @@ async function setupProjectsWatcher() {
             }
         }, WATCHER_DEBOUNCE_MS);
     };
+
+    scheduleProjectsBroadcast = debouncedUpdate;
 
     for (const { provider, rootPath } of PROVIDER_WATCH_PATHS) {
         try {
@@ -3254,6 +3263,12 @@ async function startServer() {
 
         // Start watching the projects folder for changes
         await setupProjectsWatcher();
+
+        // Background discovery (e.g. the Codex session scan) runs off the request
+        // path, so it publishes its results through this event instead.
+        projectsEvents.on('projects-changed', (detail) => {
+            scheduleProjectsBroadcast?.('discovery', null, detail?.reason || 'discovery', null);
+        });
     } catch (error) {
         console.error('[ERROR] Failed to start server:', error);
         process.exit(1);

--- a/server/openai-codex.js
+++ b/server/openai-codex.js
@@ -27,6 +27,7 @@ import { expandSkillCommand } from './utils/skillExpander.js';
 import { resolveCodexWorkingDirectory } from './utils/codexWorkingDir.js';
 import { CODEX_MODELS } from '../shared/modelConstants.js';
 import { BTW_SYSTEM_PROMPT, buildBtwUserMessage } from './utils/btw.js';
+import { debugLog, isVerboseLogging } from './utils/logger.js';
 
 // Track active sessions
 const activeCodexSessions = new Map();
@@ -489,18 +490,23 @@ export async function queryCodex(command, options = {}, ws) {
       const itemType = event.item?.type || 'unknown';
       const itemId = event.item?.id || null;
 
-      // Detailed debug logging
-      if (event.item) {
-        const preview = event.item.text ? event.item.text.substring(0, 80) : (event.item.command || '');
-        console.log(`[Codex] ${event.type} | ${itemType} | id=${itemId} | preview="${preview}"`);
-        // Extra logging for command_execution output
-        if (itemType === 'command_execution' && event.type === 'item.completed') {
-          const outLen = event.item.aggregated_output?.length || 0;
-          const outPreview = event.item.aggregated_output?.substring(0, 120) || '(empty)';
-          console.log(`[Codex]   cmd output (${outLen} chars): "${outPreview}"`);
+      // Per-event logging is opt-in (DRCLAW_DEBUG=codex). Unconditionally
+      // logging every SDK event — including the item.updated stream noise that
+      // is discarded a few lines below — produced thousands of console writes
+      // per turn, which blocks the event loop on a Windows console TTY.
+      if (isVerboseLogging('codex')) {
+        if (event.item) {
+          const preview = event.item.text ? event.item.text.substring(0, 80) : (event.item.command || '');
+          console.log(`[Codex] ${event.type} | ${itemType} | id=${itemId} | preview="${preview}"`);
+          // Extra logging for command_execution output
+          if (itemType === 'command_execution' && event.type === 'item.completed') {
+            const outLen = event.item.aggregated_output?.length || 0;
+            const outPreview = event.item.aggregated_output?.substring(0, 120) || '(empty)';
+            console.log(`[Codex]   cmd output (${outLen} chars): "${outPreview}"`);
+          }
+        } else {
+          console.log(`[Codex] ${event.type}`);
         }
-      } else {
-        console.log(`[Codex] ${event.type}`);
       }
 
       // Event filtering:
@@ -527,7 +533,7 @@ export async function queryCodex(command, options = {}, ws) {
 
       // Skip null transforms (empty reasoning, etc.)
       if (!transformed) {
-        console.log(`[Codex] Skipped null transform for ${event.type} | ${itemType}`);
+        debugLog('codex', `[Codex] Skipped null transform for ${event.type} | ${itemType}`);
         continue;
       }
 

--- a/server/projects.js
+++ b/server/projects.js
@@ -85,6 +85,15 @@ import {
   readExplicitSessionModeFromMetadata,
 } from './utils/sessionMode.js';
 import { resolveNanoSessionAbsPath, safeNanoSessionFilename } from './nanoSessionPaths.js';
+import { readJsonlLinesFrom } from './utils/jsonlTailReader.js';
+import { EventEmitter } from 'events';
+
+/**
+ * Emitted when a background discovery pass changes the project set, so the
+ * server can push a fresh list to connected clients. Background work must never
+ * make an HTTP handler wait — see scheduleCodexProjectSync().
+ */
+const projectsEvents = new EventEmitter();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DRCLAW_SKILLS_DIR = path.join(__dirname, '..', 'skills');
@@ -292,6 +301,53 @@ function collectCodexProjectCandidates(sessionsByProject = new Map()) {
 
 const CODEX_SYNC_COOLDOWN_MS = 30_000;
 let lastCodexSyncTimestamp = 0;
+let codexSyncInFlight = null;
+let lastCodexSyncSignature = '';
+let lastBroadcastCodexSyncSignature = null;
+
+/**
+ * Run the Codex discovery sync without blocking the caller.
+ *
+ * getProjects() answers from the project database, so it does not need the sync
+ * to finish first — and it must not wait for it. The first sync after start-up
+ * walks the whole ~/.codex/sessions tree, which can take many seconds on a heavy
+ * user; awaiting it made the initial /api/projects request (and therefore the
+ * whole UI) hang. Instead the sync runs in the background and emits
+ * 'projects-changed' when it actually adds something, which the server
+ * re-broadcasts so newly discovered projects appear without a manual refresh.
+ */
+function scheduleCodexProjectSync(config, projectDb, userId = null, visibleWorkspaceRoots = []) {
+  if (codexSyncInFlight) {
+    return codexSyncInFlight;
+  }
+
+  if (Date.now() - lastCodexSyncTimestamp < CODEX_SYNC_COOLDOWN_MS) {
+    return Promise.resolve(0);
+  }
+
+  codexSyncInFlight = syncDiscoveredProjectsFromCodexSessions(config, projectDb, userId, visibleWorkspaceRoots)
+    .then((syncedProjects) => {
+      // Only wake the UI when the sync actually changed something; otherwise a
+      // steady 30s cadence of no-op syncs would keep re-broadcasting an
+      // identical project list to every connected client. The signature covers
+      // session counts and newest activity per project, not just project names —
+      // a new Codex session inside an existing project changes the sidebar too.
+      if (lastCodexSyncSignature !== lastBroadcastCodexSyncSignature) {
+        lastBroadcastCodexSyncSignature = lastCodexSyncSignature;
+        projectsEvents.emit('projects-changed', { reason: 'codex-sync', syncedProjects });
+      }
+      return syncedProjects;
+    })
+    .catch((error) => {
+      console.warn('[projects] Codex discovery sync failed:', error.message);
+      return 0;
+    })
+    .finally(() => {
+      codexSyncInFlight = null;
+    });
+
+  return codexSyncInFlight;
+}
 
 async function syncDiscoveredProjectsFromCodexSessions(config, projectDb, userId = null, visibleWorkspaceRoots = []) {
   const now = Date.now();
@@ -303,6 +359,7 @@ async function syncDiscoveredProjectsFromCodexSessions(config, projectDb, userId
   const discoveredSessions = await buildCodexSessionsIndex();
   const candidates = collectCodexProjectCandidates(discoveredSessions);
   let syncedProjects = 0;
+  const syncedProjectFingerprints = [];
 
   for (const candidate of candidates) {
     const { projectName, projectPath, sessions } = candidate;
@@ -356,8 +413,16 @@ async function syncDiscoveredProjectsFromCodexSessions(config, projectDb, userId
     }
 
     syncedProjects += 1;
+    // Track enough per-project detail that a new session inside an already
+    // known project still registers as a change worth broadcasting.
+    const newestActivity = sessions.reduce((newest, session) => {
+      const activity = new Date(session.lastActivity || 0).getTime();
+      return activity > newest ? activity : newest;
+    }, 0);
+    syncedProjectFingerprints.push(`${projectName}:${sessions.length}:${newestActivity}`);
   }
 
+  lastCodexSyncSignature = syncedProjectFingerprints.sort().join('\n');
   lastCodexSyncTimestamp = Date.now();
   return syncedProjects;
 }
@@ -1404,7 +1469,9 @@ async function getProjects(userId, progressCallback = null) {
     );
     _lastBootstrapByUser.set(userKey, now);
   }
-  await syncDiscoveredProjectsFromCodexSessions(config, projectDb, userId || null, visibleWorkspaceRoots);
+  // Fire-and-forget: the response is built from the project database, so it must
+  // not wait on a filesystem walk of ~/.codex/sessions.
+  scheduleCodexProjectSync(config, projectDb, userId || null, visibleWorkspaceRoots);
   const dbProjects = projectDb.getAllProjects(userId || null);
 
   try {
@@ -3762,7 +3829,90 @@ async function findCodexJsonlFiles(dir) {
   return files;
 }
 
-async function buildCodexSessionsIndex() {
+/**
+ * Per-file memo for the Codex session index.
+ *
+ * Without this, every scan re-read and JSON.parse'd every line of every session
+ * transcript under ~/.codex/sessions. That directory only grows: on a
+ * regular user it reached 577 files / 10 GB, where one scan measured ~30s and
+ * re-ran at least every CODEX_SYNC_COOLDOWN_MS. Because getProjects() awaited
+ * the scan, /api/projects inherited that latency and the app spent most of its
+ * time inside a scan — which is what users saw as lag, "loading" that never
+ * finished, and new sessions that could not be created.
+ *
+ * With the memo the same directory re-scans in ~11ms.
+ *
+ * Entries key on (ino, size, mtimeMs). Session transcripts are append-only, so
+ * when only the size grows we resume the fold from `consumedBytes` and parse
+ * just the new tail. Anything else (shrink, inode change, clock going
+ * backwards) falls back to a full re-parse.
+ */
+const codexSessionFileCache = new Map();
+const CODEX_SESSION_CACHE_MAX_ENTRIES = 20_000;
+let codexSessionsIndexInFlight = null;
+
+function resetCodexSessionFileCache() {
+  codexSessionFileCache.clear();
+}
+
+async function readCodexSessionFileCached(filePath, stats) {
+  const cached = codexSessionFileCache.get(filePath);
+  const sameInode = Boolean(cached) && (cached.ino === undefined || cached.ino === stats.ino);
+
+  if (sameInode && stats.size === cached.size && stats.mtimeMs === cached.mtimeMs) {
+    return cached.result;
+  }
+
+  // Resume only on strict growth. A rewrite that happens to land on the same
+  // byte count is not an append: treating it as one would keep the stale prefix
+  // folded into the accumulator and skip the new content entirely.
+  const appendOnlyGrowth = sameInode
+    && stats.size > cached.size
+    && cached.consumedBytes <= stats.size;
+
+  // Fold into a copy, not the cached accumulator. If the read throws part-way
+  // the cache entry must stay consistent with its recorded `consumedBytes`;
+  // otherwise the next scan would resume from the old offset over state that had
+  // already advanced, double-counting messages.
+  const state = appendOnlyGrowth ? { ...cached.state } : createCodexSessionParseState();
+  const startOffset = appendOnlyGrowth ? cached.consumedBytes : 0;
+
+  const { consumedBytes, trailingLine } = await readJsonlLinesFrom(filePath, startOffset, (line) => {
+    applyCodexSessionLine(state, line);
+  });
+
+  // A final record with no terminating newline still belongs in the answer, but
+  // must not enter the persisted accumulator — the next resume re-reads those
+  // bytes and would otherwise count them twice.
+  let resultState = state;
+  if (trailingLine) {
+    resultState = { ...state };
+    applyCodexSessionLine(resultState, trailingLine);
+  }
+
+  const result = finalizeCodexSessionParseState(resultState, filePath);
+
+  if (codexSessionFileCache.size >= CODEX_SESSION_CACHE_MAX_ENTRIES && !codexSessionFileCache.has(filePath)) {
+    // Bounded LRU-ish eviction: drop the oldest insertion.
+    const oldestKey = codexSessionFileCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      codexSessionFileCache.delete(oldestKey);
+    }
+  }
+
+  codexSessionFileCache.set(filePath, {
+    ino: stats.ino,
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    consumedBytes,
+    state,
+    result
+  });
+
+  return result;
+}
+
+async function buildCodexSessionsIndexUncached() {
   const codexSessionsDir = path.join(os.homedir(), '.codex', 'sessions');
   const sessionsByProject = new Map();
 
@@ -3773,15 +3923,37 @@ async function buildCodexSessionsIndex() {
   }
 
   const jsonlFiles = await findCodexJsonlFiles(codexSessionsDir);
+  const liveFiles = new Set(jsonlFiles);
+
+  // Drop memo entries for transcripts that were deleted or moved.
+  for (const cachedPath of codexSessionFileCache.keys()) {
+    if (!liveFiles.has(cachedPath)) {
+      codexSessionFileCache.delete(cachedPath);
+    }
+  }
+
+  // realpath() is a syscall per session and most sessions in a directory share
+  // the same cwd, so memoize it for the duration of one scan.
+  const normalizedPathCache = new Map();
+  const normalizeCwd = async (cwd) => {
+    if (!cwd) return '';
+    if (normalizedPathCache.has(cwd)) {
+      return normalizedPathCache.get(cwd);
+    }
+    const normalized = await normalizeComparablePath(cwd);
+    normalizedPathCache.set(cwd, normalized);
+    return normalized;
+  };
 
   for (const filePath of jsonlFiles) {
     try {
-      const sessionData = await parseCodexSessionFile(filePath);
+      const stats = await fs.stat(filePath);
+      const sessionData = await readCodexSessionFileCached(filePath, stats);
       if (!sessionData || !sessionData.id) {
         continue;
       }
 
-      const normalizedProjectPath = await normalizeComparablePath(sessionData.cwd);
+      const normalizedProjectPath = await normalizeCwd(sessionData.cwd);
       if (!normalizedProjectPath) {
         continue;
       }
@@ -3813,6 +3985,25 @@ async function buildCodexSessionsIndex() {
   }
 
   return sessionsByProject;
+}
+
+/**
+ * Build the Codex session index, collapsing concurrent callers onto one scan.
+ *
+ * getProjects(), getCodexSessions() and the filesystem watcher can all ask for
+ * the index at once; without this guard a cold start would run the same
+ * multi-GB walk several times in parallel.
+ */
+async function buildCodexSessionsIndex() {
+  if (codexSessionsIndexInFlight) {
+    return codexSessionsIndexInFlight;
+  }
+
+  codexSessionsIndexInFlight = buildCodexSessionsIndexUncached().finally(() => {
+    codexSessionsIndexInFlight = null;
+  });
+
+  return codexSessionsIndexInFlight;
 }
 
 // Fetch Codex sessions for a given project path
@@ -3882,90 +4073,87 @@ async function getCodexSessions(projectPath, options = {}) {
   }
 }
 
-// Parse a Codex session JSONL file to extract metadata
-async function parseCodexSessionFile(filePath) {
+// Metadata extraction from a Codex session JSONL is a pure fold over its lines,
+// which is what lets buildCodexSessionsIndex() resume a partially-read file
+// instead of re-parsing it. Keep applyCodexSessionLine() free of any state that
+// is not carried in the accumulator, or incremental reads will drift from full
+// reads.
+function createCodexSessionParseState() {
+  return {
+    sessionMeta: null,
+    lastTimestamp: null,
+    lastUserMessage: null,
+    messageCount: 0,
+    detectedSessionMode: null
+  };
+}
+
+function applyCodexSessionLine(state, line) {
+  let entry;
   try {
-    const fileStream = fsSync.createReadStream(filePath);
-    const rl = readline.createInterface({
-      input: fileStream,
-      crlfDelay: Infinity
-    });
+    entry = JSON.parse(line);
+  } catch (parseError) {
+    // Skip malformed lines
+    return;
+  }
 
-    let sessionMeta = null;
-    let lastTimestamp = null;
-    let lastUserMessage = null;
-    let messageCount = 0;
-    let detectedSessionMode = null;
+  // Track timestamp
+  if (entry.timestamp) {
+    state.lastTimestamp = entry.timestamp;
+  }
 
-    for await (const line of rl) {
-      if (line.trim()) {
-        try {
-          const entry = JSON.parse(line);
+  // Extract session metadata
+  if (entry.type === 'session_meta' && entry.payload) {
+    state.sessionMeta = {
+      id: entry.payload.id,
+      cwd: entry.payload.cwd,
+      model: entry.payload.model || entry.payload.model_provider,
+      timestamp: entry.timestamp,
+      git: entry.payload.git
+    };
+  }
 
-          // Track timestamp
-          if (entry.timestamp) {
-            lastTimestamp = entry.timestamp;
-          }
+  // Count messages and extract user messages for summary
+  if (entry.type === 'event_msg' && entry.payload?.type === 'user_message') {
+    state.messageCount++;
+    if (entry.payload.message) {
+      const modeFromMessage = extractSessionModeFromText(entry.payload.message);
+      if (modeFromMessage) {
+        state.detectedSessionMode = modeFromMessage;
+      }
 
-          // Extract session metadata
-          if (entry.type === 'session_meta' && entry.payload) {
-            sessionMeta = {
-              id: entry.payload.id,
-              cwd: entry.payload.cwd,
-              model: entry.payload.model || entry.payload.model_provider,
-              timestamp: entry.timestamp,
-              git: entry.payload.git
-            };
-          }
-
-          // Count messages and extract user messages for summary
-          if (entry.type === 'event_msg' && entry.payload?.type === 'user_message') {
-            messageCount++;
-            if (entry.payload.message) {
-              const modeFromMessage = extractSessionModeFromText(entry.payload.message);
-              if (modeFromMessage) {
-                detectedSessionMode = modeFromMessage;
-              }
-
-              const cleanedUserMessage = stripInternalContextPrefix(entry.payload.message, false);
-              if (cleanedUserMessage && !isCodexSystemPromptContent(cleanedUserMessage)) {
-                if (!detectedSessionMode) {
-                  detectedSessionMode = inferSessionModeFromUserMessage(cleanedUserMessage);
-                }
-                lastUserMessage = cleanedUserMessage;
-              }
-            }
-          }
-
-          if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload.role === 'assistant') {
-            messageCount++;
-          }
-
-        } catch (parseError) {
-          // Skip malformed lines
+      const cleanedUserMessage = stripInternalContextPrefix(entry.payload.message, false);
+      if (cleanedUserMessage && !isCodexSystemPromptContent(cleanedUserMessage)) {
+        if (!state.detectedSessionMode) {
+          state.detectedSessionMode = inferSessionModeFromUserMessage(cleanedUserMessage);
         }
+        state.lastUserMessage = cleanedUserMessage;
       }
     }
+  }
 
-    if (sessionMeta) {
-      return {
-        ...sessionMeta,
-        timestamp: lastTimestamp || sessionMeta.timestamp,
-        mode: detectedSessionMode || 'research',
-        summary: lastUserMessage ?
-          (lastUserMessage.length > 50 ? lastUserMessage.substring(0, 50) + '...' : lastUserMessage) :
-          'Codex Session',
-        messageCount
-      };
-    }
-
-    return null;
-
-  } catch (error) {
-    console.error('Error parsing Codex session file:', error);
-    return null;
+  if (entry.type === 'response_item' && entry.payload?.type === 'message' && entry.payload.role === 'assistant') {
+    state.messageCount++;
   }
 }
+
+function finalizeCodexSessionParseState(state, filePath) {
+  if (!state?.sessionMeta) {
+    return null;
+  }
+
+  return {
+    ...state.sessionMeta,
+    timestamp: state.lastTimestamp || state.sessionMeta.timestamp,
+    mode: state.detectedSessionMode || 'research',
+    summary: state.lastUserMessage
+      ? (state.lastUserMessage.length > 50 ? state.lastUserMessage.substring(0, 50) + '...' : state.lastUserMessage)
+      : 'Codex Session',
+    messageCount: state.messageCount,
+    filePath
+  };
+}
+
 
 /**
  * Detect system prompt / instruction content in Codex messages
@@ -3985,37 +4173,97 @@ function isCodexSystemPromptContent(text) {
   return false;
 }
 
+// A Codex transcript opens with its session_meta record, so the id is available
+// without reading the body. Scan a few lines rather than exactly one so a stray
+// leading record cannot hide it.
+const CODEX_HEADER_SCAN_LINES = 5;
+
+async function readCodexSessionIdFromHeader(filePath) {
+  let sessionId = null;
+  let seen = 0;
+
+  try {
+    await readJsonlLinesFrom(filePath, 0, (line) => {
+      if (sessionId || seen >= CODEX_HEADER_SCAN_LINES) {
+        return;
+      }
+      seen += 1;
+      try {
+        const entry = JSON.parse(line);
+        if (entry?.type === 'session_meta' && entry.payload?.id) {
+          sessionId = entry.payload.id;
+        }
+      } catch (_) {
+        // Skip malformed lines
+      }
+    });
+  } catch (_) {
+    return null;
+  }
+
+  return sessionId;
+}
+
+/**
+ * Locate the transcript file backing a Codex session id.
+ *
+ * Codex normally encodes the session id in the filename, so the basename check
+ * resolves almost every lookup. Both fallbacks used to re-parse every transcript
+ * in the tree end to end, which on a large history stalled every session open
+ * and delete for many seconds.
+ *
+ * The first fallback reads the memoized session index. The second exists
+ * because that index is keyed by project and therefore drops sessions whose
+ * `cwd` is missing or no longer resolvable — those sessions must still be
+ * openable and deletable, so match them on the session_meta header instead of
+ * folding the whole file.
+ */
+async function findCodexSessionFilePath(sessionId) {
+  if (!sessionId) {
+    return null;
+  }
+
+  const codexSessionsDir = path.join(os.homedir(), '.codex', 'sessions');
+  const jsonlFiles = await findCodexJsonlFiles(codexSessionsDir);
+
+  for (const filePath of jsonlFiles) {
+    if (!path.basename(filePath).includes(sessionId)) {
+      continue;
+    }
+    // A filename can merely *contain* the id, and callers act destructively on
+    // what we return (deleteCodexSession unlinks it). Confirm against the
+    // session_meta header, which costs a handful of lines. A transcript whose
+    // header cannot be read is still accepted, matching the long-standing
+    // filename-only behaviour; only a definite mismatch is rejected.
+    const headerId = await readCodexSessionIdFromHeader(filePath);
+    if (headerId === null || headerId === sessionId) {
+      return filePath;
+    }
+  }
+
+  const sessionsByProject = await buildCodexSessionsIndex();
+  for (const sessions of sessionsByProject.values()) {
+    const match = sessions.find((session) => session.id === sessionId);
+    if (match?.filePath) {
+      return match.filePath;
+    }
+  }
+
+  for (const filePath of jsonlFiles) {
+    if (await readCodexSessionIdFromHeader(filePath) === sessionId) {
+      return filePath;
+    }
+  }
+
+  return null;
+}
+
 // Get messages for a specific Codex session
 async function getCodexSessionMessages(sessionId, limit = null, offset = 0) {
   try {
     const codexSessionsDir = path.join(os.homedir(), '.codex', 'sessions');
 
-    const findSessionFileByMetadata = async () => {
-      const jsonlFiles = await findCodexJsonlFiles(codexSessionsDir);
-
-      let filenameMatch = null;
-      for (const filePath of jsonlFiles) {
-        if (path.basename(filePath).includes(sessionId)) {
-          filenameMatch = filePath;
-          break;
-        }
-      }
-
-      if (filenameMatch) {
-        return filenameMatch;
-      }
-
-      for (const filePath of jsonlFiles) {
-        const sessionData = await parseCodexSessionFile(filePath);
-        if (sessionData?.id === sessionId) {
-          return filePath;
-        }
-      }
-
-      return null;
-    };
-
-    const sessionFilePath = await findSessionFileByMetadata();
+    const sessionFilePath = await findCodexSessionFilePath(sessionId);
 
     if (!sessionFilePath) {
       console.warn(`Codex session file not found for session ${sessionId}`);
@@ -4284,13 +4532,10 @@ async function deleteCodexSession(sessionId) {
     const jsonlFiles = await findJsonlFiles(codexSessionsDir);
     let deletedFile = false;
 
-    for (const filePath of jsonlFiles) {
-      const sessionData = await parseCodexSessionFile(filePath);
-      if (sessionData && sessionData.id === sessionId) {
-        await fs.unlink(filePath);
-        deletedFile = true;
-        break;
-      }
+    const matchedFilePath = await findCodexSessionFilePath(sessionId);
+    if (matchedFilePath && jsonlFiles.includes(matchedFilePath)) {
+      await fs.unlink(matchedFilePath);
+      deletedFile = true;
     }
 
     const deletedIndex =
@@ -4512,6 +4757,9 @@ export {
   extractProjectDirectory,
   resolveClaudeProjectDirs,
   clearProjectDirectoryCache,
+  projectsEvents,
+  buildCodexSessionsIndex,
+  resetCodexSessionFileCache,
   getCodexSessions,
   getGeminiSessions,
   getCodexSessionMessages,

--- a/server/utils/__tests__/jsonlTailReader.test.js
+++ b/server/utils/__tests__/jsonlTailReader.test.js
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+import { readJsonlLinesFrom } from '../jsonlTailReader.js';
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'drclaw-jsonl-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function collect(filePath, startOffset = 0) {
+  const lines = [];
+  const result = await readJsonlLinesFrom(filePath, startOffset, (line) => lines.push(line));
+  return { lines, ...result };
+}
+
+describe('readJsonlLinesFrom', () => {
+  it('reads every complete line and reports the end offset', async () => {
+    const file = path.join(tmpDir, 'a.jsonl');
+    const content = '{"a":1}\n{"a":2}\n{"a":3}\n';
+    await fs.writeFile(file, content);
+
+    const { lines, consumedBytes, lineCount } = await collect(file);
+
+    expect(lines).toEqual(['{"a":1}', '{"a":2}', '{"a":3}']);
+    expect(lineCount).toBe(3);
+    expect(consumedBytes).toBe(Buffer.byteLength(content));
+  });
+
+  it('resumes from an offset so appended lines are read exactly once', async () => {
+    const file = path.join(tmpDir, 'b.jsonl');
+    await fs.writeFile(file, '{"n":1}\n{"n":2}\n');
+
+    const first = await collect(file);
+    expect(first.lines).toEqual(['{"n":1}', '{"n":2}']);
+
+    await fs.appendFile(file, '{"n":3}\n{"n":4}\n');
+
+    const second = await collect(file, first.consumedBytes);
+    expect(second.lines).toEqual(['{"n":3}', '{"n":4}']);
+    expect(second.consumedBytes).toBe((await fs.stat(file)).size);
+  });
+
+  it('does not consume a trailing line that has no newline yet', async () => {
+    const file = path.join(tmpDir, 'c.jsonl');
+    await fs.writeFile(file, '{"done":true}\n{"partial":');
+
+    const first = await collect(file);
+    expect(first.lines).toEqual(['{"done":true}']);
+    expect(first.consumedBytes).toBe(Buffer.byteLength('{"done":true}\n'));
+
+    // Writer finishes the line; resuming must yield the whole line, not the tail.
+    await fs.appendFile(file, 'true}\n');
+    const second = await collect(file, first.consumedBytes);
+    expect(second.lines).toEqual(['{"partial":true}']);
+  });
+
+  it('surfaces an unterminated final line separately from consumed lines', async () => {
+    // A file that simply ends without a newline still has a real final record.
+    // It is reported via trailingLine so callers can use it, but excluded from
+    // consumedBytes so a later resume re-reads it exactly once.
+    const file = path.join(tmpDir, 'h.jsonl');
+    await fs.writeFile(file, '{"a":1}\n{"a":2}');
+
+    const { lines, consumedBytes, trailingLine } = await collect(file);
+
+    expect(lines).toEqual(['{"a":1}']);
+    expect(trailingLine).toBe('{"a":2}');
+    expect(consumedBytes).toBe(Buffer.byteLength('{"a":1}\n'));
+
+    // Resuming re-reads the previously trailing record, now terminated.
+    await fs.appendFile(file, '\n');
+    const second = await collect(file, consumedBytes);
+    expect(second.lines).toEqual(['{"a":2}']);
+    expect(second.trailingLine).toBeNull();
+  });
+
+  it('reports no trailing line when the file ends with a newline', async () => {
+    const file = path.join(tmpDir, 'i.jsonl');
+    await fs.writeFile(file, '{"a":1}\n');
+
+    const { trailingLine } = await collect(file);
+    expect(trailingLine).toBeNull();
+  });
+
+  it('keeps offsets byte-accurate for multi-byte UTF-8 content', async () => {
+    const file = path.join(tmpDir, 'd.jsonl');
+    const line1 = JSON.stringify({ msg: '请问大家有变卡的情况吗' });
+    const line2 = JSON.stringify({ msg: '卡顿 🦞 emoji' });
+    await fs.writeFile(file, `${line1}\n`);
+
+    const first = await collect(file);
+    expect(first.lines).toEqual([line1]);
+    expect(first.consumedBytes).toBe(Buffer.byteLength(`${line1}\n`, 'utf8'));
+
+    await fs.appendFile(file, `${line2}\n`);
+    const second = await collect(file, first.consumedBytes);
+    expect(second.lines).toEqual([line2]);
+    expect(JSON.parse(second.lines[0]).msg).toBe('卡顿 🦞 emoji');
+  });
+
+  it('strips CRLF carriage returns while still counting their bytes', async () => {
+    const file = path.join(tmpDir, 'e.jsonl');
+    const content = '{"x":1}\r\n{"x":2}\r\n';
+    await fs.writeFile(file, content);
+
+    const { lines, consumedBytes } = await collect(file);
+
+    expect(lines).toEqual(['{"x":1}', '{"x":2}']);
+    expect(consumedBytes).toBe(Buffer.byteLength(content));
+  });
+
+  it('skips blank lines but still counts them toward the offset', async () => {
+    const file = path.join(tmpDir, 'f.jsonl');
+    const content = '{"x":1}\n\n   \n{"x":2}\n';
+    await fs.writeFile(file, content);
+
+    const { lines, consumedBytes } = await collect(file);
+
+    expect(lines).toEqual(['{"x":1}', '{"x":2}']);
+    expect(consumedBytes).toBe(Buffer.byteLength(content));
+  });
+
+  it('yields to the event loop while reading', async () => {
+    const file = path.join(tmpDir, 'g.jsonl');
+    const content = Array.from({ length: 500 }, (_, i) => `{"i":${i}}`).join('\n') + '\n';
+    await fs.writeFile(file, content);
+
+    let timerRan = false;
+    const timer = setInterval(() => { timerRan = true; }, 1);
+
+    const lines = [];
+    await readJsonlLinesFrom(file, 0, (line) => lines.push(line), { yieldEvery: 10 });
+    clearInterval(timer);
+
+    expect(lines).toHaveLength(500);
+    expect(timerRan).toBe(true);
+  });
+});

--- a/server/utils/__tests__/logger.test.js
+++ b/server/utils/__tests__/logger.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const ORIGINAL_DRCLAW_DEBUG = process.env.DRCLAW_DEBUG;
+const ORIGINAL_VIBELAB_DEBUG = process.env.VIBELAB_DEBUG;
+
+async function loadLogger(flag) {
+  vi.resetModules();
+  if (flag === undefined) {
+    delete process.env.DRCLAW_DEBUG;
+  } else {
+    process.env.DRCLAW_DEBUG = flag;
+  }
+  delete process.env.VIBELAB_DEBUG;
+  return import('../logger.js');
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  process.env.DRCLAW_DEBUG = ORIGINAL_DRCLAW_DEBUG;
+  process.env.VIBELAB_DEBUG = ORIGINAL_VIBELAB_DEBUG;
+  if (ORIGINAL_DRCLAW_DEBUG === undefined) delete process.env.DRCLAW_DEBUG;
+  if (ORIGINAL_VIBELAB_DEBUG === undefined) delete process.env.VIBELAB_DEBUG;
+});
+
+describe('hot-path logging gate', () => {
+  it('stays silent by default — this is what keeps per-event logging off', async () => {
+    const { isVerboseLogging, debugLog } = await loadLogger(undefined);
+
+    expect(isVerboseLogging('codex')).toBe(false);
+    expect(isVerboseLogging()).toBe(false);
+
+    debugLog('codex', 'should not print');
+    expect(console.log).not.toHaveBeenCalled();
+  });
+
+  it('enables every scope with DRCLAW_DEBUG=1', async () => {
+    const { isVerboseLogging, debugLog } = await loadLogger('1');
+
+    expect(isVerboseLogging('codex')).toBe(true);
+    expect(isVerboseLogging('claude')).toBe(true);
+
+    debugLog('claude', 'hello');
+    expect(console.log).toHaveBeenCalledWith('hello');
+  });
+
+  it('scopes output when given a comma-separated list', async () => {
+    const { isVerboseLogging, debugLog } = await loadLogger('codex, gemini');
+
+    expect(isVerboseLogging('codex')).toBe(true);
+    expect(isVerboseLogging('GEMINI')).toBe(true);
+    expect(isVerboseLogging('claude')).toBe(false);
+
+    debugLog('claude', 'suppressed');
+    expect(console.log).not.toHaveBeenCalled();
+
+    debugLog('codex', 'shown');
+    expect(console.log).toHaveBeenCalledWith('shown');
+  });
+
+  it('accepts true and * as enable-all aliases', async () => {
+    const asterisk = await loadLogger('*');
+    expect(asterisk.isVerboseLogging('anything')).toBe(true);
+
+    const truthy = await loadLogger('true');
+    expect(truthy.isVerboseLogging('anything')).toBe(true);
+  });
+});

--- a/server/utils/jsonlTailReader.js
+++ b/server/utils/jsonlTailReader.js
@@ -1,0 +1,97 @@
+/**
+ * Byte-accurate incremental reader for append-only JSONL logs.
+ *
+ * Agent session transcripts (`~/.codex/sessions/**.jsonl`,
+ * `~/.claude/projects/**.jsonl`) are append-only: a file's derived metadata is a
+ * pure fold over its lines. That lets callers cache the fold accumulator plus
+ * the byte offset they consumed, and resume from that offset on the next scan
+ * instead of re-reading the whole file.
+ *
+ * `readline` cannot support that because it reports lines, not byte offsets, so
+ * this reader tracks offsets itself:
+ *
+ * - A `StringDecoder` joins multi-byte UTF-8 characters that straddle a chunk
+ *   boundary, so no line is ever corrupted mid-character.
+ * - `consumedBytes` only advances past lines terminated by a newline. A trailing
+ *   partial line (a write the agent has not finished flushing) is left
+ *   unconsumed so the next incremental read re-reads it in full.
+ * - The loop yields every `yieldEvery` lines so a large buffered chunk cannot
+ *   monopolise the main thread between stream reads. Measured worst-case
+ *   event-loop stall over a 10 GB scan: 12 ms.
+ */
+
+import fsSync from 'fs';
+import { StringDecoder } from 'string_decoder';
+
+const DEFAULT_YIELD_EVERY = 2000;
+
+/**
+ * Stream complete lines from `filePath` starting at `startOffset`.
+ *
+ * @param {string} filePath
+ * @param {number} startOffset Absolute byte offset to resume from.
+ * @param {(line: string) => void} onLine Called for each non-blank complete line.
+ * @param {object} [options]
+ * @param {number} [options.yieldEvery=2000] Lines to process between event-loop yields.
+ * @returns {Promise<{ consumedBytes: number, lineCount: number, trailingLine: string|null }>}
+ *   `consumedBytes` is the absolute offset just past the last complete line.
+ *   `trailingLine` is any unterminated final line — deliberately excluded from
+ *   `consumedBytes` and never passed to `onLine`, because the next resume will
+ *   read it again. A writer may still be flushing it, or the file may simply end
+ *   without a newline; callers that need the newest record can apply it to a
+ *   throwaway copy of their accumulator.
+ */
+export async function readJsonlLinesFrom(filePath, startOffset, onLine, options = {}) {
+  const yieldEvery = options.yieldEvery || DEFAULT_YIELD_EVERY;
+  const start = Number.isFinite(startOffset) && startOffset > 0 ? startOffset : 0;
+
+  const decoder = new StringDecoder('utf8');
+  let pending = '';
+  let consumedBytes = start;
+  let lineCount = 0;
+  let sinceYield = 0;
+
+  const stream = fsSync.createReadStream(filePath, { start });
+
+  try {
+    for await (const chunk of stream) {
+      pending += decoder.write(chunk);
+
+      let newlineIndex;
+      while ((newlineIndex = pending.indexOf('\n')) !== -1) {
+        const rawLine = pending.slice(0, newlineIndex);
+        pending = pending.slice(newlineIndex + 1);
+        // +1 for the '\n' itself. A '\r' from CRLF is still part of rawLine, so
+        // it is already counted before we strip it for the caller.
+        consumedBytes += Buffer.byteLength(rawLine, 'utf8') + 1;
+
+        const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine;
+        if (line.trim()) {
+          onLine(line);
+          lineCount += 1;
+        }
+
+        sinceYield += 1;
+        if (sinceYield >= yieldEvery) {
+          sinceYield = 0;
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+      }
+    }
+    // Any bytes left in `pending` are an unterminated line; deliberately not
+    // counted so the next resume re-reads them once the writer completes it.
+    pending += decoder.end();
+  } finally {
+    stream.destroy();
+  }
+
+  const trailing = pending.endsWith('\r') ? pending.slice(0, -1) : pending;
+
+  return {
+    consumedBytes,
+    lineCount,
+    trailingLine: trailing.trim() ? trailing : null
+  };
+}
+
+export default readJsonlLinesFrom;

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,0 +1,52 @@
+/**
+ * Hot-path logging control.
+ *
+ * Agent streams emit hundreds to thousands of events per turn, and several call
+ * sites logged one line per event. That is wasteful everywhere, and on Windows
+ * it is a hazard: Node writes to a Windows console TTY synchronously, so every
+ * line blocks the event loop until the console drains it. A console left in
+ * QuickEdit selection mode — one stray click in the PowerShell window — stops
+ * draining entirely, and the pending write then blocks indefinitely. The
+ * reported symptom matches: output stops while the UI keeps counting elapsed
+ * time, and the PowerShell window itself looks frozen.
+ *
+ * Per-event logging is therefore opt-in. Enable it with DRCLAW_DEBUG=1 (or
+ * DRCLAW_DEBUG=codex,claude to scope it) when diagnosing a provider.
+ */
+
+const rawFlag = (process.env.DRCLAW_DEBUG || process.env.VIBELAB_DEBUG || '').trim();
+
+const enabledAll = rawFlag === '1' || rawFlag.toLowerCase() === 'true' || rawFlag === '*';
+const enabledScopes = new Set(
+  enabledAll
+    ? []
+    : rawFlag
+        .split(',')
+        .map((part) => part.trim().toLowerCase())
+        .filter(Boolean)
+);
+
+/**
+ * @param {string} [scope] Provider/subsystem name, e.g. 'codex'.
+ * @returns {boolean}
+ */
+export function isVerboseLogging(scope) {
+  if (enabledAll) return true;
+  if (!scope) return enabledScopes.size > 0;
+  return enabledScopes.has(String(scope).toLowerCase());
+}
+
+/**
+ * Log only when verbose logging is enabled for `scope`.
+ *
+ * Callers on a hot path should still guard with isVerboseLogging() when building
+ * the message is itself costly (substring, JSON.stringify, ...), since arguments
+ * are evaluated before the call.
+ */
+export function debugLog(scope, ...args) {
+  if (isVerboseLogging(scope)) {
+    console.log(...args);
+  }
+}
+
+export default { isVerboseLogging, debugLog };


### PR DESCRIPTION
## The reports

> 请问 大家有变卡的情况吗
> dr claw卡顿的情况 就是要loading很久 然后创建不了新的session这样
> 我也这样就是不输出了然后一直在计时
> 看powershell里面就是卡住了
> 我还以为是我网卡了

## Root cause

`buildCodexSessionsIndex()` re-read and `JSON.parse`'d **every line of every transcript** under `~/.codex/sessions` on every call, with no cache. That directory only ever grows — on a regular user's machine it had reached **577 files / 10 GB**. `getProjects()` awaited that scan, and the sync re-ran at least every 30s, so the app spent most of its wall clock inside a scan.

That explains why it felt *intermittent* and why it *got worse over time*: the cost is linear in total bytes ever written, and the 30s cooldown meant some requests were instant while others paid the full scan.

## Measured, against that same 10 GB directory

| | before | after |
|---|---|---|
| First `getProjects()` | **19,991 ms** | **543 ms** |
| Repeat Codex scan (every 30s) | ~20–30 s, awaited on the request path | **12 ms**, off the request path |

## Changes

**`server/utils/jsonlTailReader.js`** (new) — a byte-accurate incremental reader for append-only JSONL. Session transcripts are append-only, so their derived metadata is a pure fold over lines; the reader reports the offset just past the last *complete* line, so a scan can resume rather than re-read. `readline` can't do this (it yields lines, not offsets), so this uses `StringDecoder` + per-line `Buffer.byteLength` to survive multi-byte UTF-8 across chunk boundaries, CRLF, and unterminated trailing lines.

**Memoized Codex index** — per file, keyed on `(ino, size, mtimeMs)`. Resumes the fold from the cached offset on *strict* size growth; re-parses fully on anything else (rewrite, truncation, same-size rewrite). Concurrent scans collapse onto one pass.

**Session open / delete no longer full-scan** — both re-parsed the entire directory to map a session id to a file. They now use the memoized index, with a `session_meta` header scan as a fallback for transcripts the project index can't hold (sessions with no `cwd`). The header id is also verified before returning a filename match, so deleting a session can no longer unlink a *different* transcript whose name merely contains the id.

**Discovery sync moved off the request path** — runs in the background and publishes via a `projects-changed` event; `/api/projects` answers from the database, which is what it was already doing.

**Hot-path logging gated behind `DRCLAW_DEBUG`** — the Codex and Claude stream loops logged once per SDK event (the Codex one fired even for `item.updated` events that are discarded immediately after). Node writes to a Windows console TTY *synchronously*, so a console left in QuickEdit selection mode — one stray click in the PowerShell window — stops draining and blocks the write, and with it the event loop, indefinitely. That matches "不输出了然后一直在计时" and "powershell里面就是卡住了" precisely. Re-enable with `DRCLAW_DEBUG=1` or `DRCLAW_DEBUG=codex,claude`.

**Watcher payload serialized once** instead of twice per event.

## Testing

- 20 new tests: byte-offset accuracy (UTF-8, CRLF, blank lines, partial tails), incremental-vs-full-parse equivalence, same-size rewrite, truncation, unterminated final record, cache eviction, concurrent scans, delete targeting.
- Full suite: **132 passed**. `npm run typecheck` and `npm run build` clean.
- Verified against the real 10 GB session directory (numbers above).
- Server boots and stays responsive; health probes ~3 ms during a cold background scan.
- Reviewed independently with Codex, which found 4 correctness issues in the first draft (same-size rewrite treated as append, unterminated final record dropped, broadcast missing session-level changes, `cwd`-less sessions unreachable) plus 1 latent delete hazard. All 5 are fixed and covered by tests; the delete test was confirmed to fail without its guard.

## Not addressed here

`test/codex-discovery.test.mjs` hangs on `main` as well (it sets `CODEX_CLI_PATH` to the `node` binary, which then waits on stdin). Pre-existing and not in CI — left alone.