### PR TITLE
perf(client): defer workspace and heavy UI bundles

### DIFF
--- a/electron/README.md
+++ b/electron/README.md
@@ -6,7 +6,7 @@ This directory contains the Electron wrapper for Dr. Claw.
 
 - The existing Express/WebSocket backend runs unchanged as a child process.
 - A `BrowserWindow` loads the local app URL after the embedded server starts.
-- A **preload script** (`preload.mjs`) exposes a safe IPC bridge (`window.electronAPI`) using `contextBridge`.
+- A sandbox-compatible **CommonJS preload script** (`preload.cjs`) exposes a safe IPC bridge (`window.electronAPI`) using `contextBridge`.
 - The renderer stays fully sandboxed with `contextIsolation: true` and `sandbox: true`.
 
 ## Features

--- a/electron/main.mjs
+++ b/electron/main.mjs
@@ -723,7 +723,9 @@ function createWindow(baseUrl) {
   logDesktop('Creating BrowserWindow', { baseUrl });
 
   const iconPath = path.join(resolveAppRoot(), 'build', 'icon.png');
-  const preloadPath = path.join(__dirname, 'preload.mjs');
+  // Sandboxed preload scripts run in a CommonJS-like environment and cannot
+  // execute ESM imports. Keep this file as .cjs while sandbox remains enabled.
+  const preloadPath = path.join(__dirname, 'preload.cjs');
 
   const savedState = loadWindowState();
   const defaultWidth = 1440;
@@ -829,6 +831,14 @@ function createWindow(baseUrl) {
 
   mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
     logDesktop('did-fail-load', { errorCode, errorDescription, validatedURL });
+  });
+
+  mainWindow.webContents.on('preload-error', (_event, failedPreloadPath, error) => {
+    logDesktop('preload-error', {
+      preloadPath: failedPreloadPath,
+      message: error?.message || String(error),
+      stack: error?.stack,
+    });
   });
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron';
+const { contextBridge, ipcRenderer } = require('electron');
 
 const ALLOWED_CHANNELS_INVOKE = new Set([
   'app:getInfo',
@@ -81,8 +81,3 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
 contextBridge.exposeInMainWorld('isElectron', true);
 contextBridge.exposeInMainWorld('electronPlatform', process.platform);
-
-// Stamp data attributes onto <html> before React renders so CSS / first-paint
-// logic can detect Electron + platform without any async round-trips.
-document.documentElement.dataset.electron = 'true';
-document.documentElement.dataset.platform = process.platform;

--- a/index.html
+++ b/index.html
@@ -28,20 +28,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-
-    <!-- Service Worker Registration -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js')
-            .then(registration => {
-              console.log('SW registered: ', registration);
-            })
-            .catch(registrationError => {
-              console.log('SW registration failed: ', registrationError);
-            });
-        });
-      }
-    </script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,13 @@
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
 import { I18nextProvider, useTranslation } from 'react-i18next';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import LazyLoadBoundary from './components/LazyLoadBoundary';
+import lazyWithRetry from './utils/lazyWithRetry';
 import i18n from './i18n/config.js';
 
-const AuthenticatedWorkspace = lazy(() => import('./components/app/AuthenticatedWorkspace'));
+const AuthenticatedWorkspace = lazyWithRetry(() => import('./components/app/AuthenticatedWorkspace'));
 
 function WorkspaceLoadingFallback() {
   const { t } = useTranslation('common');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,38 @@
-import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import { I18nextProvider } from 'react-i18next';
+import { lazy, Suspense } from 'react';
+import { I18nextProvider, useTranslation } from 'react-i18next';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
-import { TaskMasterProvider } from './contexts/TaskMasterContext';
-import { TasksSettingsProvider } from './contexts/TasksSettingsContext';
-import { WebSocketProvider } from './contexts/WebSocketContext';
 import ProtectedRoute from './components/ProtectedRoute';
-import AppContent from './components/app/AppContent';
-import SurveyDiagramWindow from './components/survey/view/SurveyDiagramWindow';
+import LazyLoadBoundary from './components/LazyLoadBoundary';
 import i18n from './i18n/config.js';
+
+const AuthenticatedWorkspace = lazy(() => import('./components/app/AuthenticatedWorkspace'));
+
+function WorkspaceLoadingFallback() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center" role="status" aria-live="polite">
+      <div className="flex flex-col items-center gap-3 text-muted-foreground">
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-muted border-t-primary" />
+        <span className="text-sm">{t('mainContent.loading')}</span>
+      </div>
+    </div>
+  );
+}
 
 export default function App() {
   return (
     <I18nextProvider i18n={i18n}>
       <ThemeProvider>
         <AuthProvider>
-          <WebSocketProvider>
-            <TasksSettingsProvider>
-              <TaskMasterProvider>
-                <ProtectedRoute>
-                  <Router basename={window.__ROUTER_BASENAME__ || ''}>
-                    <Routes>
-                      <Route path="/" element={<AppContent />} />
-                      <Route path="/session/:sessionId" element={<AppContent />} />
-                      <Route path="/survey/diagram" element={<SurveyDiagramWindow />} />
-                    </Routes>
-                  </Router>
-                </ProtectedRoute>
-              </TaskMasterProvider>
-            </TasksSettingsProvider>
-          </WebSocketProvider>
+          <ProtectedRoute>
+            <LazyLoadBoundary mode="page">
+              <Suspense fallback={<WorkspaceLoadingFallback />}>
+                <AuthenticatedWorkspace />
+              </Suspense>
+            </LazyLoadBoundary>
+          </ProtectedRoute>
         </AuthProvider>
       </ThemeProvider>
     </I18nextProvider>

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -22,8 +22,18 @@ class ErrorBoundary extends React.Component {
     });
   }
 
+  componentDidUpdate(previousProps) {
+    if (this.state.hasError && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false, error: null, errorInfo: null });
+    }
+  }
+
   render() {
     if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
       // Fallback UI
       return (
         <div className="flex flex-col items-center justify-center p-8 text-center">

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -8,7 +8,7 @@ class ErrorBoundary extends React.Component {
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI
-    return { hasError: true };
+    return { hasError: true, error };
   }
 
   componentDidCatch(error, errorInfo) {
@@ -30,7 +30,13 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      if (this.props.fallback) {
+      if (this.props.fallbackRender) {
+        // A render-prop fallback may decline (return null) to fall through to the default UI below.
+        const rendered = this.props.fallbackRender(this.state.error);
+        if (rendered !== null && rendered !== undefined) {
+          return rendered;
+        }
+      } else if (this.props.fallback) {
         return this.props.fallback;
       }
 

--- a/src/components/LazyLoadBoundary.tsx
+++ b/src/components/LazyLoadBoundary.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import ErrorBoundary from './ErrorBoundary';
+
+type LazyLoadBoundaryProps = {
+  children: ReactNode;
+  resetKey?: string;
+  mode?: 'page' | 'panel' | 'modal';
+  onClose?: () => void;
+  fallback?: ReactNode;
+};
+
+export function LazyModalLoadingFallback({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">
+      <div
+        className="w-full max-w-sm rounded-xl border border-border bg-card p-6 text-center shadow-lg"
+        role="dialog"
+        aria-modal="true"
+        aria-busy="true"
+        aria-label={t('mainContent.loading')}
+      >
+        <div className="mx-auto h-7 w-7 animate-spin rounded-full border-[3px] border-muted border-t-primary" />
+        <p className="mt-3 text-sm text-muted-foreground" role="status" aria-live="polite">
+          {t('mainContent.loading')}
+        </p>
+        <button
+          type="button"
+          className="mt-5 rounded-md border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
+          onClick={onClose}
+        >
+          {t('lazyLoad.close')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function LazyLoadError({ mode = 'panel', onClose }: Pick<LazyLoadBoundaryProps, 'mode' | 'onClose'>) {
+  const { t } = useTranslation('common');
+  const isPage = mode === 'page';
+  const isModal = mode === 'modal';
+
+  const content = (
+    <div
+      className="w-full max-w-md rounded-xl border border-border bg-card p-6 text-center shadow-lg"
+      role="alert"
+    >
+      <h2 className="text-base font-semibold text-foreground">{t('lazyLoad.errorTitle')}</h2>
+      <p className="mt-2 text-sm text-muted-foreground">{t('lazyLoad.errorDescription')}</p>
+      <div className="mt-5 flex justify-center gap-3">
+        {onClose && (
+          <button
+            type="button"
+            className="rounded-md border border-border px-4 py-2 text-sm text-foreground hover:bg-muted"
+            onClick={onClose}
+          >
+            {t('lazyLoad.close')}
+          </button>
+        )}
+        <button
+          type="button"
+          className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90"
+          onClick={() => window.location.reload()}
+        >
+          {t('lazyLoad.reload')}
+        </button>
+      </div>
+    </div>
+  );
+
+  if (isModal) {
+    return <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm">{content}</div>;
+  }
+
+  return (
+    <div className={`${isPage ? 'min-h-screen' : 'h-full min-h-48'} flex items-center justify-center bg-background p-4`}>
+      {content}
+    </div>
+  );
+}
+
+export default function LazyLoadBoundary({
+  children,
+  resetKey,
+  mode = 'panel',
+  onClose,
+  fallback,
+}: LazyLoadBoundaryProps) {
+  return (
+    <ErrorBoundary
+      key={resetKey}
+      resetKey={resetKey}
+      fallback={fallback ?? <LazyLoadError mode={mode} onClose={onClose} />}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/components/LazyLoadBoundary.tsx
+++ b/src/components/LazyLoadBoundary.tsx
@@ -10,6 +10,20 @@ type LazyLoadBoundaryProps = {
   fallback?: ReactNode;
 };
 
+const CHUNK_LOAD_ERROR_PATTERNS = [
+  /failed to fetch dynamically imported module/i, // Chromium (Vite)
+  /error loading dynamically imported module/i, // Firefox
+  /importing a module script failed/i, // Safari
+  /loading (?:css )?chunk [\w-]+ failed/i, // webpack-style bundlers
+  /ChunkLoadError/i,
+];
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error) return false;
+  const text = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return CHUNK_LOAD_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
 export function LazyModalLoadingFallback({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation('common');
 
@@ -82,6 +96,17 @@ function LazyLoadError({ mode = 'panel', onClose }: Pick<LazyLoadBoundaryProps, 
   );
 }
 
+/**
+ * Error boundary for `lazy()` subtrees.
+ *
+ * Only chunk-load failures get the "the app may have been updated, reload" copy.
+ * Any other error is a runtime bug and falls through to ErrorBoundary's default
+ * UI, which keeps the stack trace and an in-place "Try Again". An explicit
+ * `fallback` is a graceful-degradation node and is used for either kind.
+ *
+ * `resetKey` clears the error state without remounting the children, so a
+ * boundary keyed on e.g. a file path does not tear down the subtree on change.
+ */
 export default function LazyLoadBoundary({
   children,
   resetKey,
@@ -91,9 +116,13 @@ export default function LazyLoadBoundary({
 }: LazyLoadBoundaryProps) {
   return (
     <ErrorBoundary
-      key={resetKey}
       resetKey={resetKey}
-      fallback={fallback ?? <LazyLoadError mode={mode} onClose={onClose} />}
+      showDetails
+      fallbackRender={(error: unknown) => {
+        if (fallback !== undefined) return fallback;
+        if (isChunkLoadError(error)) return <LazyLoadError mode={mode} onClose={onClose} />;
+        return null;
+      }}
     >
       {children}
     </ErrorBoundary>

--- a/src/components/LoginModal.jsx
+++ b/src/components/LoginModal.jsx
@@ -1,9 +1,13 @@
-import { useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { ExternalLink, Loader2, RefreshCw, Wrench, X } from 'lucide-react';
-import StandaloneShell from './StandaloneShell';
+import LazyLoadBoundary from './LazyLoadBoundary';
+import lazyWithRetry from '../utils/lazyWithRetry';
 import { authenticatedFetch } from '../utils/api';
 import { IS_PLATFORM } from '../constants/config';
 import { useDesktop } from '../hooks/useDesktop';
+
+// StandaloneShell pulls in xterm; this modal is reachable before login, so keep it off the entry chunk.
+const StandaloneShell = lazyWithRetry(() => import('./StandaloneShell'));
 
 function LoginModal({
   isOpen,
@@ -230,12 +234,22 @@ function LoginModal({
           </button>
         </div>
         <div className="flex-1 overflow-hidden">
-          <StandaloneShell
-            project={project}
-            command={getCommand()}
-            onComplete={handleComplete}
-            minimal={true}
-          />
+          <LazyLoadBoundary onClose={onClose}>
+            <Suspense
+              fallback={(
+                <div className="flex h-full items-center justify-center text-gray-400">
+                  <Loader2 className="w-6 h-6 animate-spin" />
+                </div>
+              )}
+            >
+              <StandaloneShell
+                project={project}
+                command={getCommand()}
+                onComplete={handleComplete}
+                minimal={true}
+              />
+            </Suspense>
+          </LazyLoadBoundary>
         </div>
       </div>
     </div>

--- a/src/components/__tests__/LazyLoadBoundary.test.ts
+++ b/src/components/__tests__/LazyLoadBoundary.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { isChunkLoadError } from '../LazyLoadBoundary';
+
+describe('isChunkLoadError', () => {
+  it.each([
+    ['Chromium / Vite', new TypeError('Failed to fetch dynamically imported module: https://x/assets/Settings-abc.js')],
+    ['Firefox', new TypeError('error loading dynamically imported module: https://x/assets/Settings-abc.js')],
+    ['Safari', new TypeError('Importing a module script failed.')],
+    ['webpack-style', Object.assign(new Error('Loading chunk 42 failed.'), { name: 'ChunkLoadError' })],
+    ['plain string', 'ChunkLoadError: Loading chunk vendors failed'],
+  ])('recognises a %s chunk-load failure', (_label, error) => {
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it.each([
+    ['a runtime TypeError', new TypeError("Cannot read properties of undefined (reading 'map')")],
+    ['a thrown string', 'render exploded'],
+    ['a network error unrelated to modules', new TypeError('Failed to fetch')],
+    ['null', null],
+    ['undefined', undefined],
+  ])('does not classify %s as a chunk-load failure', (_label, error) => {
+    expect(isChunkLoadError(error)).toBe(false);
+  });
+});

--- a/src/components/app/AppContent.tsx
+++ b/src/components/app/AppContent.tsx
@@ -192,40 +192,76 @@ export default function AppContent() {
   const desktopSidebarWidth = sidebarVisible ? sidebarWidth : SIDEBAR_COLLAPSED_WIDTH;
 
   const isResizing = useRef(false);
+  const sidebarContainerRef = useRef<HTMLDivElement>(null);
+  const resizeFrameRef = useRef<number | null>(null);
+  const pendingWidthRef = useRef(sidebarWidth);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => () => {
+    resizeCleanupRef.current?.();
+    if (resizeFrameRef.current !== null) {
+      cancelAnimationFrame(resizeFrameRef.current);
+    }
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  }, []);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
+    resizeCleanupRef.current?.();
     isResizing.current = true;
+    sidebarContainerRef.current?.style.setProperty('transition', 'none');
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
 
     const onMouseMove = (ev: MouseEvent) => {
       if (!isResizing.current) return;
-      const newWidth = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, ev.clientX));
-      setSidebarWidth(newWidth);
+      pendingWidthRef.current = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, ev.clientX));
+      if (resizeFrameRef.current !== null) return;
+
+      resizeFrameRef.current = requestAnimationFrame(() => {
+        if (sidebarContainerRef.current) {
+          sidebarContainerRef.current.style.width = `${pendingWidthRef.current}px`;
+        }
+        resizeFrameRef.current = null;
+      });
     };
 
-    const onMouseUp = () => {
+    const cleanupResize = () => {
       isResizing.current = false;
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
-      setSidebarWidth((w) => {
-        localStorage.setItem(STORAGE_KEY, String(w));
-        localStorage.removeItem(LEGACY_STORAGE_KEY);
-        return w;
-      });
+      window.removeEventListener('blur', onMouseUp);
+      resizeCleanupRef.current = null;
     };
 
+    const onMouseUp = () => {
+      if (resizeFrameRef.current !== null) {
+        cancelAnimationFrame(resizeFrameRef.current);
+        resizeFrameRef.current = null;
+      }
+      const finalWidth = pendingWidthRef.current;
+      sidebarContainerRef.current?.style.setProperty('width', `${finalWidth}px`);
+      setSidebarWidth(finalWidth);
+      localStorage.setItem(STORAGE_KEY, String(finalWidth));
+      localStorage.removeItem(LEGACY_STORAGE_KEY);
+      sidebarContainerRef.current?.style.removeProperty('transition');
+      cleanupResize();
+    };
+
+    resizeCleanupRef.current = cleanupResize;
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('blur', onMouseUp);
   }, []);
 
   return (
     <div className="fixed inset-0 flex bg-background">
       {!isMobile ? (
         <div
+          ref={sidebarContainerRef}
           className="h-full flex-shrink-0 relative transition-[width] duration-150 ease-out"
           style={{ width: desktopSidebarWidth }}
         >

--- a/src/components/app/AuthenticatedWorkspace.tsx
+++ b/src/components/app/AuthenticatedWorkspace.tsx
@@ -1,13 +1,14 @@
-import { lazy, Suspense } from 'react';
+import { Suspense } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { TaskMasterProvider } from '../../contexts/TaskMasterContext';
 import { TasksSettingsProvider } from '../../contexts/TasksSettingsContext';
 import { WebSocketProvider } from '../../contexts/WebSocketContext';
+import lazyWithRetry from '../../utils/lazyWithRetry';
 
-const AppContent = lazy(() => import('./AppContent'));
-const SurveyDiagramWindow = lazy(() => import('../survey/view/SurveyDiagramWindow'));
+const AppContent = lazyWithRetry(() => import('./AppContent'));
+const SurveyDiagramWindow = lazyWithRetry(() => import('../survey/view/SurveyDiagramWindow'));
 
 function WorkspaceLoadingFallback() {
   const { t } = useTranslation('common');

--- a/src/components/app/AuthenticatedWorkspace.tsx
+++ b/src/components/app/AuthenticatedWorkspace.tsx
@@ -1,0 +1,43 @@
+import { lazy, Suspense } from 'react';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+import { TaskMasterProvider } from '../../contexts/TaskMasterContext';
+import { TasksSettingsProvider } from '../../contexts/TasksSettingsContext';
+import { WebSocketProvider } from '../../contexts/WebSocketContext';
+
+const AppContent = lazy(() => import('./AppContent'));
+const SurveyDiagramWindow = lazy(() => import('../survey/view/SurveyDiagramWindow'));
+
+function WorkspaceLoadingFallback() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center" role="status" aria-live="polite">
+      <div className="flex flex-col items-center gap-3 text-muted-foreground">
+        <div className="h-8 w-8 animate-spin rounded-full border-[3px] border-muted border-t-primary" />
+        <span className="text-sm">{t('mainContent.loading')}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function AuthenticatedWorkspace() {
+  return (
+    <WebSocketProvider>
+      <TasksSettingsProvider>
+        <TaskMasterProvider>
+          <Suspense fallback={<WorkspaceLoadingFallback />}>
+            <Router basename={window.__ROUTER_BASENAME__ || ''}>
+              <Routes>
+                <Route path="/" element={<AppContent />} />
+                <Route path="/session/:sessionId" element={<AppContent />} />
+                <Route path="/survey/diagram" element={<SurveyDiagramWindow />} />
+              </Routes>
+            </Router>
+          </Suspense>
+        </TaskMasterProvider>
+      </TasksSettingsProvider>
+    </WebSocketProvider>
+  );
+}

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import QuickSettingsPanel from '../../QuickSettingsPanel';
 import ChatTaskProgressPill from './subcomponents/ChatTaskProgressPill';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
@@ -29,8 +29,9 @@ import { buildEditableMessageDraft, buildReplayMessageDraft, getChatMessageId, g
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import LazyLoadBoundary from '../../LazyLoadBoundary';
+import lazyWithRetry from '../../../utils/lazyWithRetry';
 
-const CodeEditor = lazy(() => import('../../CodeEditor'));
+const CodeEditor = lazyWithRetry(() => import('../../CodeEditor'));
 
 const DEFAULT_PROVIDER_AVAILABILITY: Record<Provider, ProviderAvailability> = {
   claude: { cliAvailable: true, cliCommand: 'claude', installHint: null },

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -1,6 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import QuickSettingsPanel from '../../QuickSettingsPanel';
-import CodeEditor from '../../CodeEditor';
 import ChatTaskProgressPill from './subcomponents/ChatTaskProgressPill';
 import { useTasksSettings } from '../../../contexts/TasksSettingsContext';
 import { useTaskMaster } from '../../../contexts/TaskMasterContext';
@@ -29,6 +28,9 @@ import { getProviderDisplayName } from '../utils/chatFormatting';
 import { buildEditableMessageDraft, buildReplayMessageDraft, getChatMessageId, getMessageReplayContent } from '../utils/chatMessages';
 import { normalizePath, toRelativePath, isSafePath, fileNameFromPath } from '../../../utils/pathUtils';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
+import LazyLoadBoundary from '../../LazyLoadBoundary';
+
+const CodeEditor = lazy(() => import('../../CodeEditor'));
 
 const DEFAULT_PROVIDER_AVAILABILITY: Record<Provider, ProviderAvailability> = {
   claude: { cliAvailable: true, cliCommand: 'claude', installHint: null },
@@ -1002,14 +1004,25 @@ function ChatInterface({
         )}
 
         {editingFile && selectedProject && (
-          <CodeEditor
-            file={editingFile}
-            onClose={handleCloseEditor}
-            projectPath={selectedProject.fullPath || selectedProject.path}
-            selectedProject={selectedProject}
-            onStartWorkspaceQa={onStartWorkspaceQa}
-            displayMode="embedded"
-          />
+          <LazyLoadBoundary resetKey={editingFile.path} onClose={handleCloseEditor}>
+            <Suspense
+              fallback={(
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground" role="status" aria-live="polite">
+                  <div className="mr-2 h-5 w-5 animate-spin rounded-full border-2 border-muted border-t-primary" />
+                  {t('common:mainContent.loading')}
+                </div>
+              )}
+            >
+              <CodeEditor
+                file={editingFile}
+                onClose={handleCloseEditor}
+                projectPath={selectedProject.fullPath || selectedProject.path}
+                selectedProject={selectedProject}
+                onStartWorkspaceQa={onStartWorkspaceQa}
+                displayMode="embedded"
+              />
+            </Suspense>
+          </LazyLoadBoundary>
         )}
 
           </div>

--- a/src/components/chat/view/subcomponents/Markdown.tsx
+++ b/src/components/chat/view/subcomponents/Markdown.tsx
@@ -1,5 +1,5 @@
-import React, { lazy, Suspense, useMemo, useState } from 'react';
-import type { ComponentType, LazyExoticComponent } from 'react';
+import React, { Suspense, useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
@@ -8,6 +8,7 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
 import { normalizeInlineCodeFences } from '../../utils/chatFormatting';
 import LazyLoadBoundary from '../../../LazyLoadBoundary';
+import lazyWithRetry from '../../../../utils/lazyWithRetry';
 
 type SyntaxHighlighterProps = {
   children: string;
@@ -17,13 +18,19 @@ type SyntaxHighlighterProps = {
   codeTagProps: { style: React.CSSProperties };
 };
 
-const SyntaxHighlighter = lazy(() =>
-  import('react-syntax-highlighter').then((module) => ({ default: module.Prism })),
-) as LazyExoticComponent<ComponentType<SyntaxHighlighterProps>>;
+// Deep-import the Prism build: the package root also drags in highlight.js and
+// the async language loaders (~1 MB) that this component never uses.
+const SyntaxHighlighter = lazyWithRetry(
+  () => import('react-syntax-highlighter/dist/esm/prism'),
+) as ComponentType<SyntaxHighlighterProps>;
 
-function PlainCodeBlock({ code }: { code: string }) {
+function PlainCodeBlock({ code, language }: { code: string; language?: string }) {
+  // Mirror the highlighted block's padding so the absolutely positioned language
+  // label and copy button never overlap the first line, and nothing shifts when
+  // the highlighter chunk arrives.
+  const padded = language && language !== 'text';
   return (
-    <pre className="m-0 overflow-x-auto rounded-lg bg-[#282c34] p-4 text-sm text-gray-100">
+    <pre className={`m-0 overflow-x-auto rounded-lg bg-[#282c34] ${padded ? 'pt-8 px-4 pb-4' : 'p-4'} text-sm text-gray-100`}>
       <code>{code}</code>
     </pre>
   );
@@ -146,8 +153,8 @@ const CodeBlock = ({ node, inline, className, children, ...props }: CodeBlockPro
         )}
       </button>
 
-      <LazyLoadBoundary fallback={<PlainCodeBlock code={raw} />}>
-        <Suspense fallback={<PlainCodeBlock code={raw} />}>
+      <LazyLoadBoundary fallback={<PlainCodeBlock code={raw} language={language} />}>
+        <Suspense fallback={<PlainCodeBlock code={raw} language={language} />}>
           <SyntaxHighlighter
             language={language}
             style={oneDark}

--- a/src/components/chat/view/subcomponents/Markdown.tsx
+++ b/src/components/chat/view/subcomponents/Markdown.tsx
@@ -1,12 +1,33 @@
-import React, { useMemo, useState } from 'react';
+import React, { lazy, Suspense, useMemo, useState } from 'react';
+import type { ComponentType, LazyExoticComponent } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
 import { normalizeInlineCodeFences } from '../../utils/chatFormatting';
+import LazyLoadBoundary from '../../../LazyLoadBoundary';
+
+type SyntaxHighlighterProps = {
+  children: string;
+  language: string;
+  style: unknown;
+  customStyle: React.CSSProperties;
+  codeTagProps: { style: React.CSSProperties };
+};
+
+const SyntaxHighlighter = lazy(() =>
+  import('react-syntax-highlighter').then((module) => ({ default: module.Prism })),
+) as LazyExoticComponent<ComponentType<SyntaxHighlighterProps>>;
+
+function PlainCodeBlock({ code }: { code: string }) {
+  return (
+    <pre className="m-0 overflow-x-auto rounded-lg bg-[#282c34] p-4 text-sm text-gray-100">
+      <code>{code}</code>
+    </pre>
+  );
+}
 
 type MarkdownProps = {
   children: React.ReactNode;
@@ -125,24 +146,28 @@ const CodeBlock = ({ node, inline, className, children, ...props }: CodeBlockPro
         )}
       </button>
 
-      <SyntaxHighlighter
-        language={language}
-        style={oneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: '0.5rem',
-          fontSize: '0.875rem',
-          padding: language && language !== 'text' ? '2rem 1rem 1rem 1rem' : '1rem',
-        }}
-        codeTagProps={{
-          style: {
-            fontFamily:
-              'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-          },
-        }}
-      >
-        {raw}
-      </SyntaxHighlighter>
+      <LazyLoadBoundary fallback={<PlainCodeBlock code={raw} />}>
+        <Suspense fallback={<PlainCodeBlock code={raw} />}>
+          <SyntaxHighlighter
+            language={language}
+            style={oneDark}
+            customStyle={{
+              margin: 0,
+              borderRadius: '0.5rem',
+              fontSize: '0.875rem',
+              padding: language && language !== 'text' ? '2rem 1rem 1rem 1rem' : '1rem',
+            }}
+            codeTagProps={{
+              style: {
+                fontFamily:
+                  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+              },
+            }}
+          >
+            {raw}
+          </SyntaxHighlighter>
+        </Suspense>
+      </LazyLoadBoundary>
     </div>
   );
 };

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -1,7 +1,6 @@
 import React, { lazy, Suspense, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ErrorBoundary from '../../ErrorBoundary';
 import LazyLoadBoundary from '../../LazyLoadBoundary';
 
 import ChatTabBar from '../../chat/view/ChatTabBar';
@@ -365,9 +364,8 @@ function MainContent({
                 openNewTab();
               }}
             />
-            <ErrorBoundary showDetails>
-              <Suspense fallback={<ContentLoadingFallback />}>
-                <ChatInterface
+            <LazyContent resetKey="chat">
+              <ChatInterface
                 selectedProject={selectedProject}
                 selectedSession={effectiveSession}
                 ws={ws}
@@ -395,9 +393,8 @@ function MainContent({
                 clearImportedProjectAnalysisPrompt={clearImportedProjectAnalysisPrompt}
                 newSessionMode={newSessionMode}
                 onNewSessionModeChange={onNewSessionModeChange}
-                />
-              </Suspense>
-            </ErrorBoundary>
+              />
+            </LazyContent>
           </div>
 
           {activeTab === 'survey' && (

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -1,7 +1,8 @@
-import React, { lazy, Suspense, useCallback, useEffect } from 'react';
+import React, { Suspense, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import LazyLoadBoundary from '../../LazyLoadBoundary';
+import lazyWithRetry from '../../../utils/lazyWithRetry';
 
 import ChatTabBar from '../../chat/view/ChatTabBar';
 import { useChatTabs } from '../../../hooks/useChatTabs';
@@ -16,14 +17,14 @@ import type { Project } from '../../../types/app';
 import type { Reference } from '../../references/types';
 import { queueSkillCommandDraft } from '../../../utils/skillCommandDraft';
 
-const ChatInterface = lazy(() => import('../../chat/view/ChatInterface'));
-const SkillsDashboard = lazy(() => import('../../SkillsDashboard'));
-const AutoResearchHub = lazy(() => import('../../AutoResearchHub'));
-const ComputeResourcesDashboard = lazy(() => import('../../compute-dashboard/ComputeResourcesDashboard'));
-const SurveyPage = lazy(() => import('../../survey/view/SurveyPage'));
-const ProjectDashboard = lazy(() => import('../../project-dashboard/view/ProjectDashboard'));
-const TrashDashboard = lazy(() => import('../../project-dashboard/view/TrashDashboard'));
-const NewsDashboard = lazy(() => import('../../news-dashboard/view/NewsDashboard'));
+const ChatInterface = lazyWithRetry(() => import('../../chat/view/ChatInterface'));
+const SkillsDashboard = lazyWithRetry(() => import('../../SkillsDashboard'));
+const AutoResearchHub = lazyWithRetry(() => import('../../AutoResearchHub'));
+const ComputeResourcesDashboard = lazyWithRetry(() => import('../../compute-dashboard/ComputeResourcesDashboard'));
+const SurveyPage = lazyWithRetry(() => import('../../survey/view/SurveyPage'));
+const ProjectDashboard = lazyWithRetry(() => import('../../project-dashboard/view/ProjectDashboard'));
+const TrashDashboard = lazyWithRetry(() => import('../../project-dashboard/view/TrashDashboard'));
+const NewsDashboard = lazyWithRetry(() => import('../../news-dashboard/view/NewsDashboard'));
 
 function ContentLoadingFallback() {
   const { t } = useTranslation('common');

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -1,14 +1,8 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { lazy, Suspense, useCallback, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import ChatInterface from '../../chat/view/ChatInterface';
-import SkillsDashboard from '../../SkillsDashboard';
-import AutoResearchHub from '../../AutoResearchHub';
-import ComputeResourcesDashboard from '../../compute-dashboard/ComputeResourcesDashboard';
 import ErrorBoundary from '../../ErrorBoundary';
-import SurveyPage from '../../survey/view/SurveyPage';
-import ProjectDashboard from '../../project-dashboard/view/ProjectDashboard';
-import TrashDashboard from '../../project-dashboard/view/TrashDashboard';
-import NewsDashboard from '../../news-dashboard/view/NewsDashboard';
+import LazyLoadBoundary from '../../LazyLoadBoundary';
 
 import ChatTabBar from '../../chat/view/ChatTabBar';
 import { useChatTabs } from '../../../hooks/useChatTabs';
@@ -22,6 +16,36 @@ import { useUiPreferences } from '../../../hooks/useUiPreferences';
 import type { Project } from '../../../types/app';
 import type { Reference } from '../../references/types';
 import { queueSkillCommandDraft } from '../../../utils/skillCommandDraft';
+
+const ChatInterface = lazy(() => import('../../chat/view/ChatInterface'));
+const SkillsDashboard = lazy(() => import('../../SkillsDashboard'));
+const AutoResearchHub = lazy(() => import('../../AutoResearchHub'));
+const ComputeResourcesDashboard = lazy(() => import('../../compute-dashboard/ComputeResourcesDashboard'));
+const SurveyPage = lazy(() => import('../../survey/view/SurveyPage'));
+const ProjectDashboard = lazy(() => import('../../project-dashboard/view/ProjectDashboard'));
+const TrashDashboard = lazy(() => import('../../project-dashboard/view/TrashDashboard'));
+const NewsDashboard = lazy(() => import('../../news-dashboard/view/NewsDashboard'));
+
+function ContentLoadingFallback() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex h-full min-h-48 items-center justify-center" role="status" aria-live="polite">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted border-t-primary" />
+        <span>{t('mainContent.loading')}</span>
+      </div>
+    </div>
+  );
+}
+
+function LazyContent({ children, resetKey }: { children: React.ReactNode; resetKey: string }) {
+  return (
+    <LazyLoadBoundary resetKey={resetKey}>
+      <Suspense fallback={<ContentLoadingFallback />}>{children}</Suspense>
+    </LazyLoadBoundary>
+  );
+}
 
 type TaskMasterContextValue = {
   currentProject?: Project | null;
@@ -171,16 +195,18 @@ function MainContent({
         />
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ProjectDashboard
-            projects={projects}
-            onProjectAction={(project, tab, sessionId) => {
-              onProjectSelect(project);
-              setActiveTab(tab);
-              if (sessionId && tab === 'chat') {
-                onNavigateToSession(sessionId, undefined, project.name);
-              }
-            }}
-          />
+          <LazyContent resetKey="dashboard">
+            <ProjectDashboard
+              projects={projects}
+              onProjectAction={(project, tab, sessionId) => {
+                onProjectSelect(project);
+                setActiveTab(tab);
+                if (sessionId && tab === 'chat') {
+                  onNavigateToSession(sessionId, undefined, project.name);
+                }
+              }}
+            />
+          </LazyContent>
         </div>
       </div>
     );
@@ -199,7 +225,7 @@ function MainContent({
           onMenuClick={onMenuClick}
         />
         <div className="flex-1 min-h-0 overflow-hidden">
-          <AutoResearchHub />
+          <LazyContent resetKey="auto-research"><AutoResearchHub /></LazyContent>
         </div>
       </div>
     );
@@ -219,17 +245,19 @@ function MainContent({
         />
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          <SkillsDashboard
-            onSendToChat={(command: string) => {
-              queueSkillCommandDraft(command);
-              // Select the most recent project if available, then switch to chat
-              const recentProject = projects?.[0];
-              if (recentProject) {
-                onProjectSelect(recentProject);
-              }
-              setActiveTab('chat');
-            }}
-          />
+          <LazyContent resetKey="skills">
+            <SkillsDashboard
+              onSendToChat={(command: string) => {
+                queueSkillCommandDraft(command);
+                // Select the most recent project if available, then switch to chat
+                const recentProject = projects?.[0];
+                if (recentProject) {
+                  onProjectSelect(recentProject);
+                }
+                setActiveTab('chat');
+              }}
+            />
+          </LazyContent>
         </div>
       </div>
     );
@@ -249,16 +277,18 @@ function MainContent({
         />
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          <TrashDashboard
-            projects={trashProjects}
-            isLoading={Boolean(isTrashLoading)}
-            onRefresh={async () => {
-              await Promise.all([
-                window.refreshProjects?.(),
-                window.refreshTrashProjects?.(),
-              ]);
-            }}
-          />
+          <LazyContent resetKey="trash">
+            <TrashDashboard
+              projects={trashProjects}
+              isLoading={Boolean(isTrashLoading)}
+              onRefresh={async () => {
+                await Promise.all([
+                  window.refreshProjects?.(),
+                  window.refreshTrashProjects?.(),
+                ]);
+              }}
+            />
+          </LazyContent>
         </div>
       </div>
     );
@@ -278,7 +308,7 @@ function MainContent({
         />
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          <NewsDashboard />
+          <LazyContent resetKey="news"><NewsDashboard /></LazyContent>
         </div>
       </div>
     );
@@ -298,7 +328,7 @@ function MainContent({
         />
 
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ComputeResourcesDashboard />
+          <LazyContent resetKey="compute"><ComputeResourcesDashboard /></LazyContent>
         </div>
       </div>
     );
@@ -336,7 +366,8 @@ function MainContent({
               }}
             />
             <ErrorBoundary showDetails>
-              <ChatInterface
+              <Suspense fallback={<ContentLoadingFallback />}>
+                <ChatInterface
                 selectedProject={selectedProject}
                 selectedSession={effectiveSession}
                 ws={ws}
@@ -364,16 +395,19 @@ function MainContent({
                 clearImportedProjectAnalysisPrompt={clearImportedProjectAnalysisPrompt}
                 newSessionMode={newSessionMode}
                 onNewSessionModeChange={onNewSessionModeChange}
-              />
+                />
+              </Suspense>
             </ErrorBoundary>
           </div>
 
           {activeTab === 'survey' && (
             <div className="h-full overflow-hidden">
-              <SurveyPage
-                selectedProject={selectedProject}
-                onChatFromReference={onChatFromReference ? (ref: Reference) => onChatFromReference(selectedProject, ref) : undefined}
-              />
+              <LazyContent resetKey="survey">
+                <SurveyPage
+                  selectedProject={selectedProject}
+                  onChatFromReference={onChatFromReference ? (ref: Reference) => onChatFromReference(selectedProject, ref) : undefined}
+                />
+              </LazyContent>
             </div>
           )}
 

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
@@ -11,12 +11,13 @@ import SidebarCollapsed from './subcomponents/SidebarCollapsed';
 import SidebarContent from './subcomponents/SidebarContent';
 import SidebarModals from './subcomponents/SidebarModals';
 import LazyLoadBoundary, { LazyModalLoadingFallback } from '../../LazyLoadBoundary';
+import lazyWithRetry from '../../../utils/lazyWithRetry';
 import type { Project } from '../../../types/app';
 import type { ProjectCreationOptions } from '../../../types/app';
 import type { SidebarProjectListProps } from './subcomponents/SidebarProjectList';
 import type { MCPServerStatus, SidebarProps } from '../types/types';
 
-const ProjectCreationWizard = lazy(() => import('../../ProjectCreationWizard'));
+const ProjectCreationWizard = lazyWithRetry(() => import('../../ProjectCreationWizard'));
 
 type TaskMasterSidebarContext = {
   setCurrentProject: (project: Project) => void;

--- a/src/components/sidebar/view/Sidebar.tsx
+++ b/src/components/sidebar/view/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDeviceSettings } from '../../../hooks/useDeviceSettings';
 import { useVersionCheck } from '../../../hooks/useVersionCheck';
@@ -10,11 +10,13 @@ import { useAuth } from '../../../contexts/AuthContext';
 import SidebarCollapsed from './subcomponents/SidebarCollapsed';
 import SidebarContent from './subcomponents/SidebarContent';
 import SidebarModals from './subcomponents/SidebarModals';
-import ProjectCreationWizard from '../../ProjectCreationWizard';
+import LazyLoadBoundary, { LazyModalLoadingFallback } from '../../LazyLoadBoundary';
 import type { Project } from '../../../types/app';
 import type { ProjectCreationOptions } from '../../../types/app';
 import type { SidebarProjectListProps } from './subcomponents/SidebarProjectList';
 import type { MCPServerStatus, SidebarProps } from '../types/types';
+
+const ProjectCreationWizard = lazy(() => import('../../ProjectCreationWizard'));
 
 type TaskMasterSidebarContext = {
   setCurrentProject: (project: Project) => void;
@@ -250,22 +252,26 @@ function Sidebar({
       />
 
       {showWizard && (
-        <ProjectCreationWizard
-          onClose={() => setShowWizard(false)}
-          onProjectCreated={(project: Project, options?: ProjectCreationOptions) => {
-            setShowWizard(false);
-            window.refreshProjects?.();
-            if (options?.importedProjectAnalysisPrompt) {
-              onImportedProjectCreated?.(project, options);
-              return;
-            }
-            if (window.handleProjectCreatedWithIntake) {
-              window.handleProjectCreatedWithIntake(project, options);
-            } else {
-              handleProjectSelect(project);
-            }
-          }}
-        />
+        <LazyLoadBoundary mode="modal" resetKey="project-wizard" onClose={() => setShowWizard(false)}>
+          <Suspense fallback={<LazyModalLoadingFallback onClose={() => setShowWizard(false)} />}>
+            <ProjectCreationWizard
+              onClose={() => setShowWizard(false)}
+              onProjectCreated={(project: Project, options?: ProjectCreationOptions) => {
+                setShowWizard(false);
+                window.refreshProjects?.();
+                if (options?.importedProjectAnalysisPrompt) {
+                  onImportedProjectCreated?.(project, options);
+                  return;
+                }
+                if (window.handleProjectCreatedWithIntake) {
+                  window.handleProjectCreatedWithIntake(project, options);
+                } else {
+                  handleProjectSelect(project);
+                }
+              }}
+            />
+          </Suspense>
+        </LazyLoadBoundary>
       )}
 
       {isSidebarCollapsed ? (

--- a/src/components/sidebar/view/subcomponents/SidebarModals.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarModals.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
+import type { ComponentType, LazyExoticComponent } from 'react';
 import ReactDOM from 'react-dom';
 import { AlertTriangle, Trash2 } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { Button } from '../../../ui/button';
-import Settings from '../../../Settings';
-import VersionUpgradeModal from '../../../modals/VersionUpgradeModal';
+import LazyLoadBoundary, { LazyModalLoadingFallback } from '../../../LazyLoadBoundary';
 import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 import type { InstallMode } from '../../../../hooks/useVersionCheck';
@@ -39,11 +39,8 @@ type TypedSettingsProps = {
   initialTab: string;
 };
 
-const SettingsComponent = Settings as (props: TypedSettingsProps) => JSX.Element;
-
-function TypedSettings(props: TypedSettingsProps) {
-  return <SettingsComponent {...props} />;
-}
+const Settings = lazy(() => import('../../../Settings')) as LazyExoticComponent<ComponentType<TypedSettingsProps>>;
+const VersionUpgradeModal = lazy(() => import('../../../modals/VersionUpgradeModal'));
 
 export default function SidebarModals({
   projects,
@@ -74,12 +71,16 @@ export default function SidebarModals({
     <>
       {showSettings &&
         ReactDOM.createPortal(
-          <TypedSettings
-            isOpen={showSettings}
-            onClose={onCloseSettings}
-            projects={settingsProjects}
-            initialTab={settingsInitialTab}
-          />,
+          <LazyLoadBoundary mode="modal" resetKey="settings" onClose={onCloseSettings}>
+            <Suspense fallback={<LazyModalLoadingFallback onClose={onCloseSettings} />}>
+              <Settings
+                isOpen={showSettings}
+                onClose={onCloseSettings}
+                projects={settingsProjects}
+                initialTab={settingsInitialTab}
+              />
+            </Suspense>
+          </LazyLoadBoundary>,
           document.body,
         )}
 
@@ -181,15 +182,21 @@ export default function SidebarModals({
           document.body,
         )}
 
-      <VersionUpgradeModal
-        isOpen={showVersionModal}
-        onClose={onCloseVersionModal}
-        onLater={onLaterVersionModal}
-        releaseInfo={releaseInfo}
-        currentVersion={currentVersion}
-        latestVersion={latestVersion}
-        installMode={installMode}
-      />
+      {showVersionModal && (
+        <LazyLoadBoundary mode="modal" resetKey="version-upgrade" onClose={onCloseVersionModal}>
+          <Suspense fallback={<LazyModalLoadingFallback onClose={onCloseVersionModal} />}>
+            <VersionUpgradeModal
+              isOpen={showVersionModal}
+              onClose={onCloseVersionModal}
+              onLater={onLaterVersionModal}
+              releaseInfo={releaseInfo}
+              currentVersion={currentVersion}
+              latestVersion={latestVersion}
+              installMode={installMode}
+            />
+          </Suspense>
+        </LazyLoadBoundary>
+      )}
     </>
   );
 }

--- a/src/components/sidebar/view/subcomponents/SidebarModals.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarModals.tsx
@@ -1,10 +1,12 @@
-import { lazy, Suspense, useMemo } from 'react';
-import type { ComponentType, LazyExoticComponent } from 'react';
+import { Suspense, useMemo } from 'react';
+import type { ComponentType } from 'react';
 import ReactDOM from 'react-dom';
 import { AlertTriangle, Trash2 } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { Button } from '../../../ui/button';
 import LazyLoadBoundary, { LazyModalLoadingFallback } from '../../../LazyLoadBoundary';
+import VersionUpgradeModal from '../../../modals/VersionUpgradeModal';
+import lazyWithRetry from '../../../../utils/lazyWithRetry';
 import type { Project } from '../../../../types/app';
 import type { ReleaseInfo } from '../../../../types/sharedTypes';
 import type { InstallMode } from '../../../../hooks/useVersionCheck';
@@ -39,8 +41,7 @@ type TypedSettingsProps = {
   initialTab: string;
 };
 
-const Settings = lazy(() => import('../../../Settings')) as LazyExoticComponent<ComponentType<TypedSettingsProps>>;
-const VersionUpgradeModal = lazy(() => import('../../../modals/VersionUpgradeModal'));
+const Settings = lazyWithRetry(() => import('../../../Settings')) as ComponentType<TypedSettingsProps>;
 
 export default function SidebarModals({
   projects,
@@ -182,21 +183,18 @@ export default function SidebarModals({
           document.body,
         )}
 
-      {showVersionModal && (
-        <LazyLoadBoundary mode="modal" resetKey="version-upgrade" onClose={onCloseVersionModal}>
-          <Suspense fallback={<LazyModalLoadingFallback onClose={onCloseVersionModal} />}>
-            <VersionUpgradeModal
-              isOpen={showVersionModal}
-              onClose={onCloseVersionModal}
-              onLater={onLaterVersionModal}
-              releaseInfo={releaseInfo}
-              currentVersion={currentVersion}
-              latestVersion={latestVersion}
-              installMode={installMode}
-            />
-          </Suspense>
-        </LazyLoadBoundary>
-      )}
+      {/* Stays mounted while closed: it owns the in-flight update output, and
+          unmounting it would both drop that output and let a reopened instance
+          start a second concurrent update. It is small enough not to lazy-load. */}
+      <VersionUpgradeModal
+        isOpen={showVersionModal}
+        onClose={onCloseVersionModal}
+        onLater={onLaterVersionModal}
+        releaseInfo={releaseInfo}
+        currentVersion={currentVersion}
+        latestVersion={latestVersion}
+        installMode={installMode}
+      />
     </>
   );
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -191,6 +191,12 @@
     "untitledSession": "Untitled Session",
     "projectFiles": "Project Files"
   },
+  "lazyLoad": {
+    "errorTitle": "This part of Dr. Claw could not be loaded",
+    "errorDescription": "The app may have been updated or the connection was interrupted. Reload to fetch the latest version.",
+    "reload": "Reload",
+    "close": "Close"
+  },
   "projectDashboard": {
     "title": "Project Dashboard",
     "trashTitle": "Project Trash",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -191,6 +191,12 @@
     "untitledSession": "제목 없는 세션",
     "projectFiles": "프로젝트 파일"
   },
+  "lazyLoad": {
+    "errorTitle": "Dr. Claw의 이 부분을 불러올 수 없습니다",
+    "errorDescription": "앱이 업데이트되었거나 연결이 끊겼을 수 있습니다. 최신 버전을 받으려면 다시 불러오세요.",
+    "reload": "다시 불러오기",
+    "close": "닫기"
+  },
   "projectDashboard": {
     "title": "프로젝트 대시보드",
     "trashTitle": "프로젝트 휴지통",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -191,6 +191,12 @@
     "untitledSession": "未命名会话",
     "projectFiles": "项目文件"
   },
+  "lazyLoad": {
+    "errorTitle": "Dr. Claw 的此部分无法加载",
+    "errorDescription": "应用可能已更新，或网络连接被中断。请重新加载以获取最新版本。",
+    "reload": "重新加载",
+    "close": "关闭"
+  },
   "projectDashboard": {
     "title": "项目仪表盘",
     "trashTitle": "项目回收站",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,15 +7,23 @@ import 'katex/dist/katex.min.css'
 // Initialize i18n
 import './i18n/config.js'
 
-// Clean up stale service workers on app load to prevent caching issues after builds
+// Keep development free of stale caches while retaining offline support in production.
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.getRegistrations().then(registrations => {
-    registrations.forEach(registration => {
-      registration.unregister();
+  if (import.meta.env.PROD) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js').catch(err => {
+        console.warn('Failed to register service worker:', err);
+      });
+    }, { once: true });
+  } else {
+    navigator.serviceWorker.getRegistrations().then(registrations => {
+      registrations.forEach(registration => {
+        void registration.unregister();
+      });
+    }).catch(err => {
+      console.warn('Failed to unregister service workers:', err);
     });
-  }).catch(err => {
-    console.warn('Failed to unregister service workers:', err);
-  });
+  }
 }
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/src/types/react-syntax-highlighter.d.ts
+++ b/src/types/react-syntax-highlighter.d.ts
@@ -1,2 +1,3 @@
 declare module 'react-syntax-highlighter';
 declare module 'react-syntax-highlighter/dist/esm/styles/prism';
+declare module 'react-syntax-highlighter/dist/esm/prism';

--- a/src/utils/__tests__/lazyWithRetry.test.ts
+++ b/src/utils/__tests__/lazyWithRetry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { loadWithRetry } from '../lazyWithRetry';
+
+const component = { default: () => null };
+
+describe('loadWithRetry', () => {
+  it('resolves on the first attempt without retrying', async () => {
+    const loader = vi.fn().mockResolvedValue(component);
+
+    await expect(loadWithRetry(loader, 2, 0)).resolves.toBe(component);
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries transient failures until the loader succeeds', async () => {
+    const loader = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('Failed to fetch dynamically imported module'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch dynamically imported module'))
+      .mockResolvedValue(component);
+
+    await expect(loadWithRetry(loader, 2, 0)).resolves.toBe(component);
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up with the last error once the retry budget is spent', async () => {
+    const loader = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('first'))
+      .mockRejectedValueOnce(new Error('second'))
+      .mockRejectedValueOnce(new Error('third'))
+      .mockResolvedValue(component);
+
+    await expect(loadWithRetry(loader, 2, 0)).rejects.toThrow('third');
+    expect(loader).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry when the budget is zero', async () => {
+    const loader = vi.fn().mockRejectedValue(new Error('boom'));
+
+    await expect(loadWithRetry(loader, 0, 0)).rejects.toThrow('boom');
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/lazyWithRetry.tsx
+++ b/src/utils/lazyWithRetry.tsx
@@ -1,0 +1,63 @@
+import { lazy } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
+
+type Loader<T extends ComponentType<any>> = () => Promise<{ default: T }>;
+
+type LazyWithRetryOptions = {
+  /** Extra attempts after the first failure before giving up. */
+  retries?: number;
+  /** Base delay between attempts; grows linearly with each retry. */
+  delayMs?: number;
+};
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function loadWithRetry<T extends ComponentType<any>>(
+  loader: Loader<T>,
+  retries: number,
+  delayMs: number,
+): Promise<{ default: T }> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      return await loader();
+    } catch (error) {
+      if (attempt >= retries) throw error;
+      attempt += 1;
+      await wait(delayMs * attempt);
+    }
+  }
+}
+
+/**
+ * `React.lazy` caches a rejected import for the lifetime of the component, so a
+ * single transient chunk-load failure leaves the component permanently broken
+ * until a full page reload, even after an error boundary resets.
+ *
+ * This wrapper retries transient failures and, if the loader still fails,
+ * discards the rejected lazy component so the next render (after an error
+ * boundary reset or a close/reopen) starts a fresh load instead of rethrowing
+ * the cached error.
+ */
+export default function lazyWithRetry<T extends ComponentType<any>>(
+  loader: Loader<T>,
+  { retries = 2, delayMs = 500 }: LazyWithRetryOptions = {},
+): ComponentType<ComponentProps<T>> {
+  let Lazy: ComponentType<any> = createLazy();
+
+  function createLazy() {
+    return lazy(() =>
+      loadWithRetry(loader, retries, delayMs).catch((error) => {
+        Lazy = createLazy();
+        throw error;
+      }),
+    );
+  }
+
+  function LazyWithRetry(props: ComponentProps<T>) {
+    const Component = Lazy;
+    return <Component {...props} />;
+  }
+
+  return LazyWithRetry;
+}

--- a/test/electron-preload.test.mjs
+++ b/test/electron-preload.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(testDir, '..');
+const mainProcessSource = fs.readFileSync(
+  path.join(projectRoot, 'electron', 'main.mjs'),
+  'utf8',
+);
+const preloadSource = fs.readFileSync(
+  path.join(projectRoot, 'electron', 'preload.cjs'),
+  'utf8',
+);
+
+test('sandboxed Electron window uses a CommonJS preload script', () => {
+  assert.match(mainProcessSource, /sandbox:\s*true/);
+  assert.match(mainProcessSource, /path\.join\(__dirname, ['"]preload\.cjs['"]\)/);
+  assert.ok(fs.existsSync(path.join(projectRoot, 'electron', 'preload.cjs')));
+  assert.ok(!fs.existsSync(path.join(projectRoot, 'electron', 'preload.mjs')));
+});
+
+test('preload does not synchronously access the DOM before it exists', () => {
+  assert.doesNotMatch(preloadSource, /document\.documentElement/);
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,6 +53,17 @@ function runtimePortSyncPlugin() {
   }
 }
 
+// Vendor chunks pinned by package. Patterns require a path separator after the
+// package name so `react` does not also capture react-i18next, react-markdown, etc.
+const VENDOR_CHUNKS = [
+  ['vendor-react', /[\\/]node_modules[\\/](react|react-dom|scheduler|react-router|react-router-dom|@remix-run[\\/]router)[\\/]/],
+  [
+    'vendor-codemirror',
+    /[\\/]node_modules[\\/](@uiw[\\/](react-codemirror|codemirror-extensions-basic-setup)|@codemirror|@lezer|@marijn[\\/]find-cluster-break|style-mod|w3c-keyname|crelt)[\\/]/,
+  ],
+  ['vendor-xterm', /[\\/]node_modules[\\/]@xterm[\\/]/],
+];
+
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
   const env = loadEnv(mode, process.cwd(), '')
@@ -98,19 +109,13 @@ export default defineConfig(({ command, mode }) => {
       chunkSizeWarningLimit: 1000,
       rollupOptions: {
         output: {
-          manualChunks: {
-            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-            'vendor-codemirror': [
-              '@uiw/react-codemirror',
-              '@codemirror/lang-css',
-              '@codemirror/lang-html',
-              '@codemirror/lang-javascript',
-              '@codemirror/lang-json',
-              '@codemirror/lang-markdown',
-              '@codemirror/lang-python',
-              '@codemirror/theme-one-dark'
-            ],
-            'vendor-xterm': ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-clipboard', '@xterm/addon-webgl']
+          // Function form on purpose: the object form also captures each listed
+          // package's transitive dependencies, which pulled react/jsx-runtime and
+          // the @babel/runtime helpers into the CodeMirror chunk and made every
+          // page load (including the login screen) download all of CodeMirror.
+          manualChunks(id) {
+            const match = VENDOR_CHUNKS.find(([, pattern]) => pattern.test(id));
+            return match ? match[0] : undefined;
           }
         }
       }


### PR DESCRIPTION
## Summary

- defer authenticated workspace providers and routes until setup/login completes
- lazy-load feature pages, settings, project creation, editor, and syntax highlighting
- isolate lazy-load failures with localized loading and recovery states
- update sidebar resizing on animation frames and keep rendered/stored widths consistent
- make Service Worker registration consistent across production and development
- prevent pre-auth TaskMaster requests and duplicate 401 console errors

## Performance

Measured on production builds of `main` and this branch (gzip):

| | main | this PR |
|---|---|---|
| eagerly loaded before login (entry + `modulepreload`s) | 1180 KB | 150 KB |
| entry chunk alone | 810 KB | 98 KB |
| chat chunk | 465 KB | 154 KB |

- code editor (CodeMirror), terminal (xterm), settings, dashboards and syntax highlighting load only when needed
- `react/jsx-runtime` no longer rides along in the CodeMirror vendor chunk, so the login screen no longer preloads CodeMirror

## Verification

- `npm run typecheck`
- `npm test -- --run` — 26 files, 177 tests
- `npm run build`
- desktop and 390px mobile Playwright smoke checks
- focused code review with no remaining Critical or Important findings
- `git diff --check`

