### PR TITLE
docs: add EMNLP 2026 paper info

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
-message: "If you use Dr. Claw in your research, please cite this repository."
-title: "Dr. Claw: An AI Research Workspace from Idea to Paper"
+message: "If you use Dr. Claw in your research, please cite the paper below."
+title: "Dr. Claw: An AI Scientist Workspace for Vibe Research"
 type: software
 authors:
   - family-names: Song
@@ -23,3 +23,39 @@ year: 2026
 repository-code: "https://github.com/OpenLAIR/dr-claw"
 url: "https://github.com/OpenLAIR/dr-claw"
 license: "GPL-3.0-or-later AND AGPL-3.0-or-later"
+preferred-citation:
+  type: article
+  title: "Dr. Claw: An AI Scientist Workspace for Vibe Research"
+  authors:
+    - family-names: Song
+      given-names: Dingjie
+    - family-names: Zhang
+      given-names: Hanrong
+    - family-names: Liu
+      given-names: Dawei
+    - family-names: Liu
+      given-names: Yixin
+    - family-names: Li
+      given-names: Zongxia
+    - family-names: Yuan
+      given-names: Zhengqing
+    - family-names: Zhang
+      given-names: Siqi
+    - family-names: Zou
+      given-names: Henry Peng
+    - family-names: Yan
+      given-names: Zhiling
+    - family-names: Zhang
+      given-names: Yuxuan
+    - family-names: Ye
+      given-names: Yanfang
+    - family-names: Yu
+      given-names: Philip S.
+    - family-names: Sun
+      given-names: Lichao
+  year: 2026
+  month: 8
+  journal: "arXiv preprint arXiv:2609.00365"
+  url: "https://arxiv.org/abs/2609.00365"
+  doi: "10.48550/arXiv.2609.00365"
+  notes: "Accepted to EMNLP 2026 System Demonstrations."

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
   <img src="public/dr-claw.png" alt="Dr. Claw" width="128" height="128">
   <h1>Dr. Claw: Your AI Research Assistant</h1>
   <p><strong>Full-stack research workspace.</strong></p>
+  <p>🎉 <strong>Accepted to <a href="https://2026.emnlp.org/">EMNLP 2026</a> System Demonstrations</strong></p>
 </div>
 
 <p align="center">
@@ -10,6 +11,9 @@
 </a>
 <a href="https://openlair.github.io/dr-claw">
 <img src="https://img.shields.io/badge/%F0%9F%8C%90-Homepage-2563EB?style=for-the-badge" alt="Homepage" />
+</a>
+<a href="https://arxiv.org/abs/2609.00365">
+<img src="https://img.shields.io/badge/arXiv-2609.00365-B31B1B?style=for-the-badge&logo=arxiv&logoColor=white" alt="arXiv" />
 </a>
 <a href="https://www.npmjs.com/package/dr-claw">
 <img src="https://img.shields.io/npm/v/dr-claw?style=for-the-badge&logo=npm&color=CB3837" alt="npm version" />
@@ -101,6 +105,7 @@ Dr. Claw is a general-purpose AI research assistant designed to help researchers
 
 ## What's New
 
+- 🎉 **Accepted to EMNLP 2026** `2026-08-22` — Our paper [*Dr. Claw: An AI Scientist Workspace for Vibe Research*](https://arxiv.org/abs/2609.00365) has been accepted to the **[EMNLP 2026](https://2026.emnlp.org/) System Demonstrations** track! Catch the live demo in Budapest, Hungary, October 24–29, 2026.
 - 🧪 **Auto Research Hub** `2026-04-08` — One click to launch fully autonomous research! Pick a tool pack (ARIS, Autoresearch, DeepScientist), hit configure, choose a workflow in Chat — and watch the agent run your entire research pipeline from idea to paper while you sleep.
 - 🖥️ **Desktop App & npx** `2026-04-06` — Dr. Claw now runs as a native desktop app! Grab the `.dmg` / `.exe` from [GitHub Releases](https://github.com/OpenLAIR/dr-claw/releases), or run `npx dr-claw` for zero-setup instant start.
 - 🗂️ **Multi-Tab Sidebar** `2026-04-06` — Research Lab and Files now live side-by-side as switchable tabs in the right sidebar — everything you need, one glance away.
@@ -960,16 +965,19 @@ See [LICENSE](LICENSE) and [NOTICE](NOTICE) for the full license texts and scope
 
 ## Citation
 
-If you find Dr. Claw useful in your research, please cite:
+Dr. Claw is described in our paper **[Dr. Claw: An AI Scientist Workspace for Vibe Research](https://arxiv.org/abs/2609.00365)** (arXiv:2609.00365), accepted to **EMNLP 2026 System Demonstrations**. If you find Dr. Claw useful in your research, please cite:
 
 ```bibtex
 @misc{song2026drclaw,
-  author       = {Dingjie Song and Hanrong Zhang and Dawei Liu and Yixin Liu and Zongxia Li and Zhengqing Yuan and Siqi Zhang and Lichao Sun},
-  title        = {Dr. Claw: An AI Research Workspace from Idea to Paper},
-  year         = {2026},
-  organization = {GitHub},
-  url          = {https://github.com/OpenLAIR/dr-claw},
-  homepage     = {https://openlair.github.io/dr-claw},
+  title         = {Dr. Claw: An AI Scientist Workspace for Vibe Research},
+  author        = {Dingjie Song and Hanrong Zhang and Dawei Liu and Yixin Liu and Zongxia Li and Zhengqing Yuan and Siqi Zhang and Henry Peng Zou and Zhiling Yan and Yuxuan Zhang and Yanfang Ye and Philip S. Yu and Lichao Sun},
+  year          = {2026},
+  eprint        = {2609.00365},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  doi           = {10.48550/arXiv.2609.00365},
+  url           = {https://arxiv.org/abs/2609.00365},
+  note          = {Accepted to EMNLP 2026 System Demonstrations},
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,6 +2,7 @@
   <img src="public/dr-claw.png" alt="Dr. Claw" width="128" height="128">
   <h1>Dr. Claw: 面向科研全流程的通用 AI 研究助手</h1>
   <p><strong>在一个工作区里完成研究规划、执行与写作。</strong></p>
+  <p>🎉 <strong>论文被 <a href="https://2026.emnlp.org/">EMNLP 2026</a> System Demonstrations 接收</strong></p>
 </div>
 
 <p align="center">
@@ -10,6 +11,9 @@
 </a>
 <a href="https://openlair.github.io/dr-claw">
 <img src="https://img.shields.io/badge/%F0%9F%8C%90-%E4%B8%BB%E9%A1%B5-2563EB?style=for-the-badge" alt="主页" />
+</a>
+<a href="https://arxiv.org/abs/2609.00365">
+<img src="https://img.shields.io/badge/arXiv-2609.00365-B31B1B?style=for-the-badge&logo=arxiv&logoColor=white" alt="arXiv" />
 </a>
 <a href="https://www.npmjs.com/package/dr-claw">
 <img src="https://img.shields.io/npm/v/dr-claw?style=for-the-badge&logo=npm&color=CB3837" alt="npm version" />
@@ -102,6 +106,7 @@ Dr. Claw 是一个面向不同研究方向的通用 AI 研究助手，帮助研�
 
 ## 最新动态
 
+- 🎉 **论文被 EMNLP 2026 接收** `2026-08-22` — 我们的论文 [*Dr. Claw: An AI Scientist Workspace for Vibe Research*](https://arxiv.org/abs/2609.00365) 被 **[EMNLP 2026](https://2026.emnlp.org/) System Demonstrations** 接收！欢迎在匈牙利布达佩斯（2026 年 10 月 24–29 日）现场看我们的 Demo。
 - 🧪 **Auto Research Hub** `2026-04-08` — 一键启动全自动科研！选工具包、点配置、选工作流——然后去睡觉，醒来收论文。支持 ARIS、Autoresearch、DeepScientist 三大工具包，从 idea 到 paper 全程无人值守。
 - 🖥️ **桌面应用 & npx** `2026-04-06` — Dr. Claw 现已支持原生桌面应用！从 [GitHub Releases](https://github.com/OpenLAIR/dr-claw/releases) 下载 `.dmg` / `.exe`，或运行 `npx dr-claw` 零配置一键启动。
 - 🗂️ **多标签侧边栏** `2026-04-06` — Research Lab 和文件浏览器合并为右侧可切换标签页，所有信息一目了然。
@@ -945,16 +950,19 @@ Dr. Claw 完全响应式设计。在移动设备上：
 
 ## 引用
 
-如果这个项目对你的研究有帮助，欢迎引用我们的工作：
+Dr. Claw 的设计与评测发表于论文 **[Dr. Claw: An AI Scientist Workspace for Vibe Research](https://arxiv.org/abs/2609.00365)**（arXiv:2609.00365），已被 **EMNLP 2026 System Demonstrations** 接收。如果这个项目对你的研究有帮助，欢迎引用我们的工作：
 
 ```bibtex
 @misc{song2026drclaw,
-  author       = {Dingjie Song and Hanrong Zhang and Dawei Liu and Yixin Liu and Zongxia Li and Zhengqing Yuan and Siqi Zhang and Lichao Sun},
-  title        = {Dr. Claw: An AI Research Workspace from Idea to Paper},
-  year         = {2026},
-  organization = {GitHub},
-  url          = {https://github.com/OpenLAIR/dr-claw},
-  homepage     = {https://openlair.github.io/dr-claw},
+  title         = {Dr. Claw: An AI Scientist Workspace for Vibe Research},
+  author        = {Dingjie Song and Hanrong Zhang and Dawei Liu and Yixin Liu and Zongxia Li and Zhengqing Yuan and Siqi Zhang and Henry Peng Zou and Zhiling Yan and Yuxuan Zhang and Yanfang Ye and Philip S. Yu and Lichao Sun},
+  year          = {2026},
+  eprint        = {2609.00365},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.AI},
+  doi           = {10.48550/arXiv.2609.00365},
+  url           = {https://arxiv.org/abs/2609.00365},
+  note          = {Accepted to EMNLP 2026 System Demonstrations},
 }
 ```
 


### PR DESCRIPTION
Dr. Claw's paper [*Dr. Claw: An AI Scientist Workspace for Vibe Research*](https://arxiv.org/abs/2609.00365) (arXiv:2609.00365) was accepted to the **EMNLP 2026 System Demonstrations** track. This surfaces it in the places readers actually look.

## Changes

**README.md / README.zh-CN.md**
- EMNLP acceptance line in the centered header, directly under the tagline (raw `<a>` — GitHub does not render Markdown inside `<div align="center">`)
- arXiv badge added to the badge row
- One acceptance entry at the top of What's New; no separate "paper on arXiv" entry, the paper title in that entry links to arXiv
- Citation section rewritten and BibTeX replaced with the paper: correct title, all 13 authors, `eprint` / `archivePrefix` / `primaryClass` / `doi`, EMNLP note

**CITATION.cff**
- Title aligned with the paper title
- New `preferred-citation` entry so GitHub's "Cite this repository" points at the paper rather than the repo

## Notes

- The BibTeX key `song2026drclaw` is unchanged, so `.bib` files that already cite Dr. Claw stay valid.
- Paper metadata (title, author order, categories, the "Accepted to EMNLP 2026 System Demonstrations" comment) was taken verbatim from the arXiv API rather than the rendered abstract page. EMNLP dates come from the [official call for system demonstrations](https://2026.emnlp.org/calls/demos/) — demo notification was 2026-08-22, conference is Budapest, Oct 24–29 2026. The DOI `10.48550/arXiv.2609.00365` was checked to resolve.
- `CITATION.cff`'s top-level `authors` still lists the original 8 repo authors; the full 13-author list appears only in `preferred-citation`. CFF allows these to differ (software authorship vs. paper authorship) — say the word if you want the top-level list expanded too.
- The homepage at openlair.github.io/dr-claw lives outside this repo and still needs its own update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tv2gd15N6NUBW4mKkb6Piv