### PR TITLE
fix(models): per-provider discovery state, Fable 5.1 in the picker, Codex effort from the CLI

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,12 +92,13 @@ Discovery is strictly additive and never blocks the UI:
   so the picker recovers on its own once a CLI is installed or logged in.
 - Every probe has a 15-second hard timeout. If the harness is missing, old,
   logged out, or unresponsive, the built-in list is used instead.
-- Models present in the built-in list but no longer served by the harness are
-  still returned by the API, flagged `deprecated: true`, so an existing saved
-  model preference is never stranded; the picker shows such an entry only while
-  it is the selected value, so one model does not appear under two names. (Not
-  for Claude: its CLI runs ids it does not advertise, so nothing is demoted
-  there.)
+- Built-in entries the harness did not report are still returned by the API,
+  flagged `builtIn: true` (and `deprecated: true` where the harness would reject
+  them), so an existing saved model preference is never stranded. Once the
+  harness has answered, the picker reads like the CLI's own menu and folds the
+  built-in entries behind a "show more built-in models" toggle, so one model
+  does not appear under two names (`claude-fable-5` next to the CLI's
+  `claude-fable-5[1m]`).
 
 ### API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,10 +95,10 @@ Discovery is strictly additive and never blocks the UI:
 - Built-in entries the harness did not report are still returned by the API,
   flagged `builtIn: true` (and `deprecated: true` where the harness would reject
   them), so an existing saved model preference is never stranded. Once the
-  harness has answered, the picker reads like the CLI's own menu and folds the
-  built-in entries behind a "show more built-in models" toggle, so one model
-  does not appear under two names (`claude-fable-5` next to the CLI's
-  `claude-fable-5[1m]`).
+  harness has answered, the picker shows only what the harness reported (plus
+  the currently selected value): the built-in table is a fallback for when
+  discovery is unavailable, not a second list, so one model does not appear
+  under two names (`claude-fable-5` next to the CLI's `claude-fable-5[1m]`).
 
 ### API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -93,9 +93,11 @@ Discovery is strictly additive and never blocks the UI:
 - Every probe has a 15-second hard timeout. If the harness is missing, old,
   logged out, or unresponsive, the built-in list is used instead.
 - Models present in the built-in list but no longer served by the harness are
-  kept at the end of the picker and marked deprecated, so an existing saved
-  model preference is never stranded. (Not for Claude: its CLI runs ids it does
-  not advertise, so nothing is demoted there.)
+  still returned by the API, flagged `deprecated: true`, so an existing saved
+  model preference is never stranded; the picker shows such an entry only while
+  it is the selected value, so one model does not appear under two names. (Not
+  for Claude: its CLI runs ids it does not advertise, so nothing is demoted
+  there.)
 
 ### API
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,8 +80,8 @@ without waiting for a Dr. Claw release.
 
 | Provider | Source | Notes |
 |----------|--------|-------|
-| Claude | Agent SDK `supportedModels()` control request | The menu the bundled Claude Code CLI serves (e.g. `default`, `opus[1m]`, `claude-fable-5-1[1m]`, `sonnet`), so it tracks the SDK version Dr. Claw ships. The CLI also accepts ids it does not list, so built-in entries are kept without a deprecated marker. No tokens are consumed and settings/hooks are not loaded during the probe. |
-| Codex | `codex app-server` → `model/list` JSON-RPC | Same catalogue the Codex CLI's own picker reads. Honours `CODEX_CLI_PATH`. |
+| Claude | Agent SDK `supportedModels()` control request | The menu the bundled Claude Code CLI serves (e.g. `default`, `opus[1m]`, `sonnet`), so it tracks the SDK version Dr. Claw ships. The model configured in `~/.claude/settings.json` (or `CLAUDE_CONFIG_DIR`, or `ANTHROPIC_MODEL`) is added the way the CLI's own `/model` menu adds it. The CLI also accepts ids it does not list, so built-in entries are kept without a deprecated marker. No tokens are consumed and settings/hooks are not loaded during the probe. |
+| Codex | `codex app-server` → `model/list` JSON-RPC | Same catalogue the Codex CLI's own picker reads, including each model's supported reasoning efforts, which drive the reasoning-effort selector. Honours `CODEX_CLI_PATH`. |
 | OpenRouter | `GET https://openrouter.ai/api/v1/models` | Public endpoint, no key needed. |
 | Cursor, Gemini, Nano | Built-in list | These CLIs expose no model-listing command today. |
 | Local GPU | Ollama `/api/tags` | Existing behaviour, unchanged. |

--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -650,7 +650,7 @@ class ResponseCollector {
  *                                       'gemini-3-pro', 'composer-1', 'auto', 'gpt-5.1', 'gpt-5.1-high',
  *                                       'gpt-5.1-codex', 'gpt-5.1-codex-high', 'gpt-5.1-codex-max',
  *                                       'gpt-5.1-codex-max-high', 'opus-4.1', 'grok', and thinking variants
- *                        Codex models: 'gpt-5.6' (default), 'gpt-5.6-terra', 'gpt-5.6-luna', and legacy models
+ *                        Codex models: 'gpt-5.6-sol' (default), 'gpt-5.6-terra', 'gpt-5.6-luna', and legacy models
  *
  * @param {boolean} cleanup - (Optional) Auto-cleanup project directory after completion.
  *                           Default: true

--- a/server/utils/__tests__/harnessModelDiscovery.test.js
+++ b/server/utils/__tests__/harnessModelDiscovery.test.js
@@ -21,7 +21,9 @@ async function writeFakeCodex(name, body) {
 
 const RESPOND_WITH_MODELS = `
 const models = [
-  { id: 'gpt-9-alpha', model: 'gpt-9-alpha', displayName: 'GPT-9 Alpha', hidden: false, isDefault: true },
+  { id: 'gpt-9-alpha', model: 'gpt-9-alpha', displayName: 'GPT-9 Alpha', hidden: false, isDefault: true,
+    supportedReasoningEfforts: [{ reasoningEffort: 'low' }, { reasoningEffort: 'high' }, { reasoningEffort: 'ultra' }],
+    defaultReasoningEffort: 'low' },
   { id: 'gpt-9-beta',  model: 'gpt-9-beta',  displayName: 'GPT-9 Beta',  hidden: false, isDefault: false },
   { id: 'gpt-9-secret', model: 'gpt-9-secret', displayName: 'Hidden',    hidden: true,  isDefault: false },
 ];
@@ -64,6 +66,12 @@ describe('claude discovery', () => {
     { value: '', displayName: 'broken' },
   ];
 
+  // Point the discoverer at an empty config dir so the developer's own
+  // ~/.claude/settings.json cannot leak a configured model into the assertions.
+  function isolatedEnv(extra = {}) {
+    return { ...process.env, CLAUDE_CONFIG_DIR: tmpDir, ANTHROPIC_MODEL: '', ...extra };
+  }
+
   function fakeSdk({ models = CLI_MENU, hang = false, fail = null } = {}) {
     const calls = { closed: 0, options: null };
     const query = (args) => {
@@ -84,7 +92,7 @@ describe('claude discovery', () => {
     const { CLAUDE_MODELS } = await import('../../../shared/modelConstants.js');
     const { query, calls } = fakeSdk();
 
-    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query });
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
 
     expect(payload.source).toBe('discovered');
     expect(payload.acceptsUnlisted).toBe(true);
@@ -106,12 +114,57 @@ describe('claude discovery', () => {
     expect(calls.options.settingSources).toEqual([]);
   });
 
+  it('tells apart versions the CLI lists under one display name', async () => {
+    const { query } = fakeSdk({
+      models: [
+        { value: 'claude-fable-5[1m]', displayName: 'Fable', description: 'Fable 5 · Most capable' },
+        { value: 'claude-fable-5-1[1m]', displayName: 'Fable', description: 'Fable 5.1 · Most capable' },
+        { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 5 · Efficient' },
+      ],
+    });
+
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
+    const labels = Object.fromEntries(payload.options.map((o) => [o.value, o.label]));
+
+    expect(labels['claude-fable-5[1m]']).toBe('Fable 5');
+    expect(labels['claude-fable-5-1[1m]']).toBe('Fable 5.1');
+    // A name used once keeps the CLI's own wording.
+    expect(labels['sonnet']).toBe('Sonnet');
+  });
+
+  it('surfaces the model configured in the user settings, as the CLI itself does', async () => {
+    // A model the CLI menu does not list on its own, as Fable 5.1 was not on
+    // the 0.3.226 menu until a user configured it.
+    await fs.writeFile(path.join(tmpDir, 'settings.json'), JSON.stringify({ model: 'claude-opus-4-9[1m]' }));
+    const { query } = fakeSdk();
+
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
+    const configured = payload.options.find((o) => o.value === 'claude-opus-4-9[1m]');
+
+    expect(configured).toBeDefined();
+    expect(configured.label).toBe('Opus 4.9 [1M]');
+    expect(configured.description).toMatch(/settings/);
+    expect(configured.deprecated).toBeUndefined();
+    // It is offered, not imposed: dr-claw's own default is untouched.
+    const { CLAUDE_MODELS } = await import('../../../shared/modelConstants.js');
+    expect(payload.default).toBe(CLAUDE_MODELS.DEFAULT);
+  });
+
+  it('honours ANTHROPIC_MODEL the same way', async () => {
+    const { query } = fakeSdk();
+    const payload = await mod.getModelsForProvider('claude', {
+      sdkQuery: query,
+      env: isolatedEnv({ ANTHROPIC_MODEL: 'claude-opus-4-9' }),
+    });
+    expect(payload.options.some((o) => o.value === 'claude-opus-4-9')).toBe(true);
+  });
+
   it('falls back and closes the session when the SDK never answers', async () => {
     const { CLAUDE_MODELS } = await import('../../../shared/modelConstants.js');
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { query, calls } = fakeSdk({ hang: true });
 
-    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, timeoutMs: 50 });
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, timeoutMs: 50, env: isolatedEnv() });
 
     expect(payload.source).toBe('static');
     expect(payload.options).toEqual(CLAUDE_MODELS.OPTIONS);
@@ -123,11 +176,24 @@ describe('claude discovery', () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { query, calls } = fakeSdk({ fail: new Error('no credentials') });
 
-    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query });
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
 
     expect(payload.source).toBe('static');
     expect(payload.error).toContain('no credentials');
     expect(calls.closed).toBe(1);
+  });
+});
+
+describe('labelForClaudeModelId', () => {
+  it('renders family, dotted version and the 1M marker', () => {
+    expect(mod.labelForClaudeModelId('claude-fable-5-1[1m]')).toBe('Fable 5.1 [1M]');
+    expect(mod.labelForClaudeModelId('claude-opus-4-8')).toBe('Opus 4.8');
+    expect(mod.labelForClaudeModelId('claude-sonnet-5')).toBe('Sonnet 5');
+  });
+
+  it('leaves ids it does not understand alone', () => {
+    expect(mod.labelForClaudeModelId('opus[1m]')).toBe('opus[1m]');
+    expect(mod.labelForClaudeModelId('default')).toBe('default');
   });
 });
 
@@ -188,6 +254,21 @@ describe('codex model discovery', () => {
     const discovered = payload.options.filter((o) => !o.deprecated).map((o) => o.value);
     expect(discovered).toEqual(['gpt-9-alpha', 'gpt-9-beta']);
     expect(payload.options.map((o) => o.value)).not.toContain('gpt-9-secret');
+  });
+
+  it('carries each model\'s supported reasoning efforts through to the payload', async () => {
+    const fake = await writeFakeCodex('fake-codex.mjs', RESPOND_WITH_MODELS);
+
+    const payload = await mod.getModelsForProvider('codex', {
+      env: { ...process.env, CODEX_CLI_PATH: fake },
+    });
+
+    const alpha = payload.options.find((o) => o.value === 'gpt-9-alpha');
+    expect(alpha.reasoningEfforts).toEqual(['low', 'high', 'ultra']);
+    expect(alpha.defaultReasoningEffort).toBe('low');
+    // A model the harness reports nothing for carries no claim either way.
+    const beta = payload.options.find((o) => o.value === 'gpt-9-beta');
+    expect(beta.reasoningEfforts).toBeUndefined();
   });
 
   it('adopts the harness default when the configured one is no longer served', async () => {

--- a/server/utils/__tests__/harnessModelDiscovery.test.js
+++ b/server/utils/__tests__/harnessModelDiscovery.test.js
@@ -219,9 +219,11 @@ describe('mergeModelOptions', () => {
     // The harness's own label wins for a model both lists know about.
     expect(merged[1].label).toBe('Shared (live)');
     expect(merged[1].deprecated).toBeUndefined();
+    expect(merged[1].builtIn).toBeUndefined();
     // A model the harness no longer serves is kept but marked, so a user whose
     // saved preference points at it is not stranded.
     expect(merged[2].deprecated).toBe(true);
+    expect(merged[2].builtIn).toBe(true);
   });
 
   it('leaves built-ins undemoted for a harness that accepts unlisted ids', () => {
@@ -232,6 +234,8 @@ describe('mergeModelOptions', () => {
     );
     expect(merged.map((o) => o.value)).toEqual(['opus[1m]', 'claude-opus-4-6']);
     expect(merged[1].deprecated).toBeUndefined();
+    // Still marked as coming from the table, so the picker can fold it away.
+    expect(merged[1].builtIn).toBe(true);
   });
 
   it('keeps metadata the discoverer attached, such as description', () => {

--- a/server/utils/__tests__/harnessModelDiscovery.test.js
+++ b/server/utils/__tests__/harnessModelDiscovery.test.js
@@ -126,10 +126,21 @@ describe('claude discovery', () => {
     const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
     const labels = Object.fromEntries(payload.options.map((o) => [o.value, o.label]));
 
-    expect(labels['claude-fable-5[1m]']).toBe('Fable 5');
-    expect(labels['claude-fable-5-1[1m]']).toBe('Fable 5.1');
-    // A name used once keeps the CLI's own wording.
-    expect(labels['sonnet']).toBe('Sonnet');
+    expect(labels['claude-fable-5[1m]']).toBe('Fable 5 [1M]');
+    expect(labels['claude-fable-5-1[1m]']).toBe('Fable 5.1 [1M]');
+    // A terse name is expanded from the description when it names a version.
+    expect(labels['sonnet']).toBe('Sonnet 5');
+  });
+
+  it('labels the CLI menu so entries stand apart from the built-in list', async () => {
+    const { query } = fakeSdk();
+    const payload = await mod.getModelsForProvider('claude', { sdkQuery: query, env: isolatedEnv() });
+    const labels = Object.fromEntries(payload.options.map((o) => [o.value, o.label]));
+
+    expect(labels['default']).toBe('Default (Opus 5 with 1M context)');
+    expect(labels['opus[1m]']).toBe('Opus 5 with 1M context');
+    expect(labels['claude-fable-5-1[1m]']).toBe('Fable 5.1 [1M]');
+    expect(labels['sonnet']).toBe('Sonnet 5');
   });
 
   it('surfaces the model configured in the user settings, as the CLI itself does', async () => {

--- a/server/utils/harnessModelDiscovery.js
+++ b/server/utils/harnessModelDiscovery.js
@@ -333,22 +333,38 @@ export function labelForClaudeModelId(value) {
 }
 
 /**
- * The CLI reuses one display name for several versions ("Fable" for both
- * Fable 5 and Fable 5.1), which makes a picker built from display names
- * ambiguous. Where a name is shared, fall back to the description's leading
- * segment, which is where the CLI puts the concrete version.
+ * Turn the CLI's menu entries into picker labels that stand on their own.
+ *
+ * The CLI's display names are terse ("Fable", "Sonnet") and reused across
+ * versions ("Fable" is both Fable 5 and Fable 5.1), so next to the built-in
+ * entries they read as duplicates. The description's leading segment names
+ * the concrete version ("Fable 5.1 · Most capable…"), so prefer it whenever
+ * it is a more specific form of the display name, and spell out the 1M
+ * context variant the way the built-in list does.
  */
-export function disambiguateClaudeLabels(options) {
+export function labelClaudeOptions(options) {
   const counts = new Map();
   for (const option of options) {
     counts.set(option.displayName, (counts.get(option.displayName) || 0) + 1);
   }
   return options.map(({ displayName, ...option }) => {
-    const shared = (counts.get(displayName) || 0) > 1;
     const detail = option.description ? String(option.description).split(' · ')[0].trim() : '';
-    const label = shared
-      ? (detail && detail !== displayName ? detail : `${displayName} (${option.value})`)
-      : displayName;
+    const baseName = displayName.replace(/\s*\(.*\)$/, '').trim();
+    const shared = (counts.get(displayName) || 0) > 1;
+
+    let label;
+    if (option.value === 'default') {
+      label = detail ? `Default (${detail})` : displayName;
+    } else if (detail && detail.toLowerCase().startsWith(baseName.toLowerCase()) && detail.length > baseName.length) {
+      label = detail;
+    } else if (shared) {
+      label = detail && detail !== displayName ? detail : `${displayName} (${option.value})`;
+    } else {
+      label = displayName;
+    }
+    if (/\[1m\]$/i.test(option.value) && !/1m/i.test(label)) {
+      label = `${label} [1M]`;
+    }
     return { ...option, label };
   });
 }
@@ -393,7 +409,7 @@ async function discoverClaudeModels({ timeoutMs, env = process.env, sdkQuery } =
       }),
     ]);
 
-    const served = disambiguateClaudeLabels(
+    const served = labelClaudeOptions(
       (Array.isArray(models) ? models : [])
         .filter((model) => model && typeof model.value === 'string' && model.value)
         .map((model) => ({

--- a/server/utils/harnessModelDiscovery.js
+++ b/server/utils/harnessModelDiscovery.js
@@ -103,7 +103,12 @@ export function mergeModelOptions(discovered, staticOptions, { acceptsUnlisted =
   for (const option of staticOptions || []) {
     if (!option?.value || seen.has(option.value)) continue;
     seen.add(option.value);
-    merged.push(acceptsUnlisted ? { ...option } : { ...option, deprecated: true });
+    // builtIn: came from the compiled-in table, not from the harness. The
+    // picker folds these away by default so the list reads like the CLI's own
+    // menu, which is where the same model would otherwise appear twice
+    // (`claude-fable-5` next to the CLI's `claude-fable-5[1m]`).
+    // deprecated: the harness rejects unlisted ids, so this one cannot be used.
+    merged.push(acceptsUnlisted ? { ...option, builtIn: true } : { ...option, builtIn: true, deprecated: true });
   }
 
   return merged;

--- a/server/utils/harnessModelDiscovery.js
+++ b/server/utils/harnessModelDiscovery.js
@@ -16,7 +16,9 @@
  */
 
 import { spawn } from 'child_process';
+import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import { StringDecoder } from 'string_decoder';
 import {
   CLAUDE_MODELS,
@@ -274,12 +276,81 @@ async function discoverCodexModels({ timeoutMs, env = process.env } = {}) {
 
   return models
     .filter((model) => model && !model.hidden && (model.model || model.id))
-    .map((model) => ({
-      value: model.model || model.id,
-      label: model.displayName || model.model || model.id,
-      description: model.description || undefined,
-      isDefault: Boolean(model.isDefault),
-    }));
+    .map((model) => {
+      // Codex reports which reasoning efforts each model accepts; without this
+      // the picker would have to guess from a hand-maintained table that is
+      // wrong for every model name it has not seen yet.
+      const reasoningEfforts = (Array.isArray(model.supportedReasoningEfforts) ? model.supportedReasoningEfforts : [])
+        .map((effort) => (typeof effort === 'string' ? effort : effort?.reasoningEffort))
+        .filter((effort) => typeof effort === 'string' && effort);
+
+      return {
+        value: model.model || model.id,
+        label: model.displayName || model.model || model.id,
+        description: model.description || undefined,
+        isDefault: Boolean(model.isDefault),
+        reasoningEfforts: reasoningEfforts.length > 0 ? reasoningEfforts : undefined,
+        defaultReasoningEffort: typeof model.defaultReasoningEffort === 'string' ? model.defaultReasoningEffort : undefined,
+      };
+    });
+}
+
+/**
+ * Claude Code appends the model configured in the user's own settings to its
+ * menu (that is how a `claude-fable-5-1[1m]` set in settings.json shows up in
+ * the CLI's /model list). The probe below runs with settings disabled so no
+ * hooks can fire, so mirror that one behaviour here: read `model` from the
+ * user settings file, honouring CLAUDE_CONFIG_DIR like the CLI does, plus the
+ * ANTHROPIC_MODEL override.
+ */
+function readConfiguredClaudeModels(env = process.env) {
+  const values = [];
+  if (typeof env.ANTHROPIC_MODEL === 'string' && env.ANTHROPIC_MODEL.trim()) {
+    values.push(env.ANTHROPIC_MODEL.trim());
+  }
+  const configDir = env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+  try {
+    const settings = JSON.parse(fs.readFileSync(path.join(configDir, 'settings.json'), 'utf8'));
+    if (typeof settings?.model === 'string' && settings.model.trim()) {
+      values.push(settings.model.trim());
+    }
+  } catch (_) {
+    // No settings file, or not JSON: nothing configured.
+  }
+  return values;
+}
+
+/**
+ * Human label for a Claude model id: `claude-fable-5-1[1m]` -> `Fable 5.1 [1M]`.
+ * Ids that do not follow the `claude-<family>-<version>` shape come back as-is.
+ */
+export function labelForClaudeModelId(value) {
+  const match = /^claude-([a-z]+)-(\d+(?:-\d+)*)(\[1m\])?$/i.exec(String(value || ''));
+  if (!match) return value;
+  const family = match[1][0].toUpperCase() + match[1].slice(1).toLowerCase();
+  const version = match[2].replace(/-/g, '.');
+  return `${family} ${version}${match[3] ? ' [1M]' : ''}`;
+}
+
+/**
+ * The CLI reuses one display name for several versions ("Fable" for both
+ * Fable 5 and Fable 5.1), which makes a picker built from display names
+ * ambiguous. Where a name is shared, fall back to the description's leading
+ * segment, which is where the CLI puts the concrete version.
+ */
+export function disambiguateClaudeLabels(options) {
+  const counts = new Map();
+  for (const option of options) {
+    counts.set(option.displayName, (counts.get(option.displayName) || 0) + 1);
+  }
+  return options.map(({ displayName, ...option }) => {
+    const shared = (counts.get(displayName) || 0) > 1;
+    const detail = option.description ? String(option.description).split(' · ')[0].trim() : '';
+    const label = shared
+      ? (detail && detail !== displayName ? detail : `${displayName} (${option.value})`)
+      : displayName;
+    return { ...option, label };
+  });
 }
 
 /**
@@ -294,7 +365,7 @@ async function discoverCodexModels({ timeoutMs, env = process.env } = {}) {
  * sources are disabled so the probe cannot fire SessionStart hooks or pick up
  * project configuration.
  */
-async function discoverClaudeModels({ timeoutMs, sdkQuery } = {}) {
+async function discoverClaudeModels({ timeoutMs, env = process.env, sdkQuery } = {}) {
   const queryFn = sdkQuery || (await import('@anthropic-ai/claude-agent-sdk')).query;
 
   async function* idle() {
@@ -322,16 +393,31 @@ async function discoverClaudeModels({ timeoutMs, sdkQuery } = {}) {
       }),
     ]);
 
-    return (Array.isArray(models) ? models : [])
-      .filter((model) => model && typeof model.value === 'string' && model.value)
-      .map((model) => ({
-        value: model.value,
-        label: model.displayName || model.value,
-        description: model.description || undefined,
-        // The CLI's "default" pseudo-model resolves to whatever it currently
-        // recommends; it is the closest thing the list has to a harness default.
-        isDefault: model.value === 'default',
-      }));
+    const served = disambiguateClaudeLabels(
+      (Array.isArray(models) ? models : [])
+        .filter((model) => model && typeof model.value === 'string' && model.value)
+        .map((model) => ({
+          value: model.value,
+          displayName: model.displayName || model.value,
+          description: model.description || undefined,
+          // The CLI's "default" pseudo-model resolves to whatever it currently
+          // recommends; it is the closest thing the list has to a harness default.
+          isDefault: model.value === 'default',
+        })),
+    );
+
+    for (const configured of readConfiguredClaudeModels(env)) {
+      if (!served.some((option) => option.value === configured)) {
+        served.push({
+          value: configured,
+          label: labelForClaudeModelId(configured),
+          description: 'Configured in your Claude Code settings',
+          isDefault: false,
+        });
+      }
+    }
+
+    return served;
   } finally {
     clearTimeout(timer);
     // close() tears the child down; without it a timed-out probe would leave a
@@ -529,6 +615,7 @@ export function clearModelDiscoveryCache(provider = null) {
 }
 
 export const __testing = {
+  readConfiguredClaudeModels,
   discoverClaudeModels,
   discoverCodexModels,
   discoverOpenRouterModels,

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -63,11 +63,16 @@ export const CURSOR_MODELS = {
  */
 export const CODEX_MODELS = {
   OPTIONS: [
-    { value: 'gpt-5.6', label: 'GPT-5.6 (Sol)' },
+    // Names as codex-cli 0.145 serves them. `gpt-5.6` on its own was retired in
+    // favour of `gpt-5.6-sol`; listing both made the picker show the same model
+    // twice under two labels.
+    { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
     { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
     { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
     { value: 'gpt-5.5', label: 'GPT-5.5' },
     { value: 'gpt-5.4', label: 'GPT-5.4' },
+    { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+    { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
     { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
     { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
     { value: 'gpt-5.2', label: 'GPT-5.2' },
@@ -76,7 +81,7 @@ export const CODEX_MODELS = {
     { value: 'o4-mini', label: 'O4-mini' }
   ],
 
-  DEFAULT: 'gpt-5.6'
+  DEFAULT: 'gpt-5.6-sol'
 };
 
 /**

--- a/shared/modelConstants.js
+++ b/shared/modelConstants.js
@@ -13,6 +13,8 @@
 export const CLAUDE_MODELS = {
   // Models in SDK format (what the actual SDK accepts)
   OPTIONS: [
+    { value: 'claude-fable-5-1', label: 'Fable 5.1' },
+    { value: 'claude-fable-5-1[1m]', label: 'Fable 5.1 [1M]' },
     { value: 'claude-opus-5', label: 'Opus 5' },
     { value: 'claude-fable-5', label: 'Fable 5' },
     { value: 'claude-fable-5[1m]', label: 'Fable 5 [1M]' },

--- a/src/components/chat/constants/__tests__/codexReasoningSupport.test.ts
+++ b/src/components/chat/constants/__tests__/codexReasoningSupport.test.ts
@@ -29,6 +29,32 @@ describe('Codex reasoning effort support', () => {
     ]);
   });
 
+  it('prefers the efforts the Codex CLI reported for the model', () => {
+    const reported = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+    expect(getSupportedCodexReasoningEfforts('gpt-5.6-sol', reported)).toEqual([
+      'default',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+    ]);
+    // Names the UI cannot render are dropped rather than crashing the picker.
+    expect(getSupportedCodexReasoningEfforts('some-new-model', ['low', 'galactic'])).toEqual(['default', 'low']);
+  });
+
+  it('falls back to the built-in table when the CLI reported nothing usable', () => {
+    expect(getSupportedCodexReasoningEfforts('gpt-5.5', [])).toEqual(['default', 'low', 'medium', 'high', 'xhigh']);
+    expect(getSupportedCodexReasoningEfforts('gpt-5.5', null)).toEqual(['default', 'low', 'medium', 'high', 'xhigh']);
+    expect(getSupportedCodexReasoningEfforts('never-heard-of-it', ['galactic'])).toEqual(['default']);
+  });
+
+  it('keeps a saved effort the CLI says the model accepts, even if the table does not know it', () => {
+    expect(normalizeCodexReasoningEffort('brand-new-model', 'ultra', ['low', 'ultra'])).toBe('ultra');
+    expect(normalizeCodexReasoningEffort('brand-new-model', 'ultra', null)).toBe(DEFAULT_CODEX_REASONING_EFFORT);
+  });
+
   it('falls back safely when a saved effort is unsupported by the selected model', () => {
     expect(normalizeCodexReasoningEffort('gpt-5.6', 'minimal')).toBe(
       DEFAULT_CODEX_REASONING_EFFORT,

--- a/src/components/chat/constants/codexReasoningEfforts.ts
+++ b/src/components/chat/constants/codexReasoningEfforts.ts
@@ -1,4 +1,4 @@
-import { Atom, Brain, Circle, CircleOff, Crown, Gauge, Sparkles, Zap } from 'lucide-react';
+import { Atom, Brain, Circle, CircleOff, Crown, Gauge, Rocket, Sparkles, Zap } from 'lucide-react';
 
 export const codexReasoningEfforts = [
   {
@@ -56,6 +56,13 @@ export const codexReasoningEfforts = [
     description: 'Maximum reasoning effort',
     icon: Crown,
     color: 'text-red-600',
+  },
+  {
+    id: 'ultra',
+    name: 'Ultra',
+    description: 'The highest reasoning effort the model offers',
+    icon: Rocket,
+    color: 'text-rose-700',
   },
 ] as const;
 

--- a/src/components/chat/constants/codexReasoningSupport.ts
+++ b/src/components/chat/constants/codexReasoningSupport.ts
@@ -2,8 +2,23 @@ import type { CodexReasoningEffortId } from './codexReasoningEfforts';
 
 export const DEFAULT_CODEX_REASONING_EFFORT: CodexReasoningEffortId = 'default';
 
+/** Display order for every effort the UI knows how to render. */
+const EFFORT_ORDER: CodexReasoningEffortId[] = [
+  'default',
+  'minimal',
+  'none',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+];
+
 const DEFAULT_ONLY: CodexReasoningEffortId[] = [DEFAULT_CODEX_REASONING_EFFORT];
 const LOW_TO_XHIGH: CodexReasoningEffortId[] = ['default', 'low', 'medium', 'high', 'xhigh'];
+const LOW_TO_MAX: CodexReasoningEffortId[] = ['default', 'low', 'medium', 'high', 'xhigh', 'max'];
+const LOW_TO_ULTRA: CodexReasoningEffortId[] = ['default', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
 const GPT_56_REASONING_EFFORTS: CodexReasoningEffortId[] = [
   'default',
   'none',
@@ -14,13 +29,22 @@ const GPT_56_REASONING_EFFORTS: CodexReasoningEffortId[] = [
   'max',
 ];
 
+/**
+ * Fallback only. The authoritative list comes from the Codex CLI itself
+ * (`model/list` reports `supportedReasoningEfforts` per model) and reaches the
+ * UI through harness model discovery; this table covers the case where
+ * discovery is unavailable and the built-in model list is in use.
+ */
 const MODEL_REASONING_SUPPORT: Record<string, CodexReasoningEffortId[]> = {
   'gpt-5.6': GPT_56_REASONING_EFFORTS,
-  'gpt-5.6-terra': GPT_56_REASONING_EFFORTS,
-  'gpt-5.6-luna': GPT_56_REASONING_EFFORTS,
+  'gpt-5.6-sol': LOW_TO_ULTRA,
+  'gpt-5.6-terra': LOW_TO_ULTRA,
+  'gpt-5.6-luna': LOW_TO_MAX,
   'gpt-5.5': LOW_TO_XHIGH,
   'gpt-5.4': LOW_TO_XHIGH,
+  'gpt-5.4-mini': LOW_TO_XHIGH,
   'gpt-5.3-codex': LOW_TO_XHIGH,
+  'gpt-5.3-codex-spark': LOW_TO_XHIGH,
   'gpt-5.2-codex': LOW_TO_XHIGH,
   'gpt-5.2': LOW_TO_XHIGH,
   // Keep unknown / unverified models on default only instead of over-claiming support.
@@ -29,19 +53,48 @@ const MODEL_REASONING_SUPPORT: Record<string, CodexReasoningEffortId[]> = {
   'o4-mini': DEFAULT_ONLY,
 };
 
-export function getSupportedCodexReasoningEfforts(model: string): CodexReasoningEffortId[] {
+function isKnownEffort(value: string): value is CodexReasoningEffortId {
+  return (EFFORT_ORDER as string[]).includes(value);
+}
+
+/**
+ * Efforts the picker should offer for `model`.
+ *
+ * `discovered` is what the Codex CLI reported for this model. When present it
+ * wins outright: efforts the UI cannot render are dropped, and "default"
+ * (let the model decide) is always offered first. Without it, fall back to
+ * the built-in table.
+ */
+export function getSupportedCodexReasoningEfforts(
+  model: string,
+  discovered?: readonly string[] | null,
+): CodexReasoningEffortId[] {
+  if (discovered && discovered.length > 0) {
+    const known = EFFORT_ORDER.filter(
+      (effort) => effort !== DEFAULT_CODEX_REASONING_EFFORT && discovered.some((d) => d === effort),
+    );
+    if (known.length > 0) {
+      return [DEFAULT_CODEX_REASONING_EFFORT, ...known];
+    }
+  }
   return MODEL_REASONING_SUPPORT[model] || DEFAULT_ONLY;
 }
 
-export function supportsExplicitCodexReasoningEffort(model: string): boolean {
-  return getSupportedCodexReasoningEfforts(model).length > 1;
+export function supportsExplicitCodexReasoningEffort(
+  model: string,
+  discovered?: readonly string[] | null,
+): boolean {
+  return getSupportedCodexReasoningEfforts(model, discovered).length > 1;
 }
 
 export function normalizeCodexReasoningEffort(
   model: string,
   effort: CodexReasoningEffortId,
+  discovered?: readonly string[] | null,
 ): CodexReasoningEffortId {
-  return getSupportedCodexReasoningEfforts(model).includes(effort)
+  return getSupportedCodexReasoningEfforts(model, discovered).includes(effort)
     ? effort
     : DEFAULT_CODEX_REASONING_EFFORT;
 }
+
+export { isKnownEffort as isKnownCodexReasoningEffort };

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -69,6 +69,8 @@ interface UseChatComposerStateArgs {
   cursorModel: string;
   claudeModel: string;
   codexModel: string;
+  /** Efforts the Codex CLI reported for `codexModel`; null when discovery is unavailable. */
+  codexReasoningEfforts?: readonly string[] | null;
   geminiModel: string;
   openrouterModel: string;
   localModel: string;
@@ -248,6 +250,7 @@ export function useChatComposerState({
   cursorModel,
   claudeModel,
   codexModel,
+  codexReasoningEfforts = null,
   geminiModel,
   openrouterModel,
   localModel,
@@ -295,6 +298,7 @@ export function useChatComposerState({
       case 'high':
       case 'xhigh':
       case 'max':
+      case 'ultra':
       case 'default':
         return savedValue;
       default:
@@ -385,11 +389,11 @@ export function useChatComposerState({
   }, [geminiThinkingMode]);
 
   useEffect(() => {
-    const normalizedEffort = normalizeCodexReasoningEffort(codexModel, codexReasoningEffort);
+    const normalizedEffort = normalizeCodexReasoningEffort(codexModel, codexReasoningEffort, codexReasoningEfforts);
     if (normalizedEffort !== codexReasoningEffort) {
       setCodexReasoningEffort(normalizedEffort);
     }
-  }, [codexModel, codexReasoningEffort]);
+  }, [codexModel, codexReasoningEffort, codexReasoningEfforts]);
 
   useEffect(() => {
     const supportedModes = getSupportedGeminiThinkingModes(geminiModel);

--- a/src/components/chat/hooks/useChatProviderState.ts
+++ b/src/components/chat/hooks/useChatProviderState.ts
@@ -8,6 +8,28 @@ interface UseChatProviderStateArgs {
   selectedSession: ProjectSession | null;
 }
 
+/**
+ * A model id that can never belong to the slot it was saved in. A picker race
+ * (since fixed in useHarnessModels) briefly let one provider's model be written
+ * into another provider's storage key, e.g. `claude-model` = `gpt-5.6-sol`.
+ * Such a value would send every new session straight into an error, so drop
+ * it and fall back to the provider default instead of trusting storage.
+ */
+const FOREIGN_MODEL_PATTERNS: Partial<Record<string, RegExp>> = {
+  claude: /^(gpt-|o\d)/i,
+  codex: /^(claude-|sonnet|opus|haiku|default$)/i,
+};
+
+function readStoredModel(key: string, providerSlot: string, fallback: string): string {
+  const stored = localStorage.getItem(key);
+  if (!stored) return fallback;
+  if (FOREIGN_MODEL_PATTERNS[providerSlot]?.test(stored)) {
+    localStorage.removeItem(key);
+    return fallback;
+  }
+  return stored;
+}
+
 export function useChatProviderState({ selectedSession }: UseChatProviderStateArgs) {
   const [permissionMode, setPermissionMode] = useState<PermissionMode>('default');
   const [pendingPermissionRequests, setPendingPermissionRequests] = useState<PendingPermissionRequest[]>([]);
@@ -18,10 +40,10 @@ export function useChatProviderState({ selectedSession }: UseChatProviderStateAr
     return localStorage.getItem('cursor-model') || CURSOR_MODELS.DEFAULT;
   });
   const [claudeModel, setClaudeModel] = useState<string>(() => {
-    return localStorage.getItem('claude-model') || CLAUDE_MODELS.DEFAULT;
+    return readStoredModel('claude-model', 'claude', CLAUDE_MODELS.DEFAULT);
   });
   const [codexModel, setCodexModel] = useState<string>(() => {
-    return localStorage.getItem('codex-model') || CODEX_MODELS.DEFAULT;
+    return readStoredModel('codex-model', 'codex', CODEX_MODELS.DEFAULT);
   });
   const [geminiModel, setGeminiModel] = useState<string>(() => {
     return localStorage.getItem('gemini-model') || GEMINI_MODELS.DEFAULT;

--- a/src/components/chat/hooks/useHarnessModels.ts
+++ b/src/components/chat/hooks/useHarnessModels.ts
@@ -6,6 +6,8 @@ export interface HarnessModelOption {
   value: string;
   label: string;
   description?: string;
+  /** From the compiled-in table rather than the harness; folded away in the picker by default. */
+  builtIn?: boolean;
   /** Present in the built-in list but not reported by the harness itself. */
   deprecated?: boolean;
   isDefault?: boolean;

--- a/src/components/chat/hooks/useHarnessModels.ts
+++ b/src/components/chat/hooks/useHarnessModels.ts
@@ -8,6 +8,10 @@ export interface HarnessModelOption {
   description?: string;
   /** Present in the built-in list but not reported by the harness itself. */
   deprecated?: boolean;
+  isDefault?: boolean;
+  /** Reasoning efforts the harness says this model accepts (Codex). */
+  reasoningEfforts?: string[];
+  defaultReasoningEffort?: string;
 }
 
 export interface HarnessModels {
@@ -19,6 +23,22 @@ export interface HarnessModels {
   refresh: () => void;
 }
 
+interface LoadedModels {
+  /** The provider this answer was fetched for. */
+  provider: string;
+  options: HarnessModelOption[] | null;
+  source: 'discovered' | 'static' | null;
+  defaultModel: string | null;
+}
+
+const EMPTY: HarnessModels = {
+  options: null,
+  source: null,
+  defaultModel: null,
+  isLoading: false,
+  refresh: () => {},
+};
+
 /**
  * Ask the server for the model list the selected harness actually supports.
  *
@@ -26,17 +46,18 @@ export interface HarnessModels {
  * callers keep rendering their built-in list rather than flashing an empty
  * picker. The server never fails this call — it falls back to the built-in list
  * — so the only states here are "not answered yet" and "answered".
+ *
+ * Every answer is tagged with the provider it was fetched for, and only an
+ * answer for the *current* provider is ever exposed. State updates are
+ * asynchronous, so for at least one render after a provider switch the stored
+ * answer still describes the previous provider; handing that out would let a
+ * consumer act on Codex's list while `provider` already says Claude (which is
+ * exactly how a Codex model once ended up saved as the Claude model).
  */
 export function useHarnessModels(provider: SessionProvider | string | null | undefined): HarnessModels {
-  const [options, setOptions] = useState<HarnessModelOption[] | null>(null);
-  const [source, setSource] = useState<'discovered' | 'static' | null>(null);
-  const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState<LoadedModels | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [refreshToken, setRefreshToken] = useState(0);
-
-  // Guards against a slow response for a provider the user has already switched
-  // away from overwriting the current one.
-  const requestedProviderRef = useRef<string | null>(null);
 
   // One-shot: only the request triggered by refresh() bypasses the server
   // cache. Deriving it from `refreshToken > 0` would make every later provider
@@ -49,20 +70,12 @@ export function useHarnessModels(provider: SessionProvider | string | null | und
 
   useEffect(() => {
     if (!provider) {
-      setOptions(null);
-      setSource(null);
-      setDefaultModel(null);
+      setLoaded(null);
       return;
     }
 
     let cancelled = false;
-    requestedProviderRef.current = provider;
     setIsLoading(true);
-    // Clear immediately rather than on response: otherwise the picker keeps
-    // rendering the previous provider's models for the duration of the request.
-    setOptions(null);
-    setSource(null);
-    setDefaultModel(null);
 
     const force = forceNextRef.current;
     forceNextRef.current = false;
@@ -70,22 +83,23 @@ export function useHarnessModels(provider: SessionProvider | string | null | und
     authenticatedFetch(`/api/models/${encodeURIComponent(provider)}${query}`)
       .then(async (res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (cancelled || requestedProviderRef.current !== provider) return;
+        if (cancelled) return;
         if (!data || !Array.isArray(data.options)) {
-          setOptions(null);
-          setSource(null);
+          setLoaded({ provider, options: null, source: null, defaultModel: null });
           return;
         }
-        // A static answer carries no information the caller does not already
-        // have compiled in, so leave it on its own list.
-        setSource(data.source ?? null);
-        setOptions(data.source === 'discovered' ? data.options : null);
-        setDefaultModel(typeof data.default === 'string' ? data.default : null);
+        setLoaded({
+          provider,
+          source: data.source ?? null,
+          // A static answer carries no information the caller does not already
+          // have compiled in, so leave it on its own list.
+          options: data.source === 'discovered' ? data.options : null,
+          defaultModel: typeof data.default === 'string' ? data.default : null,
+        });
       })
       .catch(() => {
         if (cancelled) return;
-        setOptions(null);
-        setSource(null);
+        setLoaded({ provider, options: null, source: null, defaultModel: null });
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);
@@ -96,7 +110,16 @@ export function useHarnessModels(provider: SessionProvider | string | null | und
     };
   }, [provider, refreshToken]);
 
-  return { options, source, defaultModel, isLoading, refresh };
+  if (!provider) return EMPTY;
+
+  const current = loaded && loaded.provider === provider ? loaded : null;
+  return {
+    options: current?.options ?? null,
+    source: current?.source ?? null,
+    defaultModel: current?.defaultModel ?? null,
+    isLoading,
+    refresh,
+  };
 }
 
 export default useHarnessModels;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -18,6 +18,7 @@ import { useChatProviderState } from '../hooks/useChatProviderState';
 import { useChatSessionState } from '../hooks/useChatSessionState';
 import { useChatRealtimeHandlers } from '../hooks/useChatRealtimeHandlers';
 import { useChatComposerState } from '../hooks/useChatComposerState';
+import { useHarnessModels } from '../hooks/useHarnessModels';
 import type { Provider } from '../types/types';
 import { authenticatedFetch } from '../../../utils/api';
 import { readCliAvailability, writeCliAvailability } from '../../../utils/cliAvailability';
@@ -243,6 +244,14 @@ function ChatInterface({
   chatMessagesForBtwRef.current = chatMessages;
   const getChatMessagesForBtw = useCallback(() => chatMessagesForBtwRef.current, []);
 
+  // Owned here rather than in ChatComposer so the composer state hook can
+  // normalise the saved Codex reasoning effort against the same live list the
+  // picker renders.
+  const harnessModels = useHarnessModels(provider);
+  const codexReasoningEfforts = provider === 'codex'
+    ? harnessModels.options?.find((option) => option.value === codexModel)?.reasoningEfforts ?? null
+    : null;
+
   const {
     input,
     setInput,
@@ -311,6 +320,7 @@ function ChatInterface({
     cursorModel,
     claudeModel,
     codexModel,
+    codexReasoningEfforts,
     geminiModel,
     openrouterModel,
     localModel,
@@ -913,6 +923,7 @@ function ChatInterface({
           setThinkingMode={setThinkingMode}
           codexReasoningEffort={codexReasoningEffort}
           setCodexReasoningEffort={setCodexReasoningEffort}
+          harnessModels={harnessModels}
           geminiThinkingMode={geminiThinkingMode}
           setGeminiThinkingMode={setGeminiThinkingMode}
           tokenBudget={tokenBudget}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -349,17 +349,15 @@ export default function ChatComposer({
     : null;
 
   const rawModelConfig = getModelConfig(sessionProvider);
-  // Once the harness has answered, the picker reads like the CLI's own menu:
-  // entries from the compiled-in table are folded behind a "show built-in"
-  // toggle unless one is the selected value. Showing both at once lists the
-  // same model under two names (`claude-fable-5` next to the CLI's
-  // `claude-fable-5[1m]`, the retired `gpt-5.6` next to `gpt-5.6-sol`).
+  // Once the harness has answered, its list is the source of truth and the
+  // compiled-in table is only a fallback for when it has not. Showing both at
+  // once lists the same model under two names (`claude-fable-5` next to the
+  // CLI's `claude-fable-5[1m]`, the retired `gpt-5.6` next to `gpt-5.6-sol`).
+  // The one exception is the currently selected value: a saved preference
+  // the harness did not list must stay visible rather than vanish.
   const pickerModels = discoveredModels?.filter(
     (option) => !option.builtIn || option.value === currentModel,
   );
-  const builtInModels = discoveredModels?.filter(
-    (option) => option.builtIn && option.value !== currentModel,
-  ) ?? [];
   const modelConfig = sessionProvider === 'local' && ollamaModels.length > 0
     ? { ...rawModelConfig, OPTIONS: ollamaModels }
     : pickerModels && pickerModels.length > 0
@@ -688,7 +686,6 @@ export default function ChatComposer({
                         <ModelSelector
                           value={currentModel}
                           options={modelConfig.OPTIONS}
-                          moreOptions={builtInModels}
                           onChange={handleModelChange}
                         />
                       )}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -349,10 +349,17 @@ export default function ChatComposer({
     : null;
 
   const rawModelConfig = getModelConfig(sessionProvider);
+  // A built-in entry the harness no longer serves stays in the API payload
+  // (flagged deprecated) so nothing is silently lost, but it only earns a row
+  // in the picker while it is the selected value — otherwise the list shows
+  // one model under two names, e.g. the retired `gpt-5.6` next to `gpt-5.6-sol`.
+  const pickerModels = discoveredModels?.filter(
+    (option) => !option.deprecated || option.value === currentModel,
+  );
   const modelConfig = sessionProvider === 'local' && ollamaModels.length > 0
     ? { ...rawModelConfig, OPTIONS: ollamaModels }
-    : discoveredModels && discoveredModels.length > 0
-      ? { ...rawModelConfig, OPTIONS: discoveredModels }
+    : pickerModels && pickerModels.length > 0
+      ? { ...rawModelConfig, OPTIONS: pickerModels }
       : rawModelConfig;
 
   const selectProvider = (next: SessionProvider) => {

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -30,7 +30,7 @@ import type { SessionMode, SessionProvider } from '../../../../types/app';
 import { CLAUDE_MODELS, CURSOR_MODELS, CODEX_MODELS, GEMINI_MODELS, LOCAL_MODELS, NANO_CLAUDE_CODE_MODELS, OPENROUTER_MODELS } from '../../../../../shared/modelConstants';
 import { authenticatedFetch } from '../../../../utils/api';
 import { isAutoResearchScenario } from '../../utils/autoResearch';
-import { useHarnessModels } from '../../hooks/useHarnessModels';
+import type { HarnessModels } from '../../hooks/useHarnessModels';
 
 // New subcomponents
 import SkillDropdown from './SkillDropdown';
@@ -107,6 +107,8 @@ interface ChatComposerProps {
   setThinkingMode: Dispatch<SetStateAction<string>>;
   codexReasoningEffort: CodexReasoningEffortId;
   setCodexReasoningEffort: Dispatch<SetStateAction<CodexReasoningEffortId>>;
+  /** Live model list for `provider`, owned by ChatInterface so composer state can share it. */
+  harnessModels: HarnessModels;
   geminiThinkingMode: GeminiThinkingModeId;
   setGeminiThinkingMode: Dispatch<SetStateAction<GeminiThinkingModeId>>;
   tokenBudget: TokenBudget | null;
@@ -194,6 +196,7 @@ export default function ChatComposer({
   setThinkingMode,
   codexReasoningEffort,
   setCodexReasoningEffort,
+  harnessModels,
   geminiThinkingMode,
   setGeminiThinkingMode,
   tokenBudget,
@@ -340,7 +343,10 @@ export default function ChatComposer({
   // Prefer the list the harness reports over the compiled-in one, so a CLI that
   // ships new models is picked up without a dr-claw release. Falls back to the
   // built-in list whenever discovery is unavailable.
-  const { options: discoveredModels, defaultModel: discoveredDefault } = useHarnessModels(sessionProvider);
+  const { options: discoveredModels, defaultModel: discoveredDefault } = harnessModels;
+  const codexReasoningEfforts = sessionProvider === 'codex'
+    ? discoveredModels?.find((option) => option.value === codexModel)?.reasoningEfforts ?? null
+    : null;
 
   const rawModelConfig = getModelConfig(sessionProvider);
   const modelConfig = sessionProvider === 'local' && ollamaModels.length > 0
@@ -698,6 +704,7 @@ export default function ChatComposer({
                     setThinkingMode={setThinkingMode}
                     codexReasoningEffort={codexReasoningEffort}
                     setCodexReasoningEffort={setCodexReasoningEffort}
+                    codexReasoningEfforts={codexReasoningEfforts}
                     geminiThinkingMode={geminiThinkingMode}
                     setGeminiThinkingMode={setGeminiThinkingMode}
                     tokenBudget={tokenBudget}

--- a/src/components/chat/view/subcomponents/ChatComposer.tsx
+++ b/src/components/chat/view/subcomponents/ChatComposer.tsx
@@ -349,13 +349,17 @@ export default function ChatComposer({
     : null;
 
   const rawModelConfig = getModelConfig(sessionProvider);
-  // A built-in entry the harness no longer serves stays in the API payload
-  // (flagged deprecated) so nothing is silently lost, but it only earns a row
-  // in the picker while it is the selected value — otherwise the list shows
-  // one model under two names, e.g. the retired `gpt-5.6` next to `gpt-5.6-sol`.
+  // Once the harness has answered, the picker reads like the CLI's own menu:
+  // entries from the compiled-in table are folded behind a "show built-in"
+  // toggle unless one is the selected value. Showing both at once lists the
+  // same model under two names (`claude-fable-5` next to the CLI's
+  // `claude-fable-5[1m]`, the retired `gpt-5.6` next to `gpt-5.6-sol`).
   const pickerModels = discoveredModels?.filter(
-    (option) => !option.deprecated || option.value === currentModel,
+    (option) => !option.builtIn || option.value === currentModel,
   );
+  const builtInModels = discoveredModels?.filter(
+    (option) => option.builtIn && option.value !== currentModel,
+  ) ?? [];
   const modelConfig = sessionProvider === 'local' && ollamaModels.length > 0
     ? { ...rawModelConfig, OPTIONS: ollamaModels }
     : pickerModels && pickerModels.length > 0
@@ -684,6 +688,7 @@ export default function ChatComposer({
                         <ModelSelector
                           value={currentModel}
                           options={modelConfig.OPTIONS}
+                          moreOptions={builtInModels}
                           onChange={handleModelChange}
                         />
                       )}

--- a/src/components/chat/view/subcomponents/ChatInputControls.tsx
+++ b/src/components/chat/view/subcomponents/ChatInputControls.tsx
@@ -20,6 +20,8 @@ interface ChatInputControlsProps {
   setThinkingMode: React.Dispatch<React.SetStateAction<string>>;
   codexReasoningEffort: CodexReasoningEffortId;
   setCodexReasoningEffort: React.Dispatch<React.SetStateAction<CodexReasoningEffortId>>;
+  /** Efforts the Codex CLI reported for `codexModel`; null when discovery is unavailable. */
+  codexReasoningEfforts?: readonly string[] | null;
   geminiThinkingMode: GeminiThinkingModeId;
   setGeminiThinkingMode: React.Dispatch<React.SetStateAction<GeminiThinkingModeId>>;
   tokenBudget: TokenBudget | null;
@@ -41,6 +43,7 @@ export default function ChatInputControls({
   setThinkingMode,
   codexReasoningEffort,
   setCodexReasoningEffort,
+  codexReasoningEfforts = null,
   geminiThinkingMode,
   setGeminiThinkingMode,
   tokenBudget,
@@ -95,9 +98,10 @@ export default function ChatInputControls({
         <ThinkingModeSelector selectedMode={thinkingMode} onModeChange={setThinkingMode} onClose={() => {}} className="" compact={compact} />
       )}
 
-      {provider === 'codex' && supportsExplicitCodexReasoningEffort(codexModel) && (
+      {provider === 'codex' && supportsExplicitCodexReasoningEffort(codexModel, codexReasoningEfforts) && (
         <CodexReasoningEffortSelector
           model={codexModel}
+          supportedEfforts={codexReasoningEfforts}
           selectedEffort={codexReasoningEffort}
           onEffortChange={setCodexReasoningEffort}
           onClose={() => {}}

--- a/src/components/chat/view/subcomponents/CodexReasoningEffortSelector.tsx
+++ b/src/components/chat/view/subcomponents/CodexReasoningEffortSelector.tsx
@@ -8,6 +8,8 @@ import { getSupportedCodexReasoningEfforts } from '../../constants/codexReasonin
 
 type CodexReasoningEffortSelectorProps = {
   model: string;
+  /** Efforts the Codex CLI reported for `model`; null when discovery is unavailable. */
+  supportedEfforts?: readonly string[] | null;
   selectedEffort: CodexReasoningEffortId;
   onEffortChange: (effortId: CodexReasoningEffortId) => void;
   onClose?: () => void;
@@ -17,6 +19,7 @@ type CodexReasoningEffortSelectorProps = {
 
 function CodexReasoningEffortSelector({
   model,
+  supportedEfforts,
   selectedEffort,
   onEffortChange,
   onClose,
@@ -39,7 +42,7 @@ function CodexReasoningEffortSelector({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [onClose]);
 
-  const supportedEffortIds = getSupportedCodexReasoningEfforts(model);
+  const supportedEffortIds = getSupportedCodexReasoningEfforts(model, supportedEfforts);
 
   const translatedEfforts = codexReasoningEfforts
     .filter((effort) => supportedEffortIds.includes(effort.id))

--- a/src/components/chat/view/subcomponents/ModelSelector.tsx
+++ b/src/components/chat/view/subcomponents/ModelSelector.tsx
@@ -12,26 +12,18 @@ export interface ModelSelectorOption {
 interface ModelSelectorProps {
   value: string;
   options: ModelSelectorOption[];
-  /**
-   * Entries kept out of the main list (the compiled-in table, once the harness
-   * has reported its own menu). Reachable behind a toggle so nothing is lost,
-   * but not in the way.
-   */
-  moreOptions?: ModelSelectorOption[];
   onChange: (v: string) => void;
 }
 
 export default function ModelSelector({
   value,
   options,
-  moreOptions = [],
   onChange,
 }: ModelSelectorProps) {
   const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
-  const [showMore, setShowMore] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const displayLabel = [...options, ...moreOptions].find((o) => o.value === value)?.label || value;
+  const displayLabel = options.find((o) => o.value === value)?.label || value;
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -85,20 +77,6 @@ export default function ModelSelector({
       {open && (
         <div className="absolute z-50 bottom-full mb-1 left-0 w-52 max-h-[280px] bg-popover border border-border rounded-xl shadow-xl overflow-y-auto">
           {options.map(renderOption)}
-          {moreOptions.length > 0 && (
-            <>
-              <button
-                type="button"
-                onClick={() => setShowMore((v) => !v)}
-                className="w-full px-3 py-1.5 text-left text-[10px] text-muted-foreground/70 hover:bg-muted/50 border-t border-border/50"
-              >
-                {showMore
-                  ? t('modelSelector.hideBuiltIn')
-                  : t('modelSelector.showBuiltIn', { count: moreOptions.length })}
-              </button>
-              {showMore && moreOptions.map(renderOption)}
-            </>
-          )}
         </div>
       )}
     </div>

--- a/src/components/chat/view/subcomponents/ModelSelector.tsx
+++ b/src/components/chat/view/subcomponents/ModelSelector.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 interface ModelSelectorProps {
   value: string;
-  options: Array<{ value: string; label: string }>;
+  options: Array<{ value: string; label: string; description?: string; deprecated?: boolean }>;
   onChange: (v: string) => void;
 }
 
@@ -12,6 +13,7 @@ export default function ModelSelector({
   options,
   onChange,
 }: ModelSelectorProps) {
+  const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const displayLabel = options.find((o) => o.value === value)?.label || value;
@@ -50,6 +52,7 @@ export default function ModelSelector({
               <button
                 key={opt.value}
                 type="button"
+                title={opt.description || opt.value}
                 onClick={() => { onChange(opt.value); setOpen(false); }}
                 className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[11px] transition-colors ${
                   active
@@ -58,6 +61,9 @@ export default function ModelSelector({
                 }`}
               >
                 <span className="flex-1 truncate">{opt.label}</span>
+                {opt.deprecated && (
+                  <span className="text-[9px] text-muted-foreground/60 shrink-0">{t('modelSelector.notInCliList')}</span>
+                )}
                 {active && <Check className="w-3 h-3 text-primary shrink-0" />}
               </button>
             );

--- a/src/components/chat/view/subcomponents/ModelSelector.tsx
+++ b/src/components/chat/view/subcomponents/ModelSelector.tsx
@@ -31,8 +31,17 @@ export default function ModelSelector({
         setOpen(false);
       }
     };
-    if (open) document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    if (open) {
+      document.addEventListener('mousedown', handler);
+      document.addEventListener('keydown', keyHandler);
+    }
+    return () => {
+      document.removeEventListener('mousedown', handler);
+      document.removeEventListener('keydown', keyHandler);
+    };
   }, [open]);
 
   const renderOption = (opt: ModelSelectorOption) => {

--- a/src/components/chat/view/subcomponents/ModelSelector.tsx
+++ b/src/components/chat/view/subcomponents/ModelSelector.tsx
@@ -2,21 +2,36 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Check } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+export interface ModelSelectorOption {
+  value: string;
+  label: string;
+  description?: string;
+  deprecated?: boolean;
+}
+
 interface ModelSelectorProps {
   value: string;
-  options: Array<{ value: string; label: string; description?: string; deprecated?: boolean }>;
+  options: ModelSelectorOption[];
+  /**
+   * Entries kept out of the main list (the compiled-in table, once the harness
+   * has reported its own menu). Reachable behind a toggle so nothing is lost,
+   * but not in the way.
+   */
+  moreOptions?: ModelSelectorOption[];
   onChange: (v: string) => void;
 }
 
 export default function ModelSelector({
   value,
   options,
+  moreOptions = [],
   onChange,
 }: ModelSelectorProps) {
   const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
+  const [showMore, setShowMore] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const displayLabel = options.find((o) => o.value === value)?.label || value;
+  const displayLabel = [...options, ...moreOptions].find((o) => o.value === value)?.label || value;
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -27,6 +42,29 @@ export default function ModelSelector({
     if (open) document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
+
+  const renderOption = (opt: ModelSelectorOption) => {
+    const active = opt.value === value;
+    return (
+      <button
+        key={opt.value}
+        type="button"
+        title={opt.description || opt.value}
+        onClick={() => { onChange(opt.value); setOpen(false); }}
+        className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[11px] transition-colors ${
+          active
+            ? 'bg-primary/8 text-foreground font-medium'
+            : 'hover:bg-muted/50 text-muted-foreground'
+        }`}
+      >
+        <span className="flex-1 truncate">{opt.label}</span>
+        {opt.deprecated && (
+          <span className="text-[9px] text-muted-foreground/60 shrink-0">{t('modelSelector.notInCliList')}</span>
+        )}
+        {active && <Check className="w-3 h-3 text-primary shrink-0" />}
+      </button>
+    );
+  };
 
   return (
     <div ref={containerRef} className="relative">
@@ -45,29 +83,22 @@ export default function ModelSelector({
       </button>
 
       {open && (
-        <div className="absolute z-50 bottom-full mb-1 left-0 w-52 max-h-[240px] bg-popover border border-border rounded-xl shadow-xl overflow-y-auto">
-          {options.map((opt) => {
-            const active = opt.value === value;
-            return (
+        <div className="absolute z-50 bottom-full mb-1 left-0 w-52 max-h-[280px] bg-popover border border-border rounded-xl shadow-xl overflow-y-auto">
+          {options.map(renderOption)}
+          {moreOptions.length > 0 && (
+            <>
               <button
-                key={opt.value}
                 type="button"
-                title={opt.description || opt.value}
-                onClick={() => { onChange(opt.value); setOpen(false); }}
-                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-[11px] transition-colors ${
-                  active
-                    ? 'bg-primary/8 text-foreground font-medium'
-                    : 'hover:bg-muted/50 text-muted-foreground'
-                }`}
+                onClick={() => setShowMore((v) => !v)}
+                className="w-full px-3 py-1.5 text-left text-[10px] text-muted-foreground/70 hover:bg-muted/50 border-t border-border/50"
               >
-                <span className="flex-1 truncate">{opt.label}</span>
-                {opt.deprecated && (
-                  <span className="text-[9px] text-muted-foreground/60 shrink-0">{t('modelSelector.notInCliList')}</span>
-                )}
-                {active && <Check className="w-3 h-3 text-primary shrink-0" />}
+                {showMore
+                  ? t('modelSelector.hideBuiltIn')
+                  : t('modelSelector.showBuiltIn', { count: moreOptions.length })}
               </button>
-            );
-          })}
+              {showMore && moreOptions.map(renderOption)}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -597,8 +597,6 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "not in CLI list",
-    "showBuiltIn": "Show {{count}} more built-in models",
-    "hideBuiltIn": "Hide built-in models"
+    "notInCliList": "not in CLI list"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -219,6 +219,10 @@
       "max": {
         "name": "Max",
         "description": "Maximum reasoning effort"
+      },
+      "ultra": {
+        "name": "Ultra",
+        "description": "The highest reasoning effort the model offers"
       }
     },
     "buttonTitle": "Reasoning effort: {{level}}"

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -595,5 +595,8 @@
       "briefExists": "research_brief.json detected",
       "buttonLabel": "Use in Chat"
     }
+  },
+  "modelSelector": {
+    "notInCliList": "not in CLI list"
   }
 }

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -597,6 +597,8 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "not in CLI list"
+    "notInCliList": "not in CLI list",
+    "showBuiltIn": "Show {{count}} more built-in models",
+    "hideBuiltIn": "Hide built-in models"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -219,6 +219,10 @@
       "max": {
         "name": "최대",
         "description": "최대 추론 강도"
+      },
+      "ultra": {
+        "name": "울트라",
+        "description": "모델이 제공하는 최고 추론 강도"
       }
     },
     "buttonTitle": "추론 강도: {{level}}"

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -574,6 +574,8 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "CLI 목록에 없음"
+    "notInCliList": "CLI 목록에 없음",
+    "showBuiltIn": "내장 모델 {{count}}개 더 보기",
+    "hideBuiltIn": "내장 모델 숨기기"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -574,8 +574,6 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "CLI 목록에 없음",
-    "showBuiltIn": "내장 모델 {{count}}개 더 보기",
-    "hideBuiltIn": "내장 모델 숨기기"
+    "notInCliList": "CLI 목록에 없음"
   }
 }

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -572,5 +572,8 @@
       "briefExists": "research_brief.json 감지됨",
       "buttonLabel": "채팅에서 사용"
     }
+  },
+  "modelSelector": {
+    "notInCliList": "CLI 목록에 없음"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -597,6 +597,8 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "CLI 未列出"
+    "notInCliList": "CLI 未列出",
+    "showBuiltIn": "显示其余 {{count}} 个内置模型",
+    "hideBuiltIn": "隐藏内置模型"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -597,8 +597,6 @@
     }
   },
   "modelSelector": {
-    "notInCliList": "CLI 未列出",
-    "showBuiltIn": "显示其余 {{count}} 个内置模型",
-    "hideBuiltIn": "隐藏内置模型"
+    "notInCliList": "CLI 未列出"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -595,5 +595,8 @@
       "briefExists": "已检测到 research_brief.json",
       "buttonLabel": "使用模板"
     }
+  },
+  "modelSelector": {
+    "notInCliList": "CLI 未列出"
   }
 }

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -219,6 +219,10 @@
       "max": {
         "name": "最高",
         "description": "最大推理强度"
+      },
+      "ultra": {
+        "name": "极限",
+        "description": "模型提供的最高推理强度"
       }
     },
     "buttonTitle": "思考强度：{{level}}"


### PR DESCRIPTION
Follow-up to #213 / #216 for three problems found while using the picker on `main`.

## 1. Provider switch corrupted the saved model (bug)

`useHarnessModels` set its state asynchronously, so for one render after a provider switch it still held the previous provider's list while `provider` already named the new one. `ChatComposer`'s rescue effect then saw the Claude model "missing" from Codex's list and replaced it with Codex's default: `localStorage['claude-model']` ended up as `gpt-5.6-sol`, and every new Claude session would have failed.

- The hook now tags each answer with the provider it was fetched for and only exposes an answer for the current provider.
- `useChatProviderState` drops a stored model that cannot belong to its slot (a `gpt-*` under `claude-model`, a `claude-*`/alias under `codex-model`) and falls back to the default, so anyone already affected recovers on next load. Verified in the browser: the corrupted value was replaced by `claude-fable-5`.

## 2. Fable 5.1 was not selectable

The Claude probe runs with `settingSources: []` so no hooks fire. That also hides the model configured in `~/.claude/settings.json`, and that is exactly where the CLI's own `/model` menu gets Fable 5.1 from (0.3.226's base menu lists Fable 5, not 5.1). Discovery now reads `model` from the user settings file (honouring `CLAUDE_CONFIG_DIR`) and `ANTHROPIC_MODEL`, and offers it the way the CLI does. `claude-fable-5-1` / `claude-fable-5-1[1m]` are also in the built-in list so they are available even with discovery off. Duplicate CLI display names ("Fable" for both 5 and 5.1) are disambiguated from the description.

Real probe output on this machine after the change: `default`, `opus[1m]`, `claude-fable-5[1m]` → Fable, `sonnet`, `haiku`, `claude-fable-5-1[1m]` → Fable 5.1 [1M], then the built-ins.

## 3. Codex reasoning-effort selector missing for discovered models

Support was a table keyed by exact model name; `gpt-5.6-sol`, `gpt-5.4-mini`, `gpt-5.3-codex-spark` fell to "default only" and the selector disappeared. Codex's `model/list` reports `supportedReasoningEfforts` and `defaultReasoningEffort` per model, so discovery now carries them through and the selector, its gating, and the saved-effort normalisation use that list first, with the table as fallback. The `ultra` effort the CLI offers (`gpt-5.6-sol` / `-terra`) is added to the UI and en/zh-CN/ko locales.

Measured: `gpt-5.6-sol` low/medium/high/xhigh/max/ultra (default low), `gpt-5.6-luna` low…max, `gpt-5.5`/`5.4`/`5.4-mini`/`5.3-codex-spark` low…xhigh.

`useHarnessModels` moved from `ChatComposer` up to `ChatInterface` so composer state (normalisation) and the picker share one answer.

## Verification

- `npx vitest run`: 172/172 (new tests for label disambiguation, configured-model injection, `ANTHROPIC_MODEL`, Codex effort mapping, discovered-effort precedence, `labelForClaudeModelId`).
- `npm run typecheck` clean.
- End-to-end against the real Claude and Codex CLIs through the module.
- Browser: model slot sanitisation confirmed; the picker/selector UI check was cut short when the browser extension disconnected, so please give the Codex effort selector and the Claude dropdown a quick look after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBqmTvJRhyysMvMvL6cp7x