### PR TITLE
fix: drop stray node_modules symlink and quote autoresearch frontmatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Dependencies
 node_modules/
+# also match a node_modules symlink (the trailing-slash form only matches directories)
+node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/sdj/Documents/research/doctor-archive/Ai-Scientist/VibeLab/dr-claw/node_modules

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autoresearch
-description: Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. 9 subcommands: plan, debug, fix, security, ship, scenario, predict, learn.
+description: "Autonomous Goal-directed Iteration. Apply Karpathy's autoresearch principles to ANY task. Loops autonomously — modify, verify, keep/discard, repeat. 9 subcommands: plan, debug, fix, security, ship, scenario, predict, learn."
 version: 1.8.2
 license: MIT
 metadata:


### PR DESCRIPTION
Two small repo-hygiene fixes surfaced while working on #196 / #213.

## 1. Remove a committed `node_modules` symlink

#213 (`2ef73b0a`) accidentally committed a `node_modules` symlink pointing at a developer's local path (my mistake: `git add -A` in a worktree that had the symlink). It slipped past `.gitignore` because `node_modules/` with a trailing slash matches directories only, not symlinks. This PR removes the tracked symlink and adds the slash-less `node_modules` pattern so the symlink form is ignored too.

Anyone who has pulled `main` since #213 has a dangling `node_modules` symlink in their checkout; after this merges, a `git pull` removes it.

## 2. Quote the `autoresearch` skill description

`skills/autoresearch/SKILL.md` had an unquoted `description:` containing `: ` (`9 subcommands: plan, ...`), which js-yaml parses as a nested mapping and rejects. Consequences:

- `scripts/export-skills-catalog-v2.mjs` aborted with a `YAMLException` on `main`, so the catalog could not be regenerated.
- Any gray-matter based consumer that does not catch parse errors would fail on this file.

Quoting the value fixes it. Verified: all 173 `SKILL.md` files parse with gray-matter, and the export script runs to completion.

Note: this PR does **not** regenerate `skills-catalog-v2.json`. A regen currently produces a ~9k-line diff against the committed catalog (ordering and metadata drift), which deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBqmTvJRhyysMvMvL6cp7x